### PR TITLE
Add a test for test UID that start with dashes

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -270,7 +270,7 @@ class Profile:
         profile_config = self.get_profile_config(profile_name)
 
         export_config = configparser.ConfigParser()
-        export_config[Profile.default_profile] =profile_config
+        export_config[Profile.default_profile] = profile_config
         export_config[Profile.config_profile] = {
             "log_level": "WARNING",
             Profile.active_profile_key: Profile.default_profile

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -266,7 +266,8 @@ class Secret:
         if output_format == 'text':
             self.cli.output(self._format_list(record_dict))
         elif output_format == 'json':
-            records = [{"uid": x["uid"], "title": x["title"], "record_type": x["type"]} for x in record_dict]
+            records = [{"uid": x.get("uid"), "title": x.get("title"), "record_type": x.get("type")}
+                       for x in record_dict]
             self.cli.output(json.dumps(records, indent=4))
 
     def download(self, uid, name, file_output, create_folders=False):

--- a/integration/keeper_secrets_manager_cli/requirements.txt
+++ b/integration/keeper_secrets_manager_cli/requirements.txt
@@ -2,3 +2,4 @@ keeper-secrets-manager-core
 jsonpath-rw-ext
 prettytable
 importlib_metadata
+click

--- a/integration/keeper_secrets_manager_cli/tests/exec_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/exec_test.py
@@ -68,7 +68,8 @@ class ExecTest(unittest.TestCase):
                 script.seek(0)
                 os.chmod(script.name, 0o777)
 
-                os.environ["VAR_ONE"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "field", "login")
+                os.environ["VAR_ONE"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "field",
+                                                               "login")
                 os.environ["VAR_TWO"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "custom_field",
                                                                "password")
                 os.environ["NOT_ONE"] = "BLAH"
@@ -111,7 +112,8 @@ class ExecTest(unittest.TestCase):
         queue.add_response(res)
         queue.add_response(res)
 
-        with patch('integration.keeper_secrets_manager_cli.keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+        with patch('integration.keeper_secrets_manager_cli.keeper_secrets_manager_cli.KeeperCli.get_client') \
+                as mock_client:
             mock_client.return_value = secrets_manager
 
             Profile.init(
@@ -130,7 +132,8 @@ class ExecTest(unittest.TestCase):
                 script.seek(0)
                 os.chmod(script.name, 0o777)
 
-                os.environ["VAR_ONE"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "field", "login")
+                os.environ["VAR_ONE"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "field",
+                                                               "login")
                 os.environ["VAR_TWO"] = "{}://{}/{}/{}".format(SecretsManager.notation_prefix, one.uid, "custom_field",
                                                                "password")
 
@@ -145,7 +148,7 @@ class ExecTest(unittest.TestCase):
                                      "did not find the custom field password")
 
                 # For coverage we request the full array value for this one, hence ["PASS"]
-                self.assertIsNotNone(re.search('\["PASS"\]', result.output, flags=re.MULTILINE),
+                self.assertIsNotNone(re.search(r'\["PASS"\]', result.output, flags=re.MULTILINE),
                                      "did not find the field password")
                 script.close()
 

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -289,7 +289,8 @@ class SecretsManager:
                 response_dict = json_to_dict(rs.text)
 
                 if response_dict.get('result_code') == 'invalid_client_version':
-                    logging.error("Client version %s was not registered in the backend" % keeper_secrets_manager_sdk_client_id)
+                    logging.error("Client version %s was not registered in the backend" %
+                                  keeper_secrets_manager_sdk_client_id)
                     raise KeeperError(response_dict.get('additional_info'))
                 elif 'error' in response_dict:
                     # Errors:

--- a/sdk/python/core/keeper_secrets_manager_core/mock.py
+++ b/sdk/python/core/keeper_secrets_manager_core/mock.py
@@ -50,7 +50,7 @@ class ResponseQueue:
         response = self.queue.popleft()
         return response.instance(context)
 
-    def auto_responder_patch(self, path, context, payload_and_signature):
+    def auto_responder_patch(self, _path, context, _payload_and_signature):
         return self.get_response(context)
 
 
@@ -266,6 +266,11 @@ class File:
         return encrypt_aes(data, self.secret_used)
 
     def dump(self, secret, flags=None):
+
+        # No special flags for download. Do this to make PEP8 happy for unused vars.
+        if flags is not None:
+            pass
+
         self.secret_used = secret
         d = {
             "name": self.name,

--- a/sdk/python/core/keeper_secrets_manager_core/utils.py
+++ b/sdk/python/core/keeper_secrets_manager_core/utils.py
@@ -183,7 +183,6 @@ def hash_of_string(value):
 
 
 def ecies_decrypt(server_public_key, ciphertext, priv_key_data, id=b''):
-    result = None
 
     try:
         # server_public_key = ciphertext[:65]


### PR DESCRIPTION
It looks like click can handle an arg value that starts with a dash.
Even made it look a parameter.

Also made a few PEP8 fixes. And add the click module to the
requirements.txt.