### PR TITLE
Fix problems with downloading value vi notation

### DIFF
--- a/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
+++ b/integration/keeper_sm_cli/keeper_sm_cli/__init__.py
@@ -17,8 +17,6 @@ from .profile import Profile
 import sys
 import logging
 
-__version__ = "0.0.5"
-
 
 class KeeperCli:
 
@@ -67,15 +65,7 @@ class KeeperCli:
         # Default to stdout if the output is not set.
         if output is None:
             output = "stdout"
-
-        if output == "stdout":
-            self.output_fh = sys.stdout
-        elif output == "stderr":
-            self.output_fh = sys.stderr
-        elif type(output) is str:
-            self.output_fh = open(output, "w+")
-        else:
-            sys.exit("The output {} is not supported. Cannot display your information.".format(output))
+        self.output_name = output
 
     @property
     def client(self):
@@ -103,5 +93,28 @@ class KeeperCli:
         logger.setLevel(getattr(logging, value))
 
     def output(self, msg):
-        self.output_fh.write(msg)
-        self.output_fh.flush()
+
+        is_file = False
+        is_bytes = type(msg) is bytes
+        if self.output_name == "stdout":
+            output_fh = sys.stdout
+        elif self.output_name == "stderr":
+            output_fh = sys.stderr
+        elif type(self.output_name) is str:
+            output_fh = open(self.output_name, "w+")
+            is_file = True
+        else:
+            sys.exit("The output {} is not supported. Cannot display your information.".format(self.output))
+
+        # Write bytes via the buffer since we do not know the encoding. We can't decode() because it might not
+        # be utf-8.
+        if is_bytes is True:
+            output_fh.buffer.write(msg)
+        else:
+            output_fh.write(msg)
+
+        if is_file is True:
+            output_fh.close()
+        else:
+            # Make sure we push stdout and stderr out.
+            output_fh.flush()

--- a/integration/keeper_sm_cli/tests/exec_test.py
+++ b/integration/keeper_sm_cli/tests/exec_test.py
@@ -138,7 +138,6 @@ class ExecTest(unittest.TestCase):
                     'exec', '--capture-output', '--inline',
                     script.name, "{}://{}/{}/{}[]".format(Commander.notation_prefix, one.uid, "field", "password")
                 ], catch_exceptions=False)
-                print(result.output)
                 self.assertIsNotNone(re.search('My Login 1', result.output, flags=re.MULTILINE),
                                      "did not find the login")
                 self.assertIsNotNone(re.search('My Password 1', result.output, flags=re.MULTILINE),

--- a/integration/keeper_sm_cli/tests/secret_test.py
+++ b/integration/keeper_sm_cli/tests/secret_test.py
@@ -12,6 +12,9 @@ import tempfile
 import json
 import re
 import os
+import base64
+import imghdr
+import sys
 from requests import Response
 
 
@@ -289,6 +292,112 @@ class SecretTest(unittest.TestCase):
             result = runner.invoke(cli, ['secret', 'notation', notation], catch_exceptions=False)
             self.assertRegex(result.output, r'Cannot find the field', 'got an error for bad field')
             self.assertEqual(1, result.exit_code, "the exit code was not 1")
+
+    def test_notation_file(self):
+
+        commander = Commander(config=InMemoryKeyValueStorage({
+            "server": "fake.keepersecurity.com",
+            "appKey": "9vVajcvJTGsa2Opc_jvhEiJLRKHtg2Rm4PAtUoP3URw",
+            "clientId": "rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ",
+            "clientKey": "zKoSCC6eNrd3N9CByRBsdChSsTeDEAMvNj9Bdh7BJuo",
+            "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
+                          "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
+                          "jhKMhHQFaHYI"
+        }))
+
+        # This is a tiny 2x2 PNG image base64 encoded.
+        tiny_png_base64 = \
+            "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAMJlWElmTU0AKgAAAAgABwESAAMAAAABAAEAAAEa" \
+            "AAUAAAABAAAAYgEbAAUAAAABAAAAagEoAAMAAAABAAIAAAExAAIAAAARAAAAcgEyAAIAAAAUAAAAhIdpAAQAAAABAAAAmAAAAAAAAABI" \
+            "AAAAAQAAAEgAAAABUGl4ZWxtYXRvciAzLjkuOAAAMjAyMTowNzoyMiAxNDowNzo3NgAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAqAD" \
+            "AAQAAAABAAAAAgAAAAByx + BYAAAACXBIWXMAAAsTAAALEwEAmpwYAAADpmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbW" \
+            "V0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Im" \
+            "h0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD" \
+            "0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZX" \
+            "hpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS" \
+            "94YXAvMS4wLyI + CiAgICAgICAgIDx0aWZmOkNvbXByZXNzaW9uPjA8L3RpZmY6Q29tcHJlc3Npb24 + CiAgICAgICAgIDx0aWZmOl" \
+            "Jlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ + CiAgICAgICAgIDx0aWZmOlhSZXNvbHV0aW9uPjcyPC90aWZmOlhS" \
+            "ZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6T3Jp" \
+            "ZW50YXRpb24 + MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjI8L2V4aWY6UGl4ZWxYRG" \
+            "ltZW5zaW9uPgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxZRG" \
+            "ltZW5zaW9uPjI8L2V4aWY6UGl4ZWxZRGltZW5zaW9uPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPlBpeGVsbWF0b3IgMy45Ljg8L3" \
+            "htcDpDcmVhdG9yVG9vbD4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMjEtMDctMjJUMTQ6MDc6NzY8L3htcDpNb2RpZnlEYXRlPg" \
+            "ogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KPKL2agAAABNJREFUCB1j / M8gy8DAwATE" \
+            "QAAADlwBIHTDGBYAAAAASUVORK5CYII ="
+
+        file_res = mock.Response()
+        file_record = file_res.add_record(title="My File 1", record_type='file')
+        mocked_file_1 = file_record.add_file(
+            name="Tiny Png",
+            content=base64.b64decode(tiny_png_base64),
+            content_type="image/png"
+        )
+        mocked_file_2 = file_record.add_file(
+            name="my_text.txt",
+            content="My Text",
+            content_type="plain/text"
+        )
+
+        queue = mock.ResponseQueue(client=commander)
+        queue.add_response(file_res)
+        queue.add_response(file_res)
+        queue.add_response(file_res)
+        queue.add_response(file_res)
+
+        lookup = {
+            mocked_file_1.uid: mocked_file_1,
+            mocked_file_2.uid: mocked_file_2
+        }
+
+        def mock_download_get(url):
+            uid = url.replace("http://localhost/", "")
+            mock_res = Response()
+            mock_res.status_code = 200
+            mock_res.reason = "OK"
+            mock_res._content = lookup[uid].downloadable_content()
+            mock_res.headers["Content-Type"] = lookup[uid].content_type
+            return mock_res
+
+        with patch('requests.get', side_effect=mock_download_get) as mock_get:
+            with patch('integration.keeper_sm_cli.keeper_sm_cli.KeeperCli.get_client') as mock_client:
+                mock_client.return_value = commander
+
+                Profile.init(
+                    client_key='rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ'
+                )
+
+                # Write png to file. This will be binary data.
+                with tempfile.NamedTemporaryFile() as tf:
+                    print("ONE", tf.name)
+                    notation = "keeper://{}/{}/{}".format(file_record.uid, "file", "Tiny Png")
+                    runner = CliRunner()
+                    result = runner.invoke(cli, [
+                        "-o", tf.name,
+                        'secret', 'notation', notation
+                    ], catch_exceptions=False)
+                    self.assertEqual(0, result.exit_code, "the exit code was not 0")
+                    tf.seek(0)
+                    self.assertEqual("png", imghdr.what(tf), "did not get a PNG")
+                    tf.close()
+
+                # Write plain text to file. This should not be binary data.
+                with tempfile.NamedTemporaryFile() as tf:
+                    notation = "keeper://{}/{}/{}".format(file_record.uid, "file", "my_text.txt")
+                    runner = CliRunner()
+                    result = runner.invoke(cli, [
+                        "-o", tf.name,
+                        'secret', 'notation', notation
+                    ], catch_exceptions=False)
+                    self.assertEqual(0, result.exit_code, "the exit code was not 0")
+                    tf.seek(0)
+                    data = tf.read()
+                    # TODO: I hate this. Plain text comes back a binary from mock since it's not going
+                    #  threw a response handler.
+                    self.assertEqual(b'My Text', data, "did not get my text file")
+
+                # TODO: Need to capture to stdout. Can do it, however there is a charset encoding problem.
+                #  The saved file looks like "<89>PNG^M" in the first line if saved. We need to emulated it. Stuff
+                #  like "?PNG" or "�PNG" or "\ufffdPNG" are bad. :(
 
     def test_update(self):
         """Test updating an existing record

--- a/sdk/python/core/keepercommandersm/core.py
+++ b/sdk/python/core/keepercommandersm/core.py
@@ -519,12 +519,14 @@ class Commander:
             value = record.custom_field(key, single=False)
         elif file_type == "file":
             file = record.find_file_by_title(key)
-            value = file.self.get_file_data()
+            if file is None:
+                raise FileNotFoundError("Cannot find the file {} in record {}.".format(key, uid))
+            value = file.get_file_data()
         else:
             raise ValueError("Field type of {} is not value.".format(file_type))
 
         ret = value
-        if return_single is True:
+        if return_single is True and type(value) is list:
             if len(value) == 0:
                 return None
             try:

--- a/sdk/python/core/keepercommandersm/mock.py
+++ b/sdk/python/core/keepercommandersm/mock.py
@@ -255,7 +255,12 @@ class File:
         # encode the content with that secret.
         if self.secret_used is None:
             raise ValueError("The file has not be dump'd yet, Secret is unknown.")
-        return encrypt_aes(self.content.encode(), self.secret_used)
+
+        data = self.content
+        if type(data) is not bytes:
+            data = data.encode()
+
+        return encrypt_aes(data, self.secret_used)
 
     def dump(self, secret, flags=None):
         self.secret_used = secret


### PR DESCRIPTION
Needed to move the output initalization to the actual output since
we don't know what kind of value we have until we want to output.

Might by str or bytes, so we can't open a file until we know that.

Added unit test for testing and fix the mock data to handle str and
byte content.