### PR TITLE
Ignore false positive on notation detection

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exec.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exec.py
@@ -15,14 +15,17 @@ import sys
 import subprocess
 from keeper_secrets_manager_cli.exception import KsmCliException
 from keeper_secrets_manager_core.core import SecretsManager
+from keeper_secrets_manager_core.keeper_globals import logger_name
 import re
 import json
+import logging
 
 
 class Exec:
 
     def __init__(self, cli):
         self.cli = cli
+        self.logger = logging.getLogger(logger_name)
 
         # Since the cli is short lived, this won't stick around long.
         self.local_cache = {}
@@ -42,8 +45,16 @@ class Exec:
 
         for env_key, env_value in list(os.environ.items()):
             if env_value.startswith(SecretsManager.notation_prefix) is True:
-                os.environ["_" + env_key] = "_" + env_value
-                os.environ[env_key] = self._get_secret(env_value)
+                try:
+                    os.environ["_" + env_key] = "_" + env_value
+                    os.environ[env_key] = self._get_secret(env_value)
+                except ValueError as err:
+                    # TODO: Change the SDK to throw a different exception when might not be notation.
+                    # If the notation isn't actually notation, skip it, don't raise an exception
+                    if str(err).startswith("Keeper url missing"):
+                        self.logger.info("Possible notation for env key {} was not used.".format(env_key))
+                    else:
+                        raise KsmCliException(str(err))
 
     def inline_replace(self, cmd=None):
 
@@ -54,11 +65,18 @@ class Exec:
         for item in cmd:
             # Due to custom fields, that allow spaces in the label, we have not idea
             # where the notation ends.
-            results = re.search(r'{}://.*?$'.format(SecretsManager.notation_prefix), item)
-            if results is not None:
-                env_value = results.group()
-                item = item.replace(env_value, self._get_secret(env_value))
-            new_cmd.append(item)
+            try:
+                results = re.search(r'{}://.*?$'.format(SecretsManager.notation_prefix), item)
+                if results is not None:
+                    env_value = results.group()
+                    item = item.replace(env_value, self._get_secret(env_value))
+                new_cmd.append(item)
+            except ValueError as err:
+                # If the notation isn't actually notation, skip it, don't raise an exception
+                if str(err).startswith("Keeper url missing"):
+                    self.logger.info("Possible notation for inline param {} was not used.".format(item))
+                else:
+                    raise KsmCliException(str(err))
         cmd = new_cmd
 
         return cmd


### PR DESCRIPTION
If a value of an environment variable starts with "keeper" it assumes it
is notation. If it turned out not to be notation, the code would
throw an error. The prevented any env var to have a value starting
with "keeper.""

If the SDK throws an error about "Keeper url missing information..." the CLI
now will just skip it instead of throwing an error. If it gets a different
exception message, a KsmCliException is thrown instead of the ValueError so
the CLI handles it properly (no stacktrace by default).

The notation detecting could be approved in the SDK, however this will work
for now.

Also added a unit test and clean up from prior tests.