### PR TITLE
Change the name of the config sections.

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
@@ -40,7 +40,7 @@ class KeeperCli:
             config_storage.set(ConfigKeys.KEY_APP_KEY, self.config.get("appKey"))
             config_storage.set(ConfigKeys.KEY_SERVER, self.config.get("server"))
 
-            common_profile = self.profile.get_profile_config(Profile.common_profile)
+            common_profile = self.profile.get_profile_config(Profile.config_profile)
 
             self._client = self.get_client(
                 config=config_storage,


### PR DESCRIPTION
The section DEFAULT is a special INI section which is the base
for other sections. So the parser will add the values from DEFAULT
and override them with the values from the section.

The problem is when you are reading keys from sections that do not
have anything to do with SDK connection. You get all the keys.

Moved our default from 'DEFAULT' to '_default'. And changed the section
name 'common' to '_config' since it holds the config for the CLI.