### PR TITLE
cryptography needs to be >= 3.1

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -15,13 +15,11 @@ import configparser
 from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
 from keeper_secrets_manager_core.configkeys import ConfigKeys
 from keeper_secrets_manager_core.exceptions import KeeperError, KeeperAccessDenied
-from keeper_secrets_manager_core.crypto import CryptoUtils
 from .table import Table, ColumnAlign
 from colorama import Fore
 import sys
 import json
 import base64
-import hashlib
 import tempfile
 
 

--- a/sdk/python/core/requirements.txt
+++ b/sdk/python/core/requirements.txt
@@ -1,5 +1,5 @@
 ecdsa
-cryptography
+cryptography>=3.1
 requests
 pytest
 importlib_metadata

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -11,8 +11,9 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
+    'ecdsa',
+    'cryptography>=3.1',
     'requests',
-    'cryptography',
     'importlib_metadata'
 ]
 


### PR DESCRIPTION
If a system already has cryptography install the Python SDK will
not update. By pinning it to a version, installling the Python SDK
will update or already complain.

Also removed unused modules from the CLI which were causing problems.