### PR TITLE
Fixed digits & periods default value

### DIFF
--- a/sdk/javascript/packages/core/src/utils.ts
+++ b/sdk/javascript/packages/core/src/utils.ts
@@ -59,11 +59,11 @@ export const getTotpCode = async (url: string, unixTimeSeconds: number = 0) : Pr
         algorithm = 'SHA1'; // default algorithm
 
     const strDigits: string = (totpUrl.searchParams.get('digits') || '').trim();
-    let digits: number = (isNaN(+strDigits) ? 6 : parseInt(strDigits));
+    let digits: number = ((isNaN(+strDigits) || !Boolean(strDigits)) ? 6 : parseInt(strPeriod));
     digits = digits == 0 ? 6 : digits;
 
     const strPeriod: string = (totpUrl.searchParams.get('period') || '').trim();
-    let period: number = (isNaN(+strPeriod) ? 30 : parseInt(strPeriod));
+    let period: number = ((isNaN(+strPeriod) || !Boolean(strPeriod)) ? 30 : parseInt(strPeriod));
     period = period == 0 ? 30 : period;
 
     const tmBase: number = unixTimeSeconds != 0 ? unixTimeSeconds : Math.floor(Date.now() / 1000);

--- a/sdk/javascript/packages/core/src/utils.ts
+++ b/sdk/javascript/packages/core/src/utils.ts
@@ -59,7 +59,7 @@ export const getTotpCode = async (url: string, unixTimeSeconds: number = 0) : Pr
         algorithm = 'SHA1'; // default algorithm
 
     const strDigits: string = (totpUrl.searchParams.get('digits') || '').trim();
-    let digits: number = ((isNaN(+strDigits) || !Boolean(strDigits)) ? 6 : parseInt(strPeriod));
+    let digits: number = ((isNaN(+strDigits) || !Boolean(strDigits)) ? 6 : parseInt(strDigits));
     digits = digits == 0 ? 6 : digits;
 
     const strPeriod: string = (totpUrl.searchParams.get('period') || '').trim();


### PR DESCRIPTION
Hi! 

Not sure about the open source-ability of this project, but I came across a potential issue when working on how to generate a TOTP on the fly. 
I realized that the URL returned was missing search parameters `digit` & `periods` and calling the method `getTotpCode` throws a NaN when attempting to convert to a BigInt (line 70).

This could be resolved by either appending default search parameters to the URL or by fixing the fallback conditions which is what I've attempted in this PR.
A unary plus casts an empty string to 0 (`+''`) throwing off the condition and parsing a NaN instead.