### PR TITLE
Update the kv parse for update, allow raw JSON to set

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -29,13 +29,13 @@ import difflib
 import typing as t
 from update_checker import UpdateChecker
 
+
 # NOTE: For the CLI, all groups and command are lowercase. All arguments are lower case, so you cannot use
 # -n and -N for an arg flag. If you add a command, you need to add it to the list of known commands so we can
 # do a best match.
 
 
 class AliasedGroup(HelpColorsGroup):
-
     known_commands = [
         "config",
         "color",
@@ -172,7 +172,6 @@ def base_command_help(f):
 @click.pass_context
 @base_command_help
 def cli(ctx, ini_file, profile_name, output, color):
-
     """Keeper Secrets Manager CLI
     """
     ctx.obj = {
@@ -302,6 +301,7 @@ profile_command.add_command(profile_active_command)
 profile_command.add_command(profile_export_command)
 profile_command.add_command(profile_import_command)
 
+
 # SECRET GROUP
 
 
@@ -408,16 +408,21 @@ def secret_notation_command(ctx, text):
     cls=HelpColorsCommand,
     help_options_color='blue'
 )
-@click.option('--uid', '-u', required=True, type=str)
-@click.option('--field', type=str, multiple=True)
-@click.option('--custom-field', type=str, multiple=True)
+@click.option('--uid', '-u', required=True, type=str, help="Unique identifier of record.")
+@click.option('--field', type=str, multiple=True, help="Update value in field section of vault")
+@click.option('--custom-field', type=str, multiple=True, help="Update value in custom field section of vault")
+@click.option('--field-json', type=str, multiple=True, help="Update value in field section of vault using JSON")
+@click.option('--custom-field-json', type=str, multiple=True,
+              help="Update value in custom field section of vault using JSON")
 @click.pass_context
-def secret_update_command(ctx, uid, field, custom_field):
+def secret_update_command(ctx, uid, field, custom_field, field_json, custom_field_json):
     """Update an existing record."""
     ctx.obj["secret"].update(
         uid=uid,
         fields=field,
         custom_fields=custom_field,
+        fields_json=field_json,
+        custom_fields_json=custom_field_json
     )
 
 

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.0",
+    version="1.0.1",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The prior problem was on how to split text into key/value pairs since
a key or label could contain a = character. Can't just split on the
equal character.

Since we are doing an update, we know the labels/types of the fields. So
all text should start with a known field/custom field, a =, and then a
value.  Changed to match the text to a field label/type and the equal character.
Anything after that is a value.

Now the user doesn't have to escape = chracters, and also escape the escape character.

Next added some CLI options to pass in JSON. Using the options will flag to take the value,
decode it, and then store the array or dictionary as the value.

Updated unit tests.

Bumped version.

Little PEP8 clean up.