### PR TITLE
Fix problem with assuming appKey exists in config

### DIFF
--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -145,9 +145,12 @@ class Commander:
 
         transmission_key = Commander.generate_transmission_key()
         client_id = self.config.get(ConfigKeys.KEY_CLIENT_ID)
+        secret_key = None
 
         # While not use in the normal operations, it's used for mocking unit tests.
-        secret_key = base64_to_bytes(self.config.get(ConfigKeys.KEY_APP_KEY))
+        app_key = self.config.get(ConfigKeys.KEY_APP_KEY)
+        if app_key is not None:
+            secret_key = base64_to_bytes(app_key)
 
         if not client_id:
             raise Exception("Client ID is missing from the configuration")

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -18,7 +18,7 @@ install_requires = [
 
 setup(
     name="keepersecuritysm",
-    version='0.0.17a',
+    version='0.0.19a',
     description="Keeper Commander Secrets Management for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/core/tests/core_test.py
+++ b/sdk/python/core/tests/core_test.py
@@ -1,0 +1,25 @@
+import unittest
+
+from keepercommandersm.storage import InMemoryKeyValueStorage
+from keepercommandersm.configkeys import ConfigKeys
+from keepercommandersm import Commander
+
+
+class CoreTest(unittest.TestCase):
+
+    def test_prepare_context(self):
+        config = InMemoryKeyValueStorage()
+        config.set(ConfigKeys.KEY_CLIENT_KEY, "MY CLIENT KEY")
+        config.set(ConfigKeys.KEY_APP_KEY, "MY APP KEY")
+
+        # Pass in the config
+        c = Commander(config=config)
+
+        # There should be no app key
+        self.assertIsNone(c.config.get(ConfigKeys.KEY_APP_KEY), "found the app key")
+
+        context = c.prepare_context()
+
+        self.assertIsNotNone(context.transmissionKey.key, "did not find a transmission key")
+        self.assertIsNotNone(context.clientId, "did nto find a client id")
+        self.assertTrue(isinstance(context.clientId, bytes), "client id is not bytes")


### PR DESCRIPTION
If not bound, appKey is removed from the config. During
prepare_context there was attempt to convert a None to bytes,
which threw an exception.

If app_key is None, don't try to decode it. We only use it in
unit test for knowning the secret the response should be
encrypted with.