### PR TITLE
Fix conditions to use object variables

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -95,9 +95,9 @@ class SecretsManager:
 
         # If the server or client key are set in the args, make sure they makes it's way into the config. They
         # will override what is already in the config if they exist.
-        if token is not None:
+        if self.token is not None:
             config.set(ConfigKeys.KEY_CLIENT_KEY, self.token)
-        if hostname is not None:
+        if self.hostname is not None:
             config.set(ConfigKeys.KEY_HOSTNAME, self.hostname)
 
         # Make sure our public key id is set and pointing an existing key.

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-core",
-    version="16.1.7",
+    version="16.1.8",
     description="Keeper Secrets Manager for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Prior was using the variables passed into the method. Since hostname
is not passed in, hostname is always None, which caused the hostname
not to be added to the config.