### PR TITLE
Add password generator

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__init__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__init__.py
@@ -60,14 +60,18 @@ class KeeperCli:
             common_profile = self.profile.get_profile_config(Profile.config_profile)
 
             # Get the active configuration
+
+            # By default, don't use the cache.
             if self.use_cache is None:
-                self.use_cache = bool(strtobool(common_profile.get(Profile.cache_key, str(True))))
+                self.use_cache = bool(strtobool(common_profile.get(Profile.cache_key, str(False))))
 
             self._client = self.get_client(
                 config=config_storage,
                 log_level=self.log_level,
                 custom_post_function=KSMCache.caching_post_function if self.use_cache is True else None
             )
+
+            # By default, use colors.
             if self.use_color is None:
                 self.use_color = bool(strtobool(common_profile.get(Profile.color_key, str(True))))
         else:

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -16,7 +16,7 @@ import sys
 from colorama import Fore, Style
 from keeper_secrets_manager_cli.exception import KsmCliException
 from keeper_secrets_manager_core.core import SecretsManager
-from keeper_secrets_manager_core.utils import get_totp_code
+from keeper_secrets_manager_core.utils import get_totp_code, generate_password as sdk_generate_password
 from .table import Table, ColumnAlign
 import uuid
 
@@ -442,12 +442,12 @@ class Secret:
         totp_uri = None
         try:
             totp_uri = record[0].get_standard_field_value("oneTimeCode", True)
-        except Exception:
+        except (Exception,):
             pass
         if not totp_uri:
             try:
                 totp_uri = record[0].get_custom_field_value("oneTimeCode", True)
-            except Exception:
+            except (Exception,):
                 pass
 
         if not totp_uri:
@@ -550,3 +550,15 @@ class Secret:
             self.cli.client.save(record[0])
         except Exception as err:
             raise KsmCliException("Could not save record: {}".format(err))
+
+    def generate_password(self, length, lowercase, uppercase, digits, special_characters):
+
+        new_password = sdk_generate_password(
+            length=length,
+            lowercase=lowercase,
+            uppercase=uppercase,
+            digits=digits,
+            special_characters=special_characters
+        )
+
+        return self.cli.output(new_password)

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.6",
+    version="1.0.7",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_secrets_manager_cli/tests/secret_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/secret_test.py
@@ -743,6 +743,65 @@ class SecretTest(unittest.TestCase):
                 self.assertRegex(code, r'^\d{6}$', 'code is not all digits')
                 tf.close()
 
+    def test_generate_password(self):
+
+        """Generate a password
+        """
+
+        #  Default values
+        with tempfile.NamedTemporaryFile() as tf:
+            runner = CliRunner()
+            result = runner.invoke(cli, ['-o', tf.name, 'secret', 'password'],
+                                   catch_exceptions=False)
+            self.assertEqual(0, result.exit_code, "the exit code was not 0")
+            tf.seek(0)
+            password = tf.readline().decode()
+            self.assertEqual(len(password), 64, "Default password is not 64 characters.")
+
+            tf.close()
+
+        #  Set the length to 32
+        with tempfile.NamedTemporaryFile() as tf:
+            runner = CliRunner()
+            result = runner.invoke(cli, ['-o', tf.name, 'secret', 'password', '--length', '32'],
+                                   catch_exceptions=False)
+            self.assertEqual(0, result.exit_code, "the exit code was not 0")
+            tf.seek(0)
+            password = tf.readline().decode()
+            self.assertEqual(len(password), 32, "Default password is not 64 characters.")
+
+            tf.close()
+
+        #  Set character groups
+        with tempfile.NamedTemporaryFile() as tf:
+            runner = CliRunner()
+            result = runner.invoke(cli, ['-o', tf.name, 'secret', 'password',
+                                         '-lc', '4',
+                                         '-uc', '5',
+                                         '-d', '6',
+                                         '-sc', '7'],
+                                   catch_exceptions=False)
+            self.assertEqual(0, result.exit_code, "the exit code was not 0")
+            tf.seek(0)
+            password = tf.readline().decode()
+            self.assertEqual(len(password), 22, "Default password is not 64 characters.")
+
+            tf.close()
+
+        #  Bad
+        with tempfile.NamedTemporaryFile() as tf:
+            runner = CliRunner()
+            result = runner.invoke(cli, ['-o', tf.name, 'secret', 'password',
+                                         '-l', '100',
+                                         '-lc', '4',
+                                         '-uc', '5',
+                                         '-d', '6',
+                                         '-sc', '7'],
+                                   catch_exceptions=False)
+            self.assertEqual(1, result.exit_code, "the exit code was not 1")
+            print(result.stdout)
+            tf.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
$ ksm secret password

Along with these changes. Fix problem where the cache is enabled by default.

Fixed "too broad exception" Python PEP warnings in parts of the code that
don't do anything with the exception. This gets around this warning.

    except (Exception,):
        pass

Also version bump