### PR TITLE
Make args/params easier to use

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -22,7 +22,6 @@ import os
 import keeper_secrets_manager_core
 import traceback
 import importlib_metadata
-from colorama import init
 import difflib
 import typing as t
 
@@ -92,7 +91,7 @@ class AliasedGroup(HelpColorsGroup):
             if best_score > 0.50:
                 cmd_name = best_command
         return super().get_command(ctx, cmd_name)
->>>>>>> 438b27f (Make args/params easier to use)
+
 
     def parse_args(self, ctx, args: t.List[str]):
 


### PR DESCRIPTION
Craig Lurey:slack_call:  4:26 PM
I have a super small nitpicky request, which is to make the ksm parameters optionally case insensitive and plural

example:
-u vs -U
ksm secrets get vs. ksm secret get