### PR TITLE
More fixes and update from QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,13 @@ env.bak/
 venv.bak/
 .python-version
 .pytest_cache
+
+# Vim
+*~
+*.swp
+*.swo
+
+# Don't add Config files
+keeper.ini*
+*config*.json
+

--- a/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
@@ -19,6 +19,8 @@ import sys
 import os
 import keepercommandersm
 from importlib.metadata import version as meta_version
+import traceback
+from distutils.util import strtobool
 
 
 def _get_cli(ini_file=None, profile_name=None, output=None):
@@ -166,7 +168,8 @@ def secret_get_command(ctx, uid, query, json, raw, force_array):
         jsonpath_query=query,
         output_format=output,
         raw=raw,
-        force_array=force_array
+        force_array=force_array,
+        load_references=True
     )
 
 
@@ -286,7 +289,13 @@ cli.add_command(version_command)
 
 
 def main():
-    cli(obj={"cli": None})
+    try:
+        cli(obj={"cli": None})
+    except Exception as err:
+        # Set KSM_DEBUG to get a stack trace. Secret env var.
+        if strtobool(os.environ.get("KSM_DEBUG", "FALSE")) == 1:
+            print(traceback.format_exc(), file=sys.stderr)
+        sys.exit("ksm had a problem: {}".format(err))
 
 
 if __name__ == '__main__':

--- a/integration/keeper_sm_cli/keeper_sm_cli/common.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/common.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2021 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+
+import prettytable
+
+
+def table_setup(table):
+    table.align = 'l'
+    table.horizontal_char = "-"
+    table.vertical_char = " "
+    table.junction_char = " "
+    table.hrules = prettytable.HEADER
+    table.left_padding_width = 0
+    table.right_padding_width = 0

--- a/integration/keeper_sm_cli/keeper_sm_cli/profile.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/profile.py
@@ -15,6 +15,7 @@ import configparser
 from keepercommandersm.storage import InMemoryKeyValueStorage
 from keepercommandersm.configkeys import ConfigKeys
 from keepercommandersm.exceptions import KeeperError, KeeperAccessDenied
+from .common import table_setup
 import prettytable
 import sys
 import json
@@ -124,14 +125,6 @@ class Profile:
             sys.exit("{} {}".format(error_prefix, err))
 
     @staticmethod
-    def _table_setup(table):
-        table.align = 'l'
-        table.horizontal_char = "="
-        table.vertical_char = " "
-        table.junction_char = " "
-        table.hrules = prettytable.HEADER
-
-    @staticmethod
     def init(client_key, ini_file=None, server=None, profile_name=None, log_level="INFO"):
 
         from . import KeeperCli
@@ -230,7 +223,7 @@ class Profile:
             if output == 'text':
                 table = prettytable.PrettyTable()
                 table.field_names = ["Active", "Profile"]
-                Profile._table_setup(table)
+                table_setup(table)
 
                 for profile in profiles:
                     table.add_row(["*" if profile["active"] is True else " ", profile["name"]])

--- a/integration/keeper_sm_cli/requirements.txt
+++ b/integration/keeper_sm_cli/requirements.txt
@@ -1,4 +1,4 @@
 keepercommandersm
 click
-jsonpath-ng
+jsonpath-rw-ext
 prettytable

--- a/integration/keeper_sm_cli/setup.py
+++ b/integration/keeper_sm_cli/setup.py
@@ -10,13 +10,13 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 install_requires = [
     'keepercommandersm',
     'click',
-    'jsonpath-ng',
+    'jsonpath-rw-ext',
     'prettytable'
 ]
 
 setup(
     name="keeper_sm_cli",
-    version="0.0.11a0",
+    version="0.0.12a0",
     description="Command line tool for Keeper Secret Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -395,20 +395,18 @@ class Commander:
         )
 
         if not rs.ok:
-            if rs.status_code == 403:
-                logging.error("Error: {} (http error code: {})".format(rs.reason, rs.status_code))
-                return {}
-            else:
-                error_message = rs.content
-                try:
-                    resp_dict = json_to_dict(rs.text)
-                    error = resp_dict.get("message", error_message)
-                    logging.error("Error: {} (http error code: {}, row: {}".format(rs.reason, rs.status_code,
-                                                                                   resp_dict))
-                except json.JSONDecodeError as _:
-                    logging.error("Error: {} (http error code: {}, message: {}".format(rs.reason, rs.status_code,
-                                                                                       error))
 
+            error_message = rs.content
+            try:
+                resp_dict = json_to_dict(rs.text)
+                error_message = resp_dict.get("message", error_message)
+                logging.error("Error: {} (http error code: {}, row: {}".format(rs.reason, rs.status_code, resp_dict))
+            except json.JSONDecodeError as _:
+                logging.error("Error: {} (http error code: {}, message: {}".format(rs.reason, rs.status_code,
+                                                                                   error_message))
+            if rs.status_code == 403:
+                raise KeeperError(error_message)
+            else:
                 raise HTTPError(error_message)
         else:
             return True

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -18,7 +18,7 @@ install_requires = [
 
 setup(
     name="keepercommandersm",
-    version="0.0.30a0",
+    version="0.0.31a0",
     description="Keeper Secrets Management for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
KSM-153

* Reformat looks of tables
* Hide fields/custom fields that do not have any values
* Get references to other records
* Add a global exception handler to CLI. Don't show stack trace.
* Fix JSONPath problem
* Improve error message handling when saving.

The two references are addressRef and cardRef. AddressRef works, however
cardRef returns an empty folder for the response.

The JSONPath problem was the module. jsonpath-ng didn't like to do
queries where there was a conditional predicate. It would complain
about the ? in the syntax. Switched to version of the library where
this works, which is jsonpath-rw-ext.

Also moved the table formatting to a common file since multiple modules use it.