### PR TITLE
Move prepare_context and prepare_get_payload inside of while loop

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -337,10 +337,11 @@ class SecretsManager:
 
     def fetch(self, record_filter=None):
 
-        context = self.prepare_context()
-        payload_and_signature = self.prepare_get_payload(context, records_filter=record_filter)
-
         while True:
+
+            context = self.prepare_context()
+            payload_and_signature = self.prepare_get_payload(context, records_filter=record_filter)
+
             rs = self._post_query(
                 'get_secret',
                 context,
@@ -418,11 +419,11 @@ class SecretsManager:
 
         logging.info("Updating record uid: %s" % record.uid)
 
-        context = self.prepare_context()
-
-        payload_and_signature = self.prepare_update_payload(context, record)
-
         while True:
+
+            context = self.prepare_context()
+            payload_and_signature = self.prepare_update_payload(context, record)
+
             rs = self._post_query(
                 'update_secret',
                 context,

--- a/sdk/python/core/tests/exception_test.py
+++ b/sdk/python/core/tests/exception_test.py
@@ -10,7 +10,7 @@ from keeper_secrets_manager_core import mock
 from requests import HTTPError
 
 
-class SmokeTest(unittest.TestCase):
+class ExceptionTest(unittest.TestCase):
 
     def setUp(self):
 


### PR DESCRIPTION
After we switch public key, we need to regenerate the context, payload,
and signatures.

Also fixed class name of test.