### PR TITLE
.NET: Optionals `secrets` parameter in record create

### DIFF
--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -5,9 +5,9 @@
         <LangVersion>9</LangVersion>
         <Company>Keeper Security Inc.</Company>
         <Product>SecretsManager .Net</Product>
-        <AssemblyVersion>16.2.0</AssemblyVersion>
-        <FileVersion>16.2.0</FileVersion>
-        <PackageVersion>16.2.0</PackageVersion>
+        <AssemblyVersion>16.2.1</AssemblyVersion>
+        <FileVersion>16.2.1</FileVersion>
+        <PackageVersion>16.2.1</PackageVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Keeper.SecretsManager</PackageId>
         <Authors>Sergey Aldoukhov</Authors>
@@ -16,7 +16,7 @@
         <RepositoryUrl>https://github.com/Keeper-Security/secrets-manager</RepositoryUrl>
         <RepositoryType>GitHub</RepositoryType>
         <PackageTags>keeper secrets manager passwords</PackageTags>
-        <Copyright>© 2021 Keeper Security, Inc.</Copyright>
+        <Copyright>© 2022 Keeper Security, Inc.</Copyright>
         <License>https://raw.githubusercontent.com/Keeper-Security/secrets-manager/master/LICENSE?token=AACNMRVMD5L3PYT3C5MTNF3BEAFZY</License>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -373,8 +373,10 @@ namespace SecretsManager
             await PostQuery(options, "update_secret", payload);
         }
 
-        public static async Task<string> CreateSecret(SecretsManagerOptions options, string folderUid, KeeperRecordData recordData, KeeperSecrets secrets)
+        public static async Task<string> CreateSecret(SecretsManagerOptions options, string folderUid, KeeperRecordData recordData, KeeperSecrets secrets = null)
         {
+            secrets ??= await GetSecrets(options);
+            
             var payload = PrepareCreatePayload(options.Storage, folderUid, recordData, secrets);
             await PostQuery(options, "create_secret", payload);
             return payload.recordUid;


### PR DESCRIPTION
.NET SDK: Making Secrets to be options on record create. Bumping version to 16.2.1