### PR TITLE
KSM CLI - Expand hostname abbreviations in JSON profile export

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/export.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/export.py
@@ -4,6 +4,7 @@ import base64
 import json
 
 from keeper_secrets_manager_core.utils import base64_to_bytes
+from keeper_secrets_manager_core.keeper_globals import keeper_servers
 
 
 class Export:
@@ -59,7 +60,7 @@ class Export:
             "clientId": {"key": "clientId", "isBase64": True},
             "privateKey": {"key": "privateKey", "isBase64": True},
             "appKey": {"key": "appKey", "isBase64": True},
-            "hostname": {"key": "hostname", "isBase64": False},
+            "hostname": {"key": "hostname", "isBase64": False, "transformMap": keeper_servers},
             "serverPublicKeyId": {"key": "serverPublicKeyId", "isBase64": False}
         }
 
@@ -72,5 +73,8 @@ class Export:
                     # Encode a non-url safe base64
                     config_dict[info["key"]] = base64.b64encode(value_bytes).decode()
                 else:
-                    config_dict[info["key"]] = self.config[key]
+                    if "transformMap" in info:
+                        config_dict[info["key"]] = info["transformMap"].get(self.config[key], self.config[key])
+                    else:
+                        config_dict[info["key"]] = self.config[key]
         return json.dumps(config_dict, indent=4)

--- a/integration/keeper_secrets_manager_cli/tests/init_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/init_test.py
@@ -75,7 +75,7 @@ class InitTest(unittest.TestCase):
                     self.assertIsNotNone(config.get("privateKey"), "private key is missing")
                     self.assertIsNotNone(config.get("appKey"), "app key is missing")
                     self.assertIsNotNone(config.get("hostname"), "hostname is missing")
-                    self.assertEqual("US", config.get("hostname"), "hostname is not correct")
+                    self.assertEqual("keepersecurity.com", config.get("hostname"), "hostname is not correct")
                     self.assertEqual(mock_config.get("appKey"), config.get("appKey"),
                                      "app key is not correct")
 
@@ -97,7 +97,7 @@ class InitTest(unittest.TestCase):
                     self.assertIsNotNone(config.get("privateKey"), "private key is missing")
                     self.assertIsNotNone(config.get("appKey"), "app key is missing")
                     self.assertIsNotNone(config.get("hostname"), "hostname is missing")
-                    self.assertEqual("US", config.get("hostname"), "hostname is not correct")
+                    self.assertEqual("keepersecurity.com", config.get("hostname"), "hostname is not correct")
                     self.assertEqual(mock_config.get("appKey"), config.get("appKey"),
                                      "app key is not correct")
 
@@ -169,6 +169,6 @@ class InitTest(unittest.TestCase):
                     self.assertIsNotNone(config.get("privateKey"), "private key is missing")
                     self.assertIsNotNone(config.get("appKey"), "app key is missing")
                     self.assertIsNotNone(config.get("hostname"), "hostname is missing")
-                    self.assertEqual("US", config.get("hostname"), "hostname is not correct")
+                    self.assertEqual("keepersecurity.com", config.get("hostname"), "hostname is not correct")
                     self.assertEqual(mock_config.get("appKey"), config.get("appKey"),
                                      "app key is not correct")


### PR DESCRIPTION
In working with the KSM SDKs, I encountered errors stating that the hostname could not be resolved by the system's DNS. Upon further inspection of the errors produced by the SDK, it appears that the request URL is built by pulling whatever value is included for the hostname field in the config file. This appeared consistent across the SDK for multiple languages.

If the config file was created/initialized using the SDK, the hostname is fully expanded to a domain name in the config file. However, if the config file was created with a JSON export from KSM CLI, the hostname will be kept in the two-letter abbreviated form if it uses that format in the keeper.ini file used by KSM CLI.

Since KSM CLI does not output JSON files that conform to what the SDKs are expecting, I made a small addition that decodes the two-letter abbreviation to the full hostname when exporting since the primary purpose of exporting the config file in JSON is for consumption by the SDK.