### PR TITLE
Add a unit test for default config handling.

### DIFF
--- a/sdk/python/core/keepercommandersm/storage.py
+++ b/sdk/python/core/keepercommandersm/storage.py
@@ -73,6 +73,10 @@ class FileKeyValueStorage(KeyValueStorage):
 
     def save_storage(self, updated_config):
 
+        # If the dictionary is empty, don't write the config.
+        if len(updated_config) == 0:
+            raise ValueError("There are no configuration values. Cannot write an empty config JSON file.")
+
         self.create_config_file_if_missing()
 
         with open(self.default_config_file_location, "w") as write_file:


### PR DESCRIPTION
Added a test to check what happens if the config is completely missing
and there is not config variables. In the past a empty JSON file would
be created and when loaded would cause an exception since a missing
value was needed. Now if missing a config file, and there are no
dictionary values, an exception is throw and a blank config file is not
created.

The second part tests a simple instantiation of Commander with no
config passed in. The default behavior will to load the config
with FileKeyValueStorage, using the default file name.