### PR TITLE
Don't set instance password if can't find password, and more

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -272,7 +272,7 @@ class Profile:
         export_config = configparser.ConfigParser()
         export_config[Profile.default_profile] = profile_config
         export_config[Profile.config_profile] = {
-            "log_level": "WARNING",
+            "log_level": "ERROR",
             Profile.active_profile_key: Profile.default_profile
         }
 

--- a/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
+++ b/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
@@ -62,7 +62,8 @@ class Record:
 
             password_field = next((item for item in fields if item["type"] == "password"), None)
 
-            self.password = password_field.get('value')[0]
+            if password_field is not None:
+                self.password = password_field.get('value')[0]
 
     def find_file_by_title(self, title):
         """Finds file by file title"""

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-core",
-    version="0.0.32a0",
+    version="16.0.1",
     description="Keeper Secrets Manager for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=False,
     install_requires=install_requires,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://github.com/Keeper-Security/secrets-manager",

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -200,7 +200,7 @@ class SmokeTest(unittest.TestCase):
             self.assertEqual("16.1.23", client_version, "did not get the correct client version from 0.1.23a0")
 
         with patch("importlib_metadata.version") as mock_meta:
-            mock_meta.return_value = "0.1.24"
+            mock_meta.return_value = "0.2.24"
 
             client_version = get_client_version()
-            self.assertEqual("16.1.24", client_version, "did not get the correct client version from 0.1.24")
+            self.assertEqual("16.2.24", client_version, "did not get the correct client version from 0.2.24")


### PR DESCRIPTION
* In the record, if the password is not set, do not set the instance
  attribute.
* Set the CLI default logging level to ERROR
* Set the SDK's version to 16.0.1. Revert/update test.