### PR TITLE
Hard code the client version, for now. Add more public keys.

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -35,7 +35,7 @@ class SecretsManager:
 
     notation_prefix = "keeper"
     log_level = "DEBUG"
-    default_key_id = "1"
+    default_key_id = "7"
 
     def __init__(self, token=None, hostname=None, verify_ssl_certs=True, config=None, log_level=None):
 
@@ -57,6 +57,16 @@ class SecretsManager:
             config.set(ConfigKeys.KEY_CLIENT_KEY, token)
         if hostname is not None:
             config.set(ConfigKeys.KEY_HOSTNAME, hostname)
+
+        # Make sure our public key id is set and pointing an existing key.
+        if config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID) is None:
+            logging.debug("Setting public key id to the default: {}".format(SecretsManager.default_key_id))
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, SecretsManager.default_key_id)
+        elif config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID) not in keeper_public_keys:
+            logging.debug("Public key id {} does not exists, set to default : {}".format(
+                config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID),
+                SecretsManager.default_key_id))
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, SecretsManager.default_key_id)
 
         self.config: KeyValueStorage = config
 

--- a/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
+++ b/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
@@ -12,7 +12,7 @@ import importlib_metadata
 import re
 
 
-def get_client_version():
+def get_client_version(hardcode=False):
     """Get the version of the client
 
     The version # comes from metadata. In a unit test, there is metadata, so the version will
@@ -28,22 +28,26 @@ def get_client_version():
     """
     # Get the version of the keeper secrets manager core
     version_major = "16"
-    version = "{}.0.0".format(version_major)
-    try:
-        ksm_version = importlib_metadata.version("keeper-secrets-manager-core")
-        version_parts = ksm_version.split(".")
-        version_minor = version_parts[1]
-        version_revision = re.search(r'^\d+', version_parts[2]).group()
-        version = "{}.{}.{}".format(version_major, version_minor, version_revision)
-    except importlib_metadata.PackageNotFoundError:
-        # In a unit test or development run, not an installed version. Just use the default.
-        pass
-    except Exception as err:
-        raise Exception(err)
+    version = "{}.0.1".format(version_major)
+
+    # Allow the default version to be hard coded. If not build the client version from the module
+    # version.
+    if hardcode is False:
+        try:
+            ksm_version = importlib_metadata.version("keeper-secrets-manager-core")
+            version_parts = ksm_version.split(".")
+            version_minor = version_parts[1]
+            version_revision = re.search(r'^\d+', version_parts[2]).group()
+            version = "{}.{}.{}".format(version_major, version_minor, version_revision)
+        except importlib_metadata.PackageNotFoundError:
+            # In a unit test or development run, not an installed version. Just use the default.
+            pass
+        except Exception as err:
+            raise Exception(err)
     return version
 
-
-keeper_secrets_manager_sdk_client_id = "mp{}".format(get_client_version())
+# Right now the client version is being hardcoded.
+keeper_secrets_manager_sdk_client_id = "mp{}".format(get_client_version(hardcode=True))
 
 keeper_public_keys = {
     '1': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
@@ -51,7 +55,19 @@ keeper_public_keys = {
     '3': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
     '4': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
     '5': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
-    '6': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
+    '6': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
+
+    '7': 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM',
+    '8': 'BKnhy0obglZJK-igwthNLdknoSXRrGB-mvFRzyb_L-DKKefWjYdFD2888qN1ROczz4n3keYSfKz9Koj90Z6w_tQ',
+    '9': 'BAsPQdCpLIGXdWNLdAwx-3J5lNqUtKbaOMV56hUj8VzxE2USLHuHHuKDeno0ymJt-acxWV1xPlBfNUShhRTR77g',
+    '10': 'BNYIh_Sv03nRZUUJveE8d2mxKLIDXv654UbshaItHrCJhd6cT7pdZ_XwbdyxAOCWMkBb9AZ4t1XRCsM8-wkEBRg',
+    '11': 'BA6uNfeYSvqagwu4TOY6wFK4JyU5C200vJna0lH4PJ-SzGVXej8l9dElyQ58_ljfPs5Rq6zVVXpdDe8A7Y3WRhk',
+    '12': 'BMjTIlXfohI8TDymsHxo0DqYysCy7yZGJ80WhgOBR4QUd6LBDA6-_318a-jCGW96zxXKMm8clDTKpE8w75KG-FY',
+    '13': 'BJBDU1P1H21IwIdT2brKkPqbQR0Zl0TIHf7Bz_OO9jaNgIwydMkxt4GpBmkYoprZ_DHUGOrno2faB7pmTR7HhuI',
+    '14': 'BJFF8j-dH7pDEw_U347w2CBM6xYM8Dk5fPPAktjib-opOqzvvbsER-WDHM4ONCSBf9O_obAHzCyygxmtpktDuiE',
+    '15': 'BDKyWBvLbyZ-jMueORl3JwJnnEpCiZdN7yUvT0vOyjwpPBCDf6zfL4RWzvSkhAAFnwOni_1tQSl8dfXHbXqXsQ8',
+    '16': 'BDXyZZnrl0tc2jdC5I61JjwkjK2kr7uet9tZjt8StTiJTAQQmnVOYBgbtP08PWDbecxnHghx3kJ8QXq1XE68y8c',
+    '17': 'BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU'
 }
 
 keeper_servers = {

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-core",
-    version="16.0.1",
+    version="16.0.2",
     description="Keeper Secrets Manager for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/core/tests/config_test.py
+++ b/sdk/python/core/tests/config_test.py
@@ -174,3 +174,29 @@ class ConfigTest(unittest.TestCase):
 
         # App key should be removed.
         self.assertIsNone(secrets_manager.config.get(ConfigKeys.KEY_APP_KEY), "found the app key")
+
+    def test_public_key_id(self):
+
+        config = InMemoryKeyValueStorage()
+        config.set(ConfigKeys.KEY_CLIENT_KEY, "MY CLIENT KEY")
+        config.set(ConfigKeys.KEY_CLIENT_ID, "MY CLIENT ID")
+        config.set(ConfigKeys.KEY_APP_KEY, "MY APP KEY")
+        config.set(ConfigKeys.KEY_PRIVATE_KEY, "MY PRIVATE KEY")
+
+        # Test the default setting of the key id if missing
+        secrets_manager = SecretsManager(config=config)
+        self.assertEqual(
+            SecretsManager.default_key_id,
+            secrets_manager.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID),
+            "the public key is not set the default"
+        )
+
+        # Test if the config is edited and a bad key is entered that we go back to the default.
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, 1_000_000)
+        secrets_manager = SecretsManager(config=config)
+        self.assertEqual(
+            SecretsManager.default_key_id,
+            secrets_manager.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID),
+            "the public key is not set the default after bad key id"
+        )
+

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -196,7 +196,7 @@ class SmokeTest(unittest.TestCase):
         with patch("importlib_metadata.version") as mock_meta:
             mock_meta.return_value = "0.1.23a0"
 
-            client_version = get_client_version()
+            client_version = get_client_version(hardcode=False)
             self.assertEqual("16.1.23", client_version, "did not get the correct client version from 0.1.23a0")
 
         with patch("importlib_metadata.version") as mock_meta:
@@ -204,3 +204,6 @@ class SmokeTest(unittest.TestCase):
 
             client_version = get_client_version()
             self.assertEqual("16.2.24", client_version, "did not get the correct client version from 0.2.24")
+
+        client_version = get_client_version(hardcode=True)
+        self.assertEqual("16.0.1", client_version, "did not get the correct client version for hardcoded")


### PR DESCRIPTION
Hard code the client version to 16.0.1 so we can safely version the
python module until we get out of QA. Add the ECC prublic keys, 7+.
THe default is public key is is 7. Also added checks to make
sure the public key id is set in the config and it points at a
valid key.