### PR TITLE
Profile export

### DIFF
--- a/integration/keeper_sm_cli/requirements.txt
+++ b/integration/keeper_sm_cli/requirements.txt
@@ -2,3 +2,4 @@ keepercommandersm
 click
 jsonpath-rw-ext
 prettytable
+importlib_metadata

--- a/integration/keeper_sm_cli/setup.py
+++ b/integration/keeper_sm_cli/setup.py
@@ -11,12 +11,14 @@ install_requires = [
     'keepercommandersm',
     'click',
     'jsonpath-rw-ext',
-    'prettytable'
+    'prettytable',
+    'importlib_metadata'
 ]
 
+# Version set in the keeper_sm_cli.version file.
 setup(
     name="keeper_sm_cli",
-    version="0.0.16a0",
+    version="0.0.22a0",
     description="Command line tool for Keeper Secret Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Profile export/import and Python 3.7 fixes

Add the ability to export a profile. This will pull a profile from the
config and make a new config with that profile as the defaut/active.

If a --key is one of the parameters, it will AES encrypt and base64
encode the profile.

And also created a import abilit to init a new config using that
exported profile.

The main purpose of this is passing a config into a Docker build. While
the encryting looks like a nice feature, it main goal was to make a
nice line of text that would be easy to pass in a env var.

    $ docker build --build-arg "PROFILE=$(ksm profile export --key ABC builder_profile" ...

And then

    RUN ksm profile import --key ABC -f /etc/keeper.ini ${PROFILE}

Also fixed getting the module versions in 3.7. meta_version is new in
3.8, needed to use importlib_metadata.version which works in 3.7+