### PR TITLE
Fix verify_ssl_certs flag, duplicate code, allow ENV to set config file.

### DIFF
--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -1,6 +1,7 @@
 import hmac
 import logging
 import os
+from  distutils.util import strtobool
 
 import requests
 from requests import HTTPError
@@ -26,7 +27,7 @@ class Commander:
         self.server = server
 
         # Accept the env var PYTHONHTTPSVERIFY. Modules like 'requests' already use it.
-        self.verify_ssl_certs = bool(os.environ.get("PYTHONHTTPSVERIFY", verify_ssl_certs))
+        self.verify_ssl_certs = bool(strtobool(os.environ.get("PYTHONHTTPSVERIFY", str(verify_ssl_certs))))
 
         if config is None:
             config = FileKeyValueStorage()
@@ -34,7 +35,7 @@ class Commander:
         # If the server or client key are set in the args, make sure they makes it's way into the config. The
         # will override what is already in the config if they exist.
         if client_key is not None:
-            config.set(ConfigKeys.KEY_CLIENT_KEY, server)
+            config.set(ConfigKeys.KEY_CLIENT_KEY, client_key)
         if server is not None:
             config.set(ConfigKeys.KEY_SERVER, server)
 
@@ -67,12 +68,6 @@ class Commander:
                                                                   digest).digest())
 
         client_id = self.config.get(ConfigKeys.KEY_CLIENT_ID)
-
-        if not existing_secret_key_hash:
-            # Secret key was not supplied (Probably already bound and client id is present?)
-            if not client_id:
-                # Instruct user how to bound using commander or web ui
-                raise Exception("Not bound")
 
         if not existing_secret_key_hash:
             # Secret key was not supplied (Probably already bound and client id is present?)

--- a/sdk/python/core/keepercommandersm/storage.py
+++ b/sdk/python/core/keepercommandersm/storage.py
@@ -47,7 +47,8 @@ class FileKeyValueStorage(KeyValueStorage):
     def __init__(self, config_file_location=None):
 
         if config_file_location is None:
-            config_file_location = FileKeyValueStorage.default_config_file_location
+            config_file_location = os.environ.get("KEEPER_CONFIG_FILE",
+                                                  FileKeyValueStorage.default_config_file_location)
 
         self.default_config_file_location = config_file_location
 
@@ -72,10 +73,6 @@ class FileKeyValueStorage(KeyValueStorage):
         return config
 
     def save_storage(self, updated_config):
-
-        # If the dictionary is empty, don't write the config.
-        if len(updated_config) == 0:
-            raise ValueError("There are no configuration values. Cannot write an empty config JSON file.")
 
         self.create_config_file_if_missing()
 

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -6,6 +6,7 @@ import os
 from keepercommandersm.exceptions import KeeperError
 from keepercommandersm.storage import FileKeyValueStorage, InMemoryKeyValueStorage
 from keepercommandersm import Commander
+from keepercommandersm.configkeys import ConfigKeys
 from keepercommandersm import mock
 
 
@@ -168,3 +169,33 @@ class SmokeTest(unittest.TestCase):
             c.get_secrets()
         except KeeperError as err:
             self.assertRegex(err.message, r'Signature is invalid', 'did not get correct error message')
+
+
+    def test_verify_ssl_certs(self):
+
+        config = InMemoryKeyValueStorage()
+        config.set(ConfigKeys.KEY_CLIENT_KEY, 'ABC123')
+
+        os.environ.pop("PYTHONHTTPSVERIFY", None)
+        c = Commander(config=config)
+        self.assertEqual(c.verify_ssl_certs, True, "verify_ssl_certs is not true on 'no args; instance")
+
+        os.environ.pop("PYTHONHTTPSVERIFY", None)
+        c = Commander(config=config, verify_ssl_certs=True)
+        self.assertEqual(c.verify_ssl_certs, True, "verify_ssl_certs is not true on param instance")
+
+        os.environ.pop("PYTHONHTTPSVERIFY", None)
+        c = Commander(config=config, verify_ssl_certs=False)
+        self.assertEqual(c.verify_ssl_certs, False, "verify_ssl_certs is not false on param instance")
+
+        os.environ["PYTHONHTTPSVERIFY"] = "FALSE"
+        c = Commander(config=config)
+        self.assertEqual(c.verify_ssl_certs, False, "verify_ssl_certs is not false on env set (FALSE)")
+
+        os.environ["PYTHONHTTPSVERIFY"] = "NO"
+        c = Commander(config=config)
+        self.assertEqual(c.verify_ssl_certs, False, "verify_ssl_certs is not false on env set (NO)")
+
+        os.environ["PYTHONHTTPSVERIFY"] = "True"
+        c = Commander(config=config)
+        self.assertEqual(c.verify_ssl_certs, True, "verify_ssl_certs is not true on env set (True)")


### PR DESCRIPTION
Python bool will not convert a string to a bool value, like it does with
integers and other value. Use distutils.util.strtobool to convery the
string to a 1 or 0, then use bool() to convert to True/False.

Fix problem with server being used for default value of client_key, if
not set.

The existing_secret_key_hash check was a duplicate code block. This
affected the "else" block below. Removed the top duplicate block
of code.

Allow the default FileKeyValueStorage location to be set via an
environment value. This allows the config to before stored
in a persistent volume in a docker container. ie:

    ---
    version: '3.7'

    services:
      app:
        build: .
        environment:
          - KEEPER_SECRET_KEY=XXXXXXX
          - KEEPER_CONFIG_FILE=/config/client.json
        volumes:
          - keeper_config:/config
    volumes:
      keeper_config:
        driver: local