### PR TITLE
Fix the missing password on login record types

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
+++ b/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
@@ -62,7 +62,8 @@ class Record:
 
             password_field = next((item for item in fields if item["type"] == "password"), None)
 
-            if password_field is not None:
+            # If the password field exists and there is a value in the array, then set the password.
+            if password_field is not None and len(password_field.get('value', [])) > 0:
                 self.password = password_field.get('value')[0]
 
     def find_file_by_title(self, title):

--- a/sdk/python/core/keeper_secrets_manager_core/mock.py
+++ b/sdk/python/core/keeper_secrets_manager_core/mock.py
@@ -394,6 +394,13 @@ class Record:
             # SecretsManager will not add a custom key if there is no custom fields. However the UI does.
             if flags.get("prune_custom_fields", False) is True and len(record_data["custom"]) == 0:
                 record_data.pop("custom", None)
+            # Remove fields if they do not have values.
+            if flags.get("prune_empty_fields", False) is True:
+                new_fields = []
+                for field in record_data["fields"]:
+                    if len(field.get("value")) > 0:
+                        new_fields.append(field)
+                record_data["fields"] = new_fields
 
         data = {
             "recordUid": self.uid,

--- a/sdk/python/core/tests/record_test.py
+++ b/sdk/python/core/tests/record_test.py
@@ -1,0 +1,78 @@
+import unittest
+import tempfile
+import json
+import os
+
+from keeper_secrets_manager_core.storage import FileKeyValueStorage
+from keeper_secrets_manager_core import SecretsManager
+from keeper_secrets_manager_core import mock
+
+
+class RecordTest(unittest.TestCase):
+
+    def setUp(self):
+
+        self.orig_working_dir = os.getcwd()
+
+    def tearDown(self):
+
+        os.chdir(self.orig_working_dir)
+
+    def test_the_login_record_password(self):
+
+        """ If the record type is login, the password will be placed in the instance attribute.
+        """
+
+        with tempfile.NamedTemporaryFile("w") as fh:
+            fh.write(
+                json.dumps({
+                    "hostname": "fake.keepersecurity.com",
+                    "appKey": "9vVajcvJTGsa2Opc_jvhEiJLRKHtg2Rm4PAtUoP3URw",
+                    "clientId": "rYebZN1TWiJagL-wHxYboe1vPje10zx1JCJR2bpGILlhIRg7HO26"
+                                "C7HnW-NNHDaq_8SQQ2sOYYT1Nhk5Ya_SkQ",
+                    "clientKey": "zKoSCC6eNrd3N9CByRBsdChSsTeDEAMvNj9Bdh7BJuo",
+                    "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9d"
+                                  "jH0YEvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbE"
+                                  "T6joq0xCjhKMhHQFaHYI"
+                })
+            )
+            fh.seek(0)
+            secrets_manager = SecretsManager(config=FileKeyValueStorage(config_file_location=fh.name))
+
+            # A good record.
+            # 'fields': [...{'type': 'password', 'value': ['My Password']}...]
+            good_res = mock.Response()
+            good = good_res.add_record(title="Good Record", record_type='login')
+            good.field("login", "My Login")
+            good.field("password", "My Password")
+
+            # A bad record. This would be like if someone removed a password text from an existing field.
+            # 'fields': [...{'type': 'password', 'value': []}...]
+            bad_res = mock.Response()
+            bad = bad_res.add_record(title="Bad Record", record_type='login')
+            bad.field("login", "My Login")
+            bad.field("password", [])
+
+            # A ugly record. The application didn't even add the field. We need to set flags to prune empty fields.
+            # 'fields': [...]
+            ugly_res = mock.Response(flags={"prune_empty_fields": True})
+            ugly = ugly_res.add_record(title="Ugly Record", record_type='login')
+            ugly.field("login", "My Login")
+            ugly.field("password", []) # this will be removed from the fields array.
+
+            res_queue = mock.ResponseQueue(client=secrets_manager)
+            res_queue.add_response(good_res)
+            res_queue.add_response(bad_res)
+            res_queue.add_response(ugly_res)
+
+            records = secrets_manager.get_secrets()
+            self.assertEqual(1, len(records), "didn't get 1 record for the good")
+            self.assertEqual("My Password", records[0].password, "did not get correct password for the good")
+
+            records = secrets_manager.get_secrets()
+            self.assertEqual(1, len(records), "didn't get 1 record for the bad")
+            self.assertIsNone(records[0].password, "password is defined for the bad")
+
+            records = secrets_manager.get_secrets()
+            self.assertEqual(1, len(records), "didn't get 1 record for the ugly")
+            self.assertIsNone(records[0].password, "password is defined for the ugly")


### PR DESCRIPTION
If the password field is missing or if the field exists and the
value is empty [], don't set the password.