### PR TITLE
Overload for Java and non-strict json parsing

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.*
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "16.2.2"
+version = "16.2.3"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -163,6 +163,7 @@ data class KeeperFile(
     val thumbnailUrl: String?
 )
 
+@JvmOverloads
 fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: String? = null) {
     val tokenParts = oneTimeToken.split(':')
     val host: String


### PR DESCRIPTION
1. Added ability to overload `initializeStorage` in Java to avoid passing `hostName` as a property.

2. Non-strict JSON parsing if backend will return JSON object that is not properly built or has new fields that don't exist in the SDK yet.

3. Bumping Java SDK version to v16.2.3