### PR TITLE
Removed @click.pass_context

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -680,7 +680,6 @@ def version_command(ctx):
     cls=HelpColorsCommand,
     help_options_color='blue'
 )
-@click.pass_context
 def shell_command():
     """Run KSM in a shell"""
 

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.5",
+    version="1.0.6",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The context was not being used and was removed however it was
still being passed to the command. This cause an error when
starting ksm in shell mode.

ksm had a problem: shell_command() takes 0 positional arguments but 1 was given

Remove the arguments being passed.