### PR TITLE
TOTP URL to Code refactor and JVM Naming for CryptoUtils and RecordData

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.*
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "16.3.0"
+version = "16.3.1"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -1,3 +1,4 @@
+@file:JvmName("RecordData")
 @file:Suppress("unused")
 
 package com.keepersecurity.secretsManager.core


### PR DESCRIPTION
- Moving `getTotpCode` inside the `TotpCode` class and naming it `uriToTotpCode`
- Specifying JVM Name for `CryptoUtils.kt` file to name it `CryptoUtils` as opposed to `CryptoUtilsKt`
- Specifying JVM Name for `RecordData.kt` file to name it `RecordData` as opposed to `RecordDataKt`
- Bumping Java SDK version to 16.3.1