### PR TITLE
Replace placeholder notation inline for exec

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__main__.py
@@ -224,13 +224,13 @@ secret_command.add_command(secret_download_command)
 
 @click.command(name='exec')
 @click.option('--capture-output', is_flag=True, help='Capture the output and display upon cmd exit.')
+@click.option('--inline', is_flag=True, help='Replace include placeholders.')
 @click.argument('cmd', type=str, nargs=-1)
 @click.pass_context
-def exec_command(ctx, capture_output, cmd):
+def exec_command(ctx, capture_output, inline, cmd):
     """Wrap an application and expose secrets in environmental variables."""
     ex = Exec(cli=ctx.obj["cli"])
-    ex.env_replace()
-    ex.execute(cmd=cmd, capture_output=capture_output)
+    ex.execute(cmd=cmd, capture_output=capture_output, inline=inline)
 
 
 # CONFIG COMMAND

--- a/integration/keeper_sm_cli/keeper_sm_cli/exec.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/exec.py
@@ -23,46 +23,60 @@ class Exec:
     def __init__(self, cli):
         self.cli = cli
 
+        # Since the cli is short lived, this won't stick around long.
+        self.local_cache = {}
+
+    def _get_secret(self, notation):
+
+        # If not in the cache, go get the secret and then store it in the cache.
+        if notation not in self.local_cache:
+            value = self.cli.client.get_notation(notation)
+            if type(value) is dict or type(value) is list:
+                value = json.dumps(value)
+            self.local_cache[notation] = str(value)
+
+        return self.local_cache[notation]
+
     def env_replace(self):
-
-        # keeper://<UID>/field/<type>
-        # keeper://<UID>/custom_field/<label>
-        # keeper://<UID>/file/<file_id>
-
-        # Get a list of unique UID to get in one shot.
-        uids = []
-        for _, env_value in os.environ.items():
-            if env_value.startswith(Commander.notation_prefix) is True:
-                parts = env_value.split('//')
-                (uid, _, _) = parts[1].split('/')
-                if uid not in uids:
-                    uids.append(uid)
-
-        # Get the record and place them in a lookup by UID
-        record_lookup = {}
-        records = self.cli.client.get_secrets(uids)
-        for record in records:
-            record_lookup[record.uid] = record
 
         for env_key, env_value in os.environ.items():
             if env_value.startswith(Commander.notation_prefix) is True:
-
-                value = self.cli.client.get_notation(env_value)
-                if type(value) is dict or type(value) is list:
-                    value = json.dumps(value)
-
                 os.environ["_" + env_key] = "_" + env_value
-                os.environ[env_key] = str(value)
+                os.environ[env_key] = self._get_secret(env_value)
 
-    @staticmethod
-    def execute(cmd, capture_output=False):
+    def inline_replace(self, cmd=None):
 
+        if cmd is None:
+            cmd = []
+
+        new_cmd = []
+        for item in cmd:
+            # Due to custom fields, that allow spaces in the label, we have not idea
+            # where the notation ends.
+            results = re.search(r'{}://.*?$'.format(Commander.notation_prefix), item)
+            if results is not None:
+                env_value = results.group()
+                item = item.replace(env_value, self._get_secret(env_value))
+            new_cmd.append(item)
+        cmd = new_cmd
+
+        return cmd
+
+    def execute(self, cmd, capture_output=False, inline=False):
+
+        # Make a version of the command before replacing secrets. We don't want to expose them if
+        # there is error.
         full_cmd = " ".join(cmd)
 
         if len(cmd) == 0:
             sys.stderr.write("Cannot execute command, it's missing.\n")
             sys.exit(1)
         else:
+            self.env_replace()
+
+            if inline is True:
+                cmd = self.inline_replace(cmd)
+
             try:
                 completed = subprocess.run(cmd, capture_output=capture_output)
             except OSError as err:

--- a/integration/keeper_sm_cli/setup.py
+++ b/integration/keeper_sm_cli/setup.py
@@ -16,7 +16,7 @@ install_requires = [
 
 setup(
     name="keeper_sm_cli",
-    version="0.0.15a0",
+    version="0.0.16a0",
     description="Command line tool for Keeper Secret Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_sm_cli/tests/exec_test.py
+++ b/integration/keeper_sm_cli/tests/exec_test.py
@@ -82,6 +82,73 @@ class ExecTest(unittest.TestCase):
                                      "did not find the not one")
                 script.close()
 
+    def test_cmd_inline(self):
+
+        # Log level set in this one, nothing below INFO should appear.
+        commander = Commander(config=InMemoryKeyValueStorage({
+            "server": "fake.keepersecurity.com",
+            "appKey": "9vVajcvJTGsa2Opc_jvhEiJLRKHtg2Rm4PAtUoP3URw",
+            "clientId": "rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ",
+            "clientKey": "zKoSCC6eNrd3N9CByRBsdChSsTeDEAMvNj9Bdh7BJuo",
+            "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
+                          "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
+                          "jhKMhHQFaHYI"
+        }), log_level="INFO")
+
+        res = mock.Response()
+        one = res.add_record(title="My Record 1")
+        one.field("login", "My Login 1")
+        one.field("password", "PASS")
+        one.custom_field("password", "My Password 1")
+
+        queue = mock.ResponseQueue(client=commander)
+        # Profile init
+        queue.add_response(res)
+
+        # One for each var ... until we begin to cache.
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('integration.keeper_sm_cli.keeper_sm_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = commander
+
+            Profile.init(
+                client_key='rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ'
+            )
+
+            # Make a temp shell script
+            with tempfile.NamedTemporaryFile() as script:
+                the_script = [
+                    "#!/bin/sh",
+                    "echo ${VAR_ONE}",
+                    "echo ${VAR_TWO}",
+                    "echo ${1}"
+                ]
+                script.write("\n".join(the_script).encode())
+                script.seek(0)
+                os.chmod(script.name, 0o777)
+
+                os.environ["VAR_ONE"] = "{}://{}/{}/{}".format(Commander.notation_prefix, one.uid, "field", "login")
+                os.environ["VAR_TWO"] = "{}://{}/{}/{}".format(Commander.notation_prefix, one.uid, "custom_field",
+                                                               "password")
+
+                runner = CliRunner()
+                result = runner.invoke(cli, [
+                    'exec', '--capture-output', '--inline',
+                    script.name, "{}://{}/{}/{}[]".format(Commander.notation_prefix, one.uid, "field", "password")
+                ], catch_exceptions=False)
+                print(result.output)
+                self.assertIsNotNone(re.search('My Login 1', result.output, flags=re.MULTILINE),
+                                     "did not find the login")
+                self.assertIsNotNone(re.search('My Password 1', result.output, flags=re.MULTILINE),
+                                     "did not find the custom field password")
+
+                # For coverage we request the full array value for this one, hence ["PASS"]
+                self.assertIsNotNone(re.search('\["PASS"\]', result.output, flags=re.MULTILINE),
+                                     "did not find the field password")
+                script.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The reason for this is if a command like this ...

    export MYSECRET=keeper://XXXX/field/login
    ksm exec -- ./runme ${MYSECRET}

is run, Linux will replace the env var before we get to it. This will
cause ./runme to get keeper://XXXX/field/login in the ARGV instead of a
secret.

The inline will parse the cmd items and replace any keeper:// notation
with values.