### PR TITLE
Added test for TOTP code

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -428,10 +428,10 @@ def secret_download_command(ctx, uid, name, file_output, create_folders):
     cls=HelpColorsCommand,
     help_options_color='blue'
 )
-@click.option('--uid', '-u', required=True, type=str)
+@click.argument('uid', type=str, nargs=1)
 @click.pass_context
 def secret_totp_command(ctx, uid):
-    """Get TOTP code from a secret record."""
+    """Get TOTP code from a secret Record UID."""
     ctx.obj["secret"].get_totp_code(
         uid=uid
     )

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -434,7 +434,15 @@ class Secret:
         if not totp_uri:
             raise KsmCliException("Cannot find TOTP field for UID {}.".format(uid))
 
-        totp, ttl, period = get_totp_code(totp_uri)
+        try:
+            totp, ttl, period = get_totp_code(totp_uri)
+        except Exception as err:
+            # The UI doesn't appear to valid the secret key, so the user might enter a bad secret key.
+            if str(err) == 'Incorrect padding':
+                raise KsmCliException("The secret key of the two factor code field appears to be invalid."
+                                      " Please make sure the record is correct.")
+            raise err
+
         self.cli.output(totp)
 
     def get_via_notation(self, notation):

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -22,7 +22,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="0.0.33",
+    version="0.0.34",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Added a test to get the 6 digit code.
* Since only 1 param for command changed it to an argument (Lurey/Zane forecasting)
* Added a nicer exception when the secret key is "invalid" else it would say Incorrect padding
* Bump version for release