### PR TITLE
Removed default value for profile

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
@@ -24,7 +24,7 @@ class KeeperCli:
 
             # If the profile is not set
             if profile_name is None:
-                profile_name = self.profile.get_default_profile_name()
+                profile_name = self.profile.get_active_profile_name()
 
                 # If we don't have a profile we can't do anything.
                 if profile_name is None:

--- a/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
@@ -20,7 +20,7 @@ def _get_cli(ini_file=None, profile_name=None, output=None):
 # MAIN GROUP
 @click.group()
 @click.option('--ini-file', type=str, help="INI config file.")
-@click.option('--profile-name', '-p', type=str, help='Config profile', default='DEFAULT')
+@click.option('--profile-name', '-p', type=str, help='Config profile')
 @click.option('--output', '-o', type=str, help='Output [stdout|stderr|filename]', default='stdout')
 @click.pass_context
 def cli(ctx, ini_file, profile_name, output):
@@ -225,12 +225,13 @@ def config_show_command(ctx):
 
 
 @click.command(name='log')
-@click.option('--level',  type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"]),
+@click.option('--level',  '-l', type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"]),
               help="Level of message or error to display")
 @click.pass_context
 def config_log_command(ctx, level):
     """Set the log level"""
-    ctx.obj["profile"].set_log_level(level)
+    if level is not None:
+        ctx.obj["profile"].set_log_level(level)
 
 
 config_command.add_command(config_show_command)
@@ -258,6 +259,7 @@ def version_command(ctx):
 cli.add_command(profile_command)
 cli.add_command(secret_command)
 cli.add_command(exec_command)
+cli.add_command(config_command)
 cli.add_command(version_command)
 
 

--- a/integration/keeper_sm_cli/keeper_sm_cli/profile.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/profile.py
@@ -101,9 +101,9 @@ class Profile:
 
         return config[profile_name]
 
-    def get_default_profile_name(self):
-        profile_config = self.get_profile_config(Profile.common_profile)
-        return os.environ.get("KEEPER_CLI_PROFILE", profile_config.get(Profile.active_profile_key))
+    def get_active_profile_name(self):
+        common_config = self.get_profile_config(Profile.common_profile)
+        return os.environ.get("KEEPER_CLI_PROFILE", common_config.get(Profile.active_profile_key))
 
     @staticmethod
     def _table_setup(table):
@@ -191,7 +191,7 @@ class Profile:
     def list_profiles(self, output='text'):
 
         profiles = []
-        active_profile = self.get_default_profile_name()
+        active_profile = self.get_active_profile_name()
         for profile in self.get_config():
             if profile == Profile.common_profile:
                 continue


### PR DESCRIPTION
Remove the default value for the --profile-name parameter.

The command default for the profile name defaulted to DEFAULT. Even
if you selected an active profile, it would always use the DEFAULT
profile.

Also renamed the method get_default_profile_name to get_active_profile_name
to make more sense. It's returning the active profile, not the DEFAULT
profile.