### PR TITLE
Version file

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -143,10 +143,7 @@ def get_versions():
         ksm_bin_path = os.path.dirname(ksm_bin_path)
     print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
-    print(os.listdir(ksm_bin_path))
-    ksm_bin_path = ksm_bin_path.replace("\\", "//")
-    print("Changed", ksm_bin_path)
-    print(os.listdir(ksm_bin_path))
+    version_path = version_path.replace("\\", "//")
     print("Version Path", version_path)
     if os.path.isfile(version_path) is True:
         with open(version_path, "r") as fh:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -143,6 +143,10 @@ def get_versions():
         ksm_bin_path = os.path.dirname(ksm_bin_path)
     print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
+    print(os.listdir(ksm_bin_path))
+    ksm_bin_path = ksm_bin_path.replace("\\", "//")
+    print("Changed", ksm_bin_path)
+    print(os.listdir(ksm_bin_path))
     print("Version Path", version_path)
     if os.path.isfile(version_path) is True:
         with open(version_path, "r") as fh:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -138,9 +138,12 @@ def get_versions():
     # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
     # directory.
     ksm_bin_path = os.path.dirname(__file__)
+    print("Pre clean up", ksm_bin_path)
     if ksm_bin_path.endswith("keeper_secrets_manager_cli") is True:
         ksm_bin_path = os.path.dirname(ksm_bin_path)
+    print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
+    print("Version Path", version_path)
     if os.path.exists(version_path) is True:
         with open(version_path, "r") as fh:
             lines = fh.readlines()

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -143,12 +143,15 @@ def get_versions():
         ksm_bin_path = os.path.dirname(ksm_bin_path)
     print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
-    version_path = version_path.replace("\\", "//")
+    # version_path = version_path.replace("\\", "//")
     print("Version Path", version_path)
     if os.path.isfile(version_path) is True:
+        print("Found it")
         with open(version_path, "r") as fh:
             lines = fh.readlines()
+            print("Lines", lines)
             for line in lines:
+                print("Line", line)
                 parts = line.split("==")
                 if parts[0] in versions:
                     versions[parts[0]] = parts[1].replace('\n', '').replace('\r', '')

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -131,11 +131,24 @@ def get_versions():
         "keeper-secrets-manager-core": "Unknown",
         "keeper-secrets-manager-cli": "Unknown"
     }
-    for module in versions:
-        try:
-            versions[module] = importlib_metadata.version(module)
-        except importlib_metadata.PackageNotFoundError:
-            pass
+
+    # Inside of binaries, it's hard to get versions so we create a versions.txt file. If that is it,
+    # get the version from the text file.
+    if os.path.exists("versions.txt") is True:
+        with open("versions.txt", "r") as fh:
+            lines = fh.readlines()
+            for line in lines:
+                parts = line.split("==")
+                if parts[0] in versions:
+                    versions[parts[0]] = parts[1]
+            fh.close()
+    # Else detect the versions
+    else:
+        for module in versions:
+            try:
+                versions[module] = importlib_metadata.version(module)
+            except importlib_metadata.PackageNotFoundError:
+                pass
 
     return versions
 

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -132,12 +132,12 @@ def get_versions():
         "keeper-secrets-manager-cli": "Unknown"
     }
 
-    # Inside of binaries, it's hard to get versions so we create a versions.txt file. If that is it,
-    # get the version from the text file.
+    # Inside of the binaries, it's hard to get versions # so we create a versions.txt file in the build.
+    # If the versions.txt file exists, read the versions from that file.
 
-    # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
-    # directory.
     ksm_bin_path = os.path.dirname(__file__)
+    # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
+    # directory. There is no keeper_secrets_manager_cli directory.
     if ksm_bin_path.endswith("keeper_secrets_manager_cli") is True:
         ksm_bin_path = os.path.dirname(ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
@@ -145,11 +145,13 @@ def get_versions():
         with open(version_path, "r") as fh:
             lines = fh.readlines()
             for line in lines:
+                # The versions file follows the requirements.txt file format.
                 parts = line.split("==")
                 if parts[0] in versions:
+                    # Remove the line feed at the end. Just makes the "version" command output have extra lines.
                     versions[parts[0]] = parts[1].replace('\n', '').replace('\r', '')
             fh.close()
-    # Else detect the versions
+    # Else detect the versions from the site-packages
     else:
         for module in versions:
             try:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -144,7 +144,7 @@ def get_versions():
     print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
     print("Version Path", version_path)
-    if os.path.exists(version_path) is True:
+    if os.path.isfile(version_path) is True:
         with open(version_path, "r") as fh:
             lines = fh.readlines()
             for line in lines:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -136,8 +136,10 @@ def get_versions():
     # get the version from the text file.
 
     ksm_bin_path = os.path.dirname(__file__)
-    if os.path.exists(os.path.join(ksm_bin_path, "versions.txt")) is True:
-        with open("versions.txt", "r") as fh:
+    version_path = os.path.join(ksm_bin_path, "versions.txt")
+    print("Checking {}/versions.txt".format(ksm_bin_path))
+    if os.path.exists(version_path) is True:
+        with open(version_path, "r") as fh:
             lines = fh.readlines()
             for line in lines:
                 parts = line.split("==")

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -146,7 +146,7 @@ def get_versions():
             for line in lines:
                 parts = line.split("==")
                 if parts[0] in versions:
-                    versions[parts[0]] = parts[1]
+                    versions[parts[0]] = parts[1].replace('\n', '').replace('\r', '')
             fh.close()
     # Else detect the versions
     else:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -134,7 +134,9 @@ def get_versions():
 
     # Inside of binaries, it's hard to get versions so we create a versions.txt file. If that is it,
     # get the version from the text file.
-    if os.path.exists("versions.txt") is True:
+
+    ksm_bin_path = os.path.dirname(__file__)
+    if os.path.exists(os.path.join(ksm_bin_path, "versions.txt")) is True:
         with open("versions.txt", "r") as fh:
             lines = fh.readlines()
             for line in lines:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -139,6 +139,7 @@ def get_versions():
     # /usr/local/ksm/bin/keeper_secrets_manager_cli as the directory. However the versions.txt
     # will be in the bin directory, so we need the parent of keeper_secrets_manager_cli directory.
     ksm_bin_path = os.path.dirname(os.path.dirname(__file__))
+    print("KSM BIN PATH", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
     if os.path.exists(version_path) is True:
         with open(version_path, "r") as fh:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -135,11 +135,11 @@ def get_versions():
     # Inside of binaries, it's hard to get versions so we create a versions.txt file. If that is it,
     # get the version from the text file.
 
-    # We want the parent directory. In the binary, the os.path.dirname(__file__) will return
-    # /usr/local/ksm/bin/keeper_secrets_manager_cli as the directory. However the versions.txt
-    # will be in the bin directory, so we need the parent of keeper_secrets_manager_cli directory.
-    ksm_bin_path = os.path.dirname(os.path.dirname(__file__))
-    print("KSM BIN PATH", ksm_bin_path)
+    # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
+    # directory.
+    ksm_bin_path = os.path.dirname(__file__)
+    if ksm_bin_path.endswith("keeper_secrets_manager_cli") is True:
+        ksm_bin_path = os.path.dirname(ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
     if os.path.exists(version_path) is True:
         with open(version_path, "r") as fh:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -135,9 +135,11 @@ def get_versions():
     # Inside of binaries, it's hard to get versions so we create a versions.txt file. If that is it,
     # get the version from the text file.
 
-    ksm_bin_path = os.path.dirname(__file__)
+    # We want the parent directory. In the binary, the os.path.dirname(__file__) will return
+    # /usr/local/ksm/bin/keeper_secrets_manager_cli as the directory. However the versions.txt
+    # will be in the bin directory, so we need the parent of keeper_secrets_manager_cli directory.
+    ksm_bin_path = os.path.dirname(os.path.dirname(__file__))
     version_path = os.path.join(ksm_bin_path, "versions.txt")
-    print("Checking {}/versions.txt".format(ksm_bin_path))
     if os.path.exists(version_path) is True:
         with open(version_path, "r") as fh:
             lines = fh.readlines()

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -138,20 +138,13 @@ def get_versions():
     # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
     # directory.
     ksm_bin_path = os.path.dirname(__file__)
-    print("Pre clean up", ksm_bin_path)
     if ksm_bin_path.endswith("keeper_secrets_manager_cli") is True:
         ksm_bin_path = os.path.dirname(ksm_bin_path)
-    print("Post clean up", ksm_bin_path)
     version_path = os.path.join(ksm_bin_path, "versions.txt")
-    # version_path = version_path.replace("\\", "//")
-    print("Version Path", version_path)
     if os.path.isfile(version_path) is True:
-        print("Found it")
         with open(version_path, "r") as fh:
             lines = fh.readlines()
-            print("Lines", lines)
             for line in lines:
-                print("Line", line)
                 parts = line.split("==")
                 if parts[0] in versions:
                     versions[parts[0]] = parts[1].replace('\n', '').replace('\r', '')

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.3",
+    version="1.0.4",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The binaries were unable to detect the versions of the CLI and SDK. The binaries build now creates a versions.txt file and added it to the package. The CLI checks if the file exists and will read that for the versions instead of detecting. This is only used in the binaries.