### PR TITLE
Fix cli app helper

### DIFF
--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -1,7 +1,5 @@
 from .common import load_file
 from importlib import import_module
-import sys
-import inspect
 
 
 class Record:
@@ -25,7 +23,6 @@ class Record:
         self.version = version
 
         try:
-            print(">>>>>>>>", inspect.getfile(self.__class__))
             self.record_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record")
             self.parser_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.parser")
             self.record_type_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record_type")

--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -1,6 +1,7 @@
 from .common import load_file
 from importlib import import_module
 import sys
+import inspect
 
 
 class Record:
@@ -24,7 +25,7 @@ class Record:
         self.version = version
 
         try:
-            print(">>>>>>>>", self.__file__)
+            print(">>>>>>>>", inspect.getfile(self.__class__))
             self.record_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record")
             self.parser_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.parser")
             self.record_type_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record_type")

--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -1,5 +1,6 @@
 from .common import load_file
 from importlib import import_module
+import sys
 
 
 class Record:
@@ -23,6 +24,7 @@ class Record:
         self.version = version
 
         try:
+            print("Module Paths", "\n".join(sys.path))
             self.record_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record")
             self.parser_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.parser")
             self.record_type_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record_type")

--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -25,6 +25,7 @@ class Record:
 
         try:
             print("Module Paths", "\n".join(sys.path))
+            print("Modules Install", sys.modules)
             self.record_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record")
             self.parser_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.parser")
             self.record_type_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record_type")

--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -24,8 +24,7 @@ class Record:
         self.version = version
 
         try:
-            print("Module Paths", "\n".join(sys.path))
-            print("Modules Install", sys.modules)
+            print(">>>>>>>>", self.__file__)
             self.record_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record")
             self.parser_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.parser")
             self.record_type_mod = import_module(f"keeper_secrets_manager_helper.{self.version}.record_type")

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
@@ -129,7 +129,11 @@ def load_record_type_from_data(record_types):
 
 # We are going to make some classes based off a YAML file.
 default_record_type_file = "default_record_types.yml"
-module_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+if os.path.exists(f"v3_{default_record_type_file}") is True:
+    schema_file = f"v3_{default_record_type_file}"
+else:
+    schema_file = os.path.abspath(inspect.getfile(inspect.currentframe()))
+module_dir = os.path.dirname(schema_file)
 load_record_type_from_file(os.path.join(module_dir, default_record_type_file))
 
 

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
@@ -130,11 +130,13 @@ def load_record_type_from_data(record_types):
 default_record_type_file = "default_record_types.yml"
 print("DIR >>>>>>>>")
 print(os.listdir())
+print("IM IN HERE", os.path.dirname(__file__))
+this_dir = os.path.abspath(inspect.getfile(inspect.currentframe()))
+print("SCHEMA BLAH", this_dir)
 if os.path.exists(f"v3_{default_record_type_file}") is True:
-    schema_file = f"v3_{default_record_type_file}"
-else:
-    schema_file = os.path.abspath(inspect.getfile(inspect.currentframe()))
-module_dir = os.path.dirname(schema_file)
+    this_dir = f"v3_{default_record_type_file}"
+
+module_dir = os.path.dirname(this_dir)
 load_record_type_from_file(os.path.join(module_dir, default_record_type_file))
 
 

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
@@ -2,7 +2,6 @@ from keeper_secrets_manager_helper.v3.field_type import FieldType, get_field_typ
 from keeper_secrets_manager_helper.v3.enum import BaseEnum
 from keeper_secrets_manager_helper.common import load_file
 import os
-import inspect
 import yaml
 import json
 import re
@@ -128,16 +127,31 @@ def load_record_type_from_data(record_types):
 
 
 default_record_type_file = "default_record_types.yml"
-print("DIR >>>>>>>>")
-print(os.listdir())
-print("IM IN HERE", os.path.dirname(__file__))
-this_dir = os.path.abspath(inspect.getfile(inspect.currentframe()))
-print("SCHEMA BLAH", this_dir)
-if os.path.exists(f"v3_{default_record_type_file}") is True:
-    this_dir = f"v3_{default_record_type_file}"
 
-module_dir = os.path.dirname(this_dir)
-load_record_type_from_file(os.path.join(module_dir, default_record_type_file))
+# Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
+# directory. There is no keeper_secrets_manager_cli directory.
+
+# This is the module installed check. The default_record_type_file will be in that
+# directory
+current_directory = os.path.dirname(__file__)
+schema_dir = None
+if os.path.exists(os.path.join(current_directory, default_record_type_file)) is True:
+    schema_dir = current_directory
+
+# Else this is the binary where the schema has a different name and is in the root of
+# the app directory.
+else:
+    default_record_type_file = f"v3_{default_record_type_file}"
+    # Find the default_record_type_file in the path. Quit if reach the root fs
+    while current_directory != "/":
+        current_directory = os.path.dirname(current_directory)
+        if os.path.exists(os.path.join(current_directory, default_record_type_file)) is True:
+            schema_dir = current_directory
+            break
+    if schema_dir is None:
+        raise FileNotFoundError(f"Cannot find {default_record_type_file} in the binary app.")
+
+load_record_type_from_file(os.path.join(schema_dir, default_record_type_file))
 
 
 def get_class_by_type(class_name):

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
@@ -127,8 +127,9 @@ def load_record_type_from_data(record_types):
         class_map_by_type[item.get("name")] = record_type_class
 
 
-# We are going to make some classes based off a YAML file.
 default_record_type_file = "default_record_types.yml"
+print("DIR >>>>>>>>")
+print(os.listdir())
 if os.path.exists(f"v3_{default_record_type_file}") is True:
     schema_file = f"v3_{default_record_type_file}"
 else:

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record_type.py
@@ -131,19 +131,23 @@ default_record_type_file = "default_record_types.yml"
 # Get the directory of the executable file. If last directory is keeper_secrets_manager_cli, get the parent
 # directory. There is no keeper_secrets_manager_cli directory.
 
-# This is the module installed check. The default_record_type_file will be in that
-# directory
+# This is the Pypi module installed check. The default_record_type_file.yml will be in this directory along
+# the other V3 modules.
 current_directory = os.path.dirname(__file__)
 schema_dir = None
 if os.path.exists(os.path.join(current_directory, default_record_type_file)) is True:
     schema_dir = current_directory
 
-# Else this is the binary where the schema has a different name and is in the root of
-# the app directory.
+# Else this is the binary install. For PyInstaller, we move the YAML file to the rood
+# directory of the application. We don't want to hardcode the directory, so walk backwards
+# from here looking for the file. If we get to the root directory the file wasn't found.
 else:
+    # Change the filename to include the version
     default_record_type_file = f"v3_{default_record_type_file}"
-    # Find the default_record_type_file in the path. Quit if reach the root fs
-    while current_directory != "/":
+
+    # Find the default_record_type_file in the path. Quit if reach the root directory.
+    root_dir = os.path.abspath(os.sep)
+    while current_directory != root_dir:
         current_directory = os.path.dirname(current_directory)
         if os.path.exists(os.path.join(current_directory, default_record_type_file)) is True:
             schema_dir = current_directory

--- a/sdk/python/helper/setup.py
+++ b/sdk/python/helper/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-helper",
-    version="1.0.1",
+    version="1.0.2",
     description="Keeper Secrets Manager SDK helper for managing records.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Since the CLI binaries bundle modules differently that a normal pip3 install, this find help find the record schema file. PyInstaller won't automatically install the files, so they manually need to be defined and placing the file in the root of the package makes it's easier to find.