### PR TITLE
Add log level config to CLI and allow SDK to have level set

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
@@ -205,9 +205,40 @@ def exec_command(ctx, capture_output, cmd):
     ex.execute(cmd=cmd, capture_output=capture_output)
 
 
+# CONFIG COMMAND
+@click.group(name='config')
+@click.pass_context
+def config_command(ctx):
+    """Configure the command line tool."""
+    ctx.obj["profile"] = Profile(cli=ctx.obj["cli"])
+    pass
+
+
+@click.command(name='show')
+@click.pass_context
+def config_show_command(ctx):
+    """Show current configuration."""
+    ctx.obj["profile"].show_config()
+
+
+@click.command(name='log')
+@click.option('--level',  type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"]),
+              help="Level of message or error to display")
+@click.pass_context
+def config_log_command(ctx, level):
+    """Set the log level"""
+    ctx.obj["profile"].set_log_level(level)
+
+
+config_command.add_command(config_show_command)
+config_command.add_command(config_log_command)
+
+
+# TOP LEVEL COMMANDS
 cli.add_command(profile_command)
 cli.add_command(secret_command)
 cli.add_command(exec_command)
+cli.add_command(config_command)
 
 
 def main():

--- a/integration/keeper_sm_cli/keeper_sm_cli/profile.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/profile.py
@@ -14,6 +14,7 @@ class Profile:
     active_profile_key = "active_profile"
     default_profile = os.environ.get("KEEPER_CLI_PROFILE", "DEFAULT")
     default_ini_file = os.environ.get("KEEPER_INI_FILE", "keeper.ini")
+    log_level_key = "log_level"
 
     def __init__(self, cli, ini_file=None):
 
@@ -113,7 +114,7 @@ class Profile:
         table.hrules = prettytable.HEADER
 
     @staticmethod
-    def init(client_key, ini_file=None, server=None, profile_name=None):
+    def init(client_key, ini_file=None, server=None, profile_name=None, log_level="INFO"):
 
         from . import KeeperCli
 
@@ -141,7 +142,7 @@ class Profile:
         if os.path.exists(ini_file) is False:
             config[Profile.default_profile] = {}
             config[Profile.common_profile] = {
-                "log_level": "WARNING",
+                "log_level": log_level,
                 Profile.active_profile_key: Profile.default_profile
             }
             with open(ini_file, 'w') as configfile:
@@ -155,7 +156,7 @@ class Profile:
         if server is not None:
             config_storage.set(ConfigKeys.KEY_SERVER, server)
 
-        client = KeeperCli.get_client(config=config_storage)
+        client = KeeperCli.get_client(config=config_storage, log_level=log_level)
 
         # Get the secret records to get the app key. The SDK will add the app key to the config.
         try:
@@ -223,3 +224,15 @@ class Profile:
         self.save()
 
         print("{} is now the active profile.".format(profile_name), file=sys.stderr)
+
+    def set_log_level(self, level):
+        common_config = self.get_profile_config(Profile.common_profile)
+        common_config[Profile.log_level_key] = level
+        self.cli.log_level = level
+        self.save()
+
+    def show_config(self):
+        common_config = self.get_profile_config(Profile.common_profile)
+        not_set_text = "-NOT SET-"
+        print("Active Profile: {}".format(common_config.get(Profile.active_profile_key, not_set_text)))
+        print("Log Level: {}".format(common_config.get(Profile.log_level_key, not_set_text)))

--- a/integration/keeper_sm_cli/tests/exec_test.py
+++ b/integration/keeper_sm_cli/tests/exec_test.py
@@ -23,6 +23,7 @@ class ProfileTest(unittest.TestCase):
 
     def test_cmd(self):
 
+        # Log level set in this one, nothing below INFO should appear.
         commander = Commander(config=InMemoryKeyValueStorage({
             "server": "fake.keepersecurity.com",
             "appKey": "9vVajcvJTGsa2Opc_jvhEiJLRKHtg2Rm4PAtUoP3URw",
@@ -31,7 +32,7 @@ class ProfileTest(unittest.TestCase):
             "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
                           "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
                           "jhKMhHQFaHYI"
-        }))
+        }), log_level="INFO")
 
         res = mock.Response()
         one = res.add_record(title="My Record 1")

--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -24,8 +24,9 @@ from keepercommandersm.utils import bytes_to_url_safe_str, base64_to_bytes, sign
 class Commander:
 
     notation_prefix = "keeper"
+    log_level = "DEBUG"
 
-    def __init__(self, client_key=None, server=None, verify_ssl_certs=True, config=None):
+    def __init__(self, client_key=None, server=None, verify_ssl_certs=True, config=None, log_level=None):
 
         self.client_key = client_key
         self.server = server
@@ -45,17 +46,23 @@ class Commander:
 
         self.config: KeyValueStorage = config
 
-        self._init_logger()
+        self._init_logger(log_level=log_level)
 
         self._init()
 
     @staticmethod
-    def _init_logger():
+    def _init_logger(log_level=None):
         # Configure logs
 
+        if log_level is None:
+            log_level = Commander.log_level
+
+        # basicConfig will not clobber a user's logging configuration, even the log level
+        # "This function does nothing if the root logger already has handlers configured, unless the keyword argument
+        # force is set to True."
         logging.basicConfig(
-            level=logging.DEBUG,
-            format='%(asctime)s | %(name)s | %(levelname)s | %(message)s'
+            format='%(asctime)s | %(name)s | %(levelname)s | %(message)s',
+            level=getattr(logging, log_level)
         )
 
     def _init(self):


### PR DESCRIPTION
Added to the CLI the ability to set the log level.

Allow the SDK to have the log level passed in. Default to DEBUG. If
the application using the SDK setup a logger, the SDK's logging will
not be used.