### PR TITLE
Removed DEBUG from public view.

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__init__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__init__.py
@@ -16,7 +16,7 @@ from keeper_secrets_manager_core.configkeys import ConfigKeys
 from distutils.util import strtobool
 from .profile import Profile
 import sys
-import logging
+import os
 
 
 class KeeperCli:
@@ -30,7 +30,7 @@ class KeeperCli:
         self.profile = Profile(cli=self, ini_file=ini_file)
         self._client = None
 
-        self._log_level = "INFO"
+        self.log_level = os.environ.get("KSM_DEBUG", None)
         self.use_color = use_color
 
         # If no config file is loaded, then don't init the SDK
@@ -58,13 +58,12 @@ class KeeperCli:
 
             self._client = self.get_client(
                 config=config_storage,
-                log_level=common_profile.get("log_level", self._log_level)
+                log_level=self.log_level
             )
             if self.use_color is None:
                 self.use_color = bool(strtobool(common_profile.get("color", str(True))))
         else:
             # Set the log level. We don't have the client to set the level, so set it here.
-            self.log_level = self._log_level
             if use_color is None:
                 self.use_color = True
 
@@ -82,21 +81,6 @@ class KeeperCli:
     @client.setter
     def client(self, value):
         self._client = value
-
-    @property
-    def log_level(self):
-        return self._log_level
-
-    @log_level.setter
-    def log_level(self, value):
-        self.set_log_level(value)
-        self._log_level = value
-
-    @staticmethod
-    def set_log_level(value):
-        logger = logging.getLogger()
-        # Set the log level. Look up the int value using the string.
-        logger.setLevel(getattr(logging, value))
 
     def output(self, msg):
 

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -24,7 +24,6 @@ import traceback
 import importlib_metadata
 from distutils.util import strtobool
 from colorama import init
-import logging
 
 
 def _get_cli(**kwargs):
@@ -78,7 +77,7 @@ def cli(ctx, ini_file, profile_name, output, color):
                  " sub-command, specify the INI file on the sub-command parameters instead on the top level command.")
     except Exception as err:
         # Set KSM_DEBUG to get a stack trace. Secret env var.
-        if strtobool(os.environ.get("KSM_DEBUG", "FALSE")) == 1:
+        if os.environ.get("KSM_DEBUG") is not None:
             print(traceback.format_exc(), file=sys.stderr)
         sys.exit("Could not run the command. Got the error: {}".format(err))
 
@@ -364,21 +363,6 @@ def config_show_command(ctx):
     """Show current configuration."""
     ctx.obj["profile"].show_config()
 
-
-@click.command(
-    name='log',
-    cls=HelpColorsCommand,
-    help_options_color='blue'
-)
-@click.option('--level',  '-l', type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"]),
-              help="Level of message or error to display")
-@click.pass_context
-def config_log_command(ctx, level):
-    """Set the log level"""
-    if level is not None:
-        ctx.obj["profile"].set_log_level(level)
-
-
 @click.command(
     name='color',
     cls=HelpColorsCommand,
@@ -438,17 +422,12 @@ cli.add_command(version_command)
 
 def main():
     try:
-        # We have to init logging here else the SDK will init it. We handle our own error messages, so
-        # first init the root logger, then disable it.
-        logging.basicConfig(level=logging.CRITICAL)
-        logging.disabled = True
-
         # This init colors for Windows. CMD looks great. PS has no yellow :(
         init()
         cli(obj={"cli": None})
     except Exception as err:
         # Set KSM_DEBUG to get a stack trace. Secret env var.
-        if strtobool(os.environ.get("KSM_DEBUG", "FALSE")) == 1:
+        if os.environ.get("KSM_DEBUG") is not None:
             print(traceback.format_exc(), file=sys.stderr)
         sys.exit("ksm had a problem: {}".format(err))
 

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -31,7 +31,6 @@ class Profile:
     active_profile_key = "active_profile"
     default_profile = os.environ.get("KSM_CLI_PROFILE", "_default")
     default_ini_file = os.environ.get("KSM_INI_FILE", "keeper.ini")
-    log_level_key = "log_level"
     color_key = "color"
 
     def __init__(self, cli, ini_file=None):
@@ -131,7 +130,7 @@ class Profile:
             sys.exit("{} {}".format(error_prefix, err))
 
     @staticmethod
-    def init(token, ini_file=None, server=None, profile_name=None, log_level="INFO"):
+    def init(token, ini_file=None, server=None, profile_name=None):
 
         from . import KeeperCli
 
@@ -165,7 +164,6 @@ class Profile:
 
             # Create our config section name.
             config[Profile.config_profile] = {
-                "log_level": log_level,
                 Profile.active_profile_key: Profile.default_profile
             }
             with open(ini_file, 'w') as configfile:
@@ -179,7 +177,7 @@ class Profile:
         if server is not None:
             config_storage.set(ConfigKeys.KEY_HOSTNAME, server)
 
-        client = KeeperCli.get_client(config=config_storage, log_level=log_level)
+        client = KeeperCli.get_client(config=config_storage)
 
         # Get the secret records to get the app key. The SDK will add the app key to the config.
         try:
@@ -273,7 +271,6 @@ class Profile:
         export_config = configparser.ConfigParser()
         export_config[Profile.default_profile] = profile_config
         export_config[Profile.config_profile] = {
-            "log_level": "ERROR",
             Profile.active_profile_key: Profile.default_profile
         }
 
@@ -315,12 +312,6 @@ class Profile:
 
         print("Imported config saved to {}".format(file), file=sys.stderr)
 
-    def set_log_level(self, level):
-        common_config = self._get_common_config("Cannot set log level.")
-        common_config[Profile.log_level_key] = level
-        self.cli.log_level = level
-        self.save()
-
     def set_color(self, on_off):
         common_config = self._get_common_config("Cannot set log level.")
         common_config[Profile.color_key] = str(on_off)
@@ -331,5 +322,4 @@ class Profile:
         common_config = self._get_common_config("Cannot show the config.")
         not_set_text = "-NOT SET-"
         print("Active Profile: {}".format(common_config.get(Profile.active_profile_key, not_set_text)))
-        print("Log Level: {}".format(common_config.get(Profile.log_level_key, not_set_text)))
         print("Color Enabled: {}".format(common_config.get(Profile.color_key, not_set_text)))

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -18,7 +18,6 @@ from colorama import Fore, Style
 from keeper_secrets_manager_core.exceptions import KeeperError, KeeperAccessDenied
 from .table import Table, ColumnAlign
 import uuid
-import logging
 
 
 class Secret:

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="0.0.26",
+    version="0.0.27",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_secrets_manager_cli/tests/exec_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/exec_test.py
@@ -40,7 +40,7 @@ class ExecTest(unittest.TestCase):
             "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
                           "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
                           "jhKMhHQFaHYI"
-        }), log_level="INFO")
+        }))
 
         res = mock.Response()
         one = res.add_record(title="My Record 1")
@@ -106,7 +106,7 @@ class ExecTest(unittest.TestCase):
             "privateKey": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgaKWvicgtslVJKJU-_LBMQQGfJAycwOtx9djH0Y"
                           "EvBT-hRANCAASB1L44QodSzRaIOhF7f_2GlM8Fg0R3i3heIhMEdkhcZRDLxIGEeOVi3otS0UBFTrbET6joq0xC"
                           "jhKMhHQFaHYI"
-        }), log_level="INFO")
+        }))
 
         res = mock.Response()
         one = res.add_record(title="My Record 1")


### PR DESCRIPTION
In the normal working mode of KSM CLI, there is no logging. The
error message come from the exception messages.

However, the env var KSM_DEBUG will enabled logging.

    $ KSM_DEBUG=DEBUG ksm secret list
    2021-08-12 17:04:26,339 | ksm | DEBUG | Setting public key id to the default: 7
    2021-08-12 17:04:26,339 | ksm | INFO | Secret key found in configuration file
    2021-08-12 17:04:26,339 | ksm | DEBUG | Already bound
    2021-08-12 17:04:26,390 | ksm | DEBUG | Keeper hostname keepersecurity.com
    2021-08-12 17:04:26,613 | ksm | INFO | Server has requested we use public key 10
    2021-08-12 17:04:26,613 | ksm | DEBUG | Error:  (http error code 401): {"key_id":10,"error":"key","message":"invalid key id"}
    2021-08-12 17:04:26,617 | ksm | DEBUG | Keeper hostname keepersecurity.com
    2021-08-12 17:04:26,847 | ksm | DEBUG | Individual record count: 1
    2021-08-12 17:04:26,847 | ksm | DEBUG | Folder count: 1
    2021-08-12 17:04:26,850 | ksm | DEBUG | Total record count: 3

     UID                     Record Type Title
     ----------------------- ----------- ----------------------
     xtlguWgodbpFkKJn7_7mAQ  login       Rose 3rd Party Website
     l-fD6_OM7yCd7F56vXTxnQ  login       Florist Web Site
     7uQuxoGwAHpyW8JemKrxcQ  file        Rose Bucket Photos

KSM_DEBUG will also show stacktraces when exceptions happend.