### PR TITLE
Java SDK: Privacy screen and create record method overload

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.*
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "16.2.4"
+version = "16.2.5"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -99,13 +99,14 @@ data class FileRef @JvmOverloads constructor(
 data class OneTimeCode @JvmOverloads constructor(
     override var label: String? = null,
     var required: Boolean? = null,
+    var privacyScreen: Boolean? = null,
     val value: MutableList<String>) : KeeperRecordField(){
 
     /**
      * Constructor with the single value to eliminate the complexity of the passing List as a value
      * @param value TOTP URL. Ex. otpauth://totp/asdfsadf:asdf@asdf.com?secret=2355666655444334&issuer=asdfsadf&algorithm=SHA256&digits=6&period=30
      */
-    constructor(value: String): this(null, null, mutableListOf(value))
+    constructor(value: String): this(null, null, null, mutableListOf(value))
 }
 
 @Serializable
@@ -113,12 +114,13 @@ data class OneTimeCode @JvmOverloads constructor(
 data class OneTimePassword @JvmOverloads constructor(
     override var label: String? = null,
     var required: Boolean? = null,
+    var privacyScreen: Boolean? = null,
     val value: MutableList<String>) : KeeperRecordField(){
 
     /**
      * Constructor with the single value to eliminate the complexity of the passing List as a value
      */
-    constructor(value: String): this(null, null, mutableListOf(value))
+    constructor(value: String): this(null, null, null, mutableListOf(value))
 }
 
 @Serializable
@@ -273,12 +275,13 @@ data class AddressRef @JvmOverloads constructor(
 data class PinCode @JvmOverloads constructor(
     override var label: String? = null,
     var required: Boolean? = null,
+    var privacyScreen: Boolean? = null,
     val value: MutableList<String>) : KeeperRecordField(){
 
     /**
      * Constructor with the single value to eliminate the complexity of the passing List as a value
      */
-    constructor(value: String): this(null, null, mutableListOf(value))
+    constructor(value: String): this(null, null, null, mutableListOf(value))
 }
 
 @Serializable
@@ -324,12 +327,13 @@ data class Phones @JvmOverloads constructor(
 data class HiddenField @JvmOverloads constructor(
     override val label: String? = null,
     var required: Boolean? = null,
+    var privacyScreen: Boolean? = null,
     val value: List<String>) : KeeperRecordField(){
 
     /**
      * Constructor with the single value to eliminate the complexity of the passing List as a value
      */
-    constructor(value: String): this(null, null, mutableListOf(value))
+    constructor(value: String): this(null, null, null, mutableListOf(value))
 }
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -246,7 +246,9 @@ fun updateSecret(options: SecretsManagerOptions, record: KeeperRecord) {
 }
 
 @ExperimentalSerializationApi
-fun createSecret(options: SecretsManagerOptions, folderUid: String, recordData: KeeperRecordData, secrets: KeeperSecrets): String {
+@JvmOverloads
+fun createSecret(options: SecretsManagerOptions, folderUid: String, recordData: KeeperRecordData, secrets: KeeperSecrets = getSecrets(options)): String {
+
     val payload = prepareCreatePayload(options.storage, folderUid, recordData, secrets)
     postQuery(options, "create_secret", payload)
     return payload.recordUid


### PR DESCRIPTION
1. Overloaded create record to get secrets if not available

2. Adding `privacyScreen` to OneTimeCode, OneTimePassword, PinCode, and HiddenField

3. Bumped Java SDK version to 16.2.5