### PR TITLE
Various fixes

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
@@ -29,13 +29,23 @@ def _get_cli(ini_file=None, profile_name=None, output=None):
     )
 
 
+def base_command_help(f):
+    doc = f.__doc__
+    f.__doc__ = "{} Version: {} ".format(doc, meta_version('keeper_sm_cli'))
+    return f
+
+
 # MAIN GROUP
 @click.group()
 @click.option('--ini-file', type=str, help="INI config file.")
 @click.option('--profile-name', '-p', type=str, help='Config profile')
 @click.option('--output', '-o', type=str, help='Output [stdout|stderr|filename]', default='stdout')
 @click.pass_context
+@base_command_help
 def cli(ctx, ini_file, profile_name, output):
+
+    """Keeper Secret Manager CLI
+    """
 
     try:
         ctx.obj = {
@@ -45,10 +55,10 @@ def cli(ctx, ini_file, profile_name, output):
             "output": output
         }
     except FileNotFoundError as _:
-        exit("Could not find the INI file specified on the top level command. If you are running the init"
+        sys.exit("Could not find the INI file specified on the top level command. If you are running the init"
              " sub-command, specify the INI file on the sub-command parameters instead on the top level command.")
     except Exception as err:
-        exit("Could not run the command. Got the error: {}".format(err))
+        sys.exit("Could not run the command. Got the error: {}".format(err))
 
 
 # PROFILE GROUP
@@ -61,12 +71,12 @@ def profile_command():
 
 
 @click.command(name='init')
-@click.option('--client-key', '-c', type=str, required=True, help="The client key.")
+@click.option('--token', '-t', type=str, required=True, help="The One Time Access Token.")
 @click.option('--server', '-s', type=str, default="US", help="Server code or URL.")
 @click.option('--ini-file', type=str, help="INI config file to create.")
 @click.option('--profile-name', '-p', type=str, help='Config profile to create.')
 @click.pass_context
-def profile_init_command(ctx, client_key, server, ini_file, profile_name):
+def profile_init_command(ctx, token, server, ini_file, profile_name):
     """Initialize a profile."""
 
     # Since the top level commands are available for all command, it might be confusing the init command since
@@ -76,7 +86,7 @@ def profile_init_command(ctx, client_key, server, ini_file, profile_name):
               " level command parameter will be ignored for the init sub-command.", file=sys.stderr)
 
     Profile.init(
-        client_key=client_key,
+        client_key=token,
         server=server,
         ini_file=ini_file,
         profile_name=profile_name

--- a/integration/keeper_sm_cli/keeper_sm_cli/profile.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/profile.py
@@ -36,9 +36,9 @@ class Profile:
         if ini_file is None:
             ini_file = Profile.find_ini_config()
 
-            # If we can't find it, and the KSM_SECRET_KEY env is set, auto create it. We do this because
+            # If we can't find it, and the KSM_TOKEN env is set, auto create it. We do this because
             # this might be a container startup and there is not INI file, but we have passed in the client key.
-            client_key = os.environ.get("KSM_SECRET_KEY")
+            client_key = os.environ.get("KSM_TOKEN")
             if client_key is not None:
                 Profile.init(
                     client_key=client_key,
@@ -116,6 +116,12 @@ class Profile:
     def get_active_profile_name(self):
         common_config = self.get_profile_config(Profile.config_profile)
         return os.environ.get("KSM_CLI_PROFILE", common_config.get(Profile.active_profile_key))
+
+    def _get_common_config(self, error_prefix):
+        try:
+            return self.get_profile_config(Profile.config_profile)
+        except Exception as err:
+            sys.exit("{} {}".format(error_prefix, err))
 
     @staticmethod
     def _table_setup(table):
@@ -209,31 +215,37 @@ class Profile:
     def list_profiles(self, output='text'):
 
         profiles = []
-        active_profile = self.get_active_profile_name()
-        for profile in self.get_config():
-            if profile == Profile.config_profile:
-                continue
-            profiles.append({
-                "active": profile == active_profile,
-                "name": profile
-            })
 
-        if output == 'text':
-            table = prettytable.PrettyTable()
-            table.field_names = ["Active", "Profile"]
-            Profile._table_setup(table)
+        try:
+            active_profile = self.get_active_profile_name()
 
-            for profile in profiles:
-                table.add_row(["*" if profile["active"] is True else " ", profile["name"]])
+            for profile in self.get_config():
+                if profile == Profile.config_profile:
+                    continue
+                profiles.append({
+                    "active": profile == active_profile,
+                    "name": profile
+                })
 
-            # TODO: Why won't this work with self.cli.output
-            self.cli.output(table.get_string() + "\n")
-        elif output == 'json':
-            self.cli.output(json.dumps(profiles))
-        return profiles
+            if output == 'text':
+                table = prettytable.PrettyTable()
+                table.field_names = ["Active", "Profile"]
+                Profile._table_setup(table)
+
+                for profile in profiles:
+                    table.add_row(["*" if profile["active"] is True else " ", profile["name"]])
+
+                self.cli.output(table.get_string() + "\n")
+            elif output == 'json':
+                self.cli.output(json.dumps(profiles))
+            return profiles
+
+        except FileNotFoundError as err:
+            sys.exit("Cannot get list of profiles. {}".format(err))
 
     def set_active(self, profile_name):
-        common_config = self.get_profile_config(Profile.config_profile)
+
+        common_config = self._get_common_config("Cannot set active profile.")
 
         if profile_name not in self.get_config():
             exit("Cannot set profile {} to active. It does not exists.".format(profile_name))
@@ -244,13 +256,13 @@ class Profile:
         print("{} is now the active profile.".format(profile_name), file=sys.stderr)
 
     def set_log_level(self, level):
-        common_config = self.get_profile_config(Profile.config_profile)
+        common_config = self._get_common_config("Cannot set log level.")
         common_config[Profile.log_level_key] = level
         self.cli.log_level = level
         self.save()
 
     def show_config(self):
-        common_config = self.get_profile_config(Profile.config_profile)
+        common_config = self._get_common_config("Cannot show the config.")
         not_set_text = "-NOT SET-"
         print("Active Profile: {}".format(common_config.get(Profile.active_profile_key, not_set_text)))
         print("Log Level: {}".format(common_config.get(Profile.log_level_key, not_set_text)))

--- a/integration/keeper_sm_cli/keeper_sm_cli/secret.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/secret.py
@@ -16,6 +16,7 @@ import sys
 from collections import deque
 import prettytable
 from keepercommandersm.exceptions import KeeperError, KeeperAccessDenied
+import traceback
 
 
 class Secret:
@@ -34,7 +35,7 @@ class Secret:
     @staticmethod
     def _record_to_dict(record):
         custom_fields = []
-        for custom_field in record.dict.get('custom'):
+        for custom_field in record.dict.get('custom', []):
             field_type = custom_field.get("type")
             value = custom_field.get("value")
             custom_fields.append({
@@ -172,10 +173,13 @@ class Secret:
             for record in self.cli.client.get_secrets(uids=uids):
                 records.append(self._record_to_dict(record))
         except KeeperError as err:
+            traceback.print_exc(file=sys.stderr)
             sys.exit("Could not query the records: {}".format(err.message))
         except KeeperAccessDenied as err:
+            traceback.print_exc(file=sys.stderr)
             sys.exit("Could not query the records: {}".format(err.message))
         except Exception as err:
+            traceback.print_exc(file=sys.stderr)
             sys.exit("Could not query the records: {}".format(err))
 
         if jsonpath_query is not None:

--- a/integration/keeper_sm_cli/setup.py
+++ b/integration/keeper_sm_cli/setup.py
@@ -16,7 +16,7 @@ install_requires = [
 
 setup(
     name="keeper_sm_cli",
-    version="0.0.8a0",
+    version="0.0.10a0",
     description="Command line tool for Keeper Secret Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_sm_cli/tests/profile_test.py
+++ b/integration/keeper_sm_cli/tests/profile_test.py
@@ -54,13 +54,13 @@ class ExecTest(unittest.TestCase):
 
             default_client_key = "XYZ321"
             runner = CliRunner()
-            result = runner.invoke(cli, ['profile', 'init', '-c', default_client_key], catch_exceptions=False)
+            result = runner.invoke(cli, ['profile', 'init', '-t', default_client_key], catch_exceptions=False)
             print(result.output)
             self.assertEqual(0, result.exit_code, "did not get a success for default init")
             self.assertTrue(os.path.exists(Profile.default_ini_file), "could not find ini file")
 
             test_client_key = "ABC123"
-            result = runner.invoke(cli, ['profile', 'init', "-p", "test", '-c',
+            result = runner.invoke(cli, ['profile', 'init', "-p", "test", '-t',
                                          test_client_key], catch_exceptions=False)
             self.assertEqual(0, result.exit_code, "did not get a success for test init")
             self.assertTrue(os.path.exists(Profile.default_ini_file), "could not find ini file")

--- a/integration/keeper_sm_cli/tests/secret_test.py
+++ b/integration/keeper_sm_cli/tests/secret_test.py
@@ -77,7 +77,7 @@ class SecretTest(unittest.TestCase):
                 client_key='rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ'
             )
 
-            # JSON Ouput
+            # JSON Output
             with tempfile.NamedTemporaryFile() as tf:
                 runner = CliRunner()
                 result = runner.invoke(cli, ['-o', tf.name, 'secret', 'list', '--json'], catch_exceptions=False)
@@ -399,6 +399,55 @@ class SecretTest(unittest.TestCase):
             self.fail("The key/value of 'bad' should have failed.")
         except Exception as err:
             self.assertRegex(str(err), r'The key/value format is invalid', 'did not get correct error message')
+
+    def test_commander_record(self):
+
+        """ Test how Commander stores record. Not custom fields, not 'custom' key in the response JSON.
+        """
+
+        commander = Commander(config=InMemoryKeyValueStorage({
+            "server": "fake.keepersecurity.com",
+            "appKey": "9vVajcvJTGsa2Opc_jvhEiJLRKHtg2Rm4PAtUoP3URw",
+            "clientId": "rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ",
+            "clientKey": "zKoSCC6eNrd3N9CByRBsdChSsTeDEAMvNj9Bdh7BJuo",
+            "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
+                          "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
+                          "jhKMhHQFaHYI"
+        }))
+
+        res = mock.Response(flags={
+            "prune_custom_fields": True
+        })
+
+        one = res.add_record(title="My Record 1")
+        one.field("login", "My Login 1")
+        one.field("password", "My Password 1")
+
+        queue = mock.ResponseQueue(client=commander)
+        # The profile init
+        queue.add_response(res)
+        # The secret get
+        queue.add_response(res)
+
+        with patch('integration.keeper_sm_cli.keeper_sm_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = commander
+
+            Profile.init(
+                client_key='rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ'
+            )
+
+            # JSON Output
+            with tempfile.NamedTemporaryFile() as tf:
+                runner = CliRunner()
+                result = runner.invoke(cli, [
+                    '-o', tf.name,
+                    'secret', 'get', '-u', one.uid, '--json'], catch_exceptions=False)
+                self.assertEqual(0, result.exit_code, "the exit code was not 0")
+                tf.seek(0)
+                secret = json.load(tf)
+                self.assertEqual(dict, type(secret), "record is not a dictionary")
+                self.assertEqual(0, len(secret["custom_fields"]), "custom fields were not empty")
+                tf.close()
 
 
 if __name__ == '__main__':

--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -126,7 +126,7 @@ class Commander:
         """Returns client_id from the environment variable, config file, or in the code"""
 
         # Case 1: Environment Variable
-        env_secret_key = os.getenv('KSM_SECRET_KEY')
+        env_secret_key = os.getenv('KSM_TOKEN')
 
         current_secret_key = None
 

--- a/sdk/python/core/keepercommandersm/dto/dtos.py
+++ b/sdk/python/core/keepercommandersm/dto/dtos.py
@@ -125,7 +125,7 @@ class Record:
     def custom_field(self, label, value=None, field_type=None, single=False):
 
         found_item = None
-        for item in self.dict.get('custom'):
+        for item in self.dict.get('custom', []):
             found = False
 
             # If the user doesn't set the label in the UI, and uses the default, the label will be missing :/
@@ -175,7 +175,7 @@ class Record:
         print("")
         print("Custom Fields")
         print("------")
-        for item in self.dict.get('custom'):
+        for item in self.dict.get('custom', []):
             print("{} ({}) : {}".format(item["label"], item["type"], ", ".join(item["value"])))
 
 

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -18,7 +18,7 @@ install_requires = [
 
 setup(
     name="keepercommandersm",
-    version="0.0.27a0",
+    version="0.0.28a0",
     description="Keeper Secrets Management for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -170,7 +170,6 @@ class SmokeTest(unittest.TestCase):
         except KeeperError as err:
             self.assertRegex(err.message, r'Signature is invalid', 'did not get correct error message')
 
-
     def test_verify_ssl_certs(self):
 
         config = InMemoryKeyValueStorage()


### PR DESCRIPTION
KSM-150

* Change the client key and secret references to token.
* Handle exceptions with using profile/config commands without a config
  file.
* Fix problem with SDK and CLI breaking when Commander doesn't include
  custom field.
* Add name of app and version to CLI help screen.