### PR TITLE
Use the notation code in the SDK

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/exec.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/exec.py
@@ -15,6 +15,7 @@ import sys
 import subprocess
 from keepercommandersm.core import Commander
 import re
+import json
 
 
 class Exec:
@@ -45,19 +46,13 @@ class Exec:
 
         for env_key, env_value in os.environ.items():
             if env_value.startswith(Commander.notation_prefix) is True:
-                parts = env_value.split('//')
-                (uid, file_type, key) = parts[1].split('/')
 
-                if file_type == "field":
-                    value = record_lookup[uid].field(key, single=True)
-                elif file_type == "custom_field":
-                    value = record_lookup[uid].custom_field(key, single=True)
-                elif file_type == "file":
-                    value = record_lookup[uid].download_file_by_title(key)
-                else:
-                    raise ValueError("Field type of {} is not value.".format(file_type))
+                value = self.cli.client.get_notation(env_value)
+                if type(value) is dict or type(value) is list:
+                    value = json.dumps(value)
+
                 os.environ["_" + env_key] = "_" + env_value
-                os.environ[env_key] = value
+                os.environ[env_key] = str(value)
 
     @staticmethod
     def execute(cmd, capture_output=False):

--- a/integration/keeper_sm_cli/setup.py
+++ b/integration/keeper_sm_cli/setup.py
@@ -16,7 +16,7 @@ install_requires = [
 
 setup(
     name="keeper_sm_cli",
-    version="0.0.14a0",
+    version="0.0.15a0",
     description="Command line tool for Keeper Secret Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_sm_cli/tests/exec_test.py
+++ b/integration/keeper_sm_cli/tests/exec_test.py
@@ -11,7 +11,7 @@ from integration.keeper_sm_cli.keeper_sm_cli.__main__ import cli
 from integration.keeper_sm_cli.keeper_sm_cli.profile import Profile
 
 
-class ProfileTest(unittest.TestCase):
+class ExecTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.orig_dir = os.getcwd()
@@ -40,6 +40,11 @@ class ProfileTest(unittest.TestCase):
         one.custom_field("password", "My Password 1")
 
         queue = mock.ResponseQueue(client=commander)
+        # Profile init
+        queue.add_response(res)
+
+        # One for each var ... until we begin to cache.
+        queue.add_response(res)
         queue.add_response(res)
         queue.add_response(res)
 

--- a/integration/keeper_sm_cli/tests/secret_test.py
+++ b/integration/keeper_sm_cli/tests/secret_test.py
@@ -512,5 +512,6 @@ class SecretTest(unittest.TestCase):
 
                 tf.close()
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The 'exec' was using the original code, which was outdated. Also
make sure the value is a string env vars only like strings.