### PR TITLE
Only set the capture if value is True

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exec.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exec.py
@@ -80,10 +80,11 @@ class Exec:
             # Python 3.6's subprocess.run does not have a capture flag. Instead it used the PIPE with
             # the stderr parameter.
             kwargs = {}
-            if (sys.version_info[0] == 3 and sys.version_info[1] < 7) and capture_output is True:
-                kwargs["stdout"] = subprocess.PIPE
-            else:
-                kwargs["capture_output"] = capture_output
+            if capture_output is True:
+                if sys.version_info[0] == 3 and sys.version_info[1] < 7:
+                    kwargs["stdout"] = subprocess.PIPE
+                else:
+                    kwargs["capture_output"] = capture_output
 
             try:
                 completed = subprocess.run(cmd, **kwargs)

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.8",
+    version="1.0.9",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This only seems to affect the binary. If --capture-output is not set, it throws an error. Assume the value
might be set to None.

    $ ./ksm exec -- bash
    Imported config saved to profile App1 at keeper.ini.
    Error: Cannot execute command: __init__() got an unexpected keyword argument 'capture_output'

However if --capture-output is set it's happy as punch.

    $ KSM_DEBUG=DEBUG ./ksm exec --capture-output -- bash
    Imported config saved to profile App1 at keeper.ini.
    2022-03-25 16:02:14,911 | ksm | DEBUG | Setting public key id to the default: 10

So the change will only set the value if --capture-output is used.