### PR TITLE
Add keeper_create and keeper_info plugins.

### DIFF
--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
@@ -65,7 +65,9 @@ If you omit the `collections` , you will need to use the full plugin name.
 * `keepersecurity.keeper_secrets_manager.keeper_copy` - Copy file, or value, from your vault to a remote server.
 * `keepersecurity.keeper_secrets_manager.keeper_get` - Get a value from your vault.
 * `keepersecurity.keeper_secrets_manager.keeper_set` - Set a value of an existing record in your vault.
+* `keepersecurity.keeper_secrets_manager.keeper_create` - Create a new record in your vault.
 * `keepersecurity.keeper_secrets_manager.keeper_cleanup` - Clean up Keeper related files.
+* `keepersecurity.keeper_secrets_manager.keeper_info` - Display information about plugin, record and field types.
 * `keepersecurity.keeper_secrets_manager.keeper_init` - Init a one-time access token. Returns a configuration.
 
 ## Lookup

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/meta/runtime.yml
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/meta/runtime.yml
@@ -6,3 +6,5 @@ action_groups:
     - keeper_get
     - keeper_set
     - keeper_cleanup
+    - keeper_create
+    - keeper_info

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
@@ -257,6 +257,14 @@ class KeeperAnsible:
 
         return records[0]
 
+    def create_record(self, new_record, shared_folder_uid):
+        try:
+            record_uid = self.client.create_secret(shared_folder_uid, new_record)
+        except Exception as err:
+            raise Exception("Cannot get create record: {}".format(err))
+
+        return record_uid
+
     @staticmethod
     def _gather_secrets(obj):
         """ Walk the secret structure and get values. These should just be str, list, and dict. Warn if the SDK

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__main__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__main__.py
@@ -79,12 +79,10 @@ def _init(args):
     task_args = {
         "keeper_force_config_write": True
     }
-    if args.keeper_token is not None:
-        task_args["keeper_token"] = args.keeper_token
-    if args.keeper_config_file is not None:
-        task_args["keeper_config_file"] = args.keeper_config_file
-    if args.keeper_hostname is not None:
-        task_args["keeper_hostname"] = args.keeper_hostname
+    if args.token is not None:
+        task_args["keeper_token"] = args.token
+    if args.config_file is not None:
+        task_args["keeper_config_file"] = args.config_file
 
     if task_args.get("keeper_token") is not None and ":" in task_args["keeper_token"]:
         task_args["keeper_hostname"], task_args["keeper_token"] = task_args["keeper_token"].split(":")
@@ -100,9 +98,8 @@ def _init(args):
 
 def main(*args):
     parser = argparse.ArgumentParser(description='Ansible config generator')
-    parser.add_argument('--keeper_token', metavar='-t', type=str, required=False, help='client key')
-    parser.add_argument('--keeper_config_file', metavar='--cf', type=str, help='config file name', required=False)
-    parser.add_argument('--keeper_hostname', metavar='--host', type=str, help='host name', required=False)
+    parser.add_argument('--token', type=str, required=False, help='One time access token')
+    parser.add_argument('--config-file', type=str, help='Config file name', required=False)
     parser.add_argument('--config', help='Get configuration information', action='store_true')
     parser.add_argument('--version', help='Get version information', action='store_true')
     parsed_args = parser.parse_args(*args)

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_create.py
@@ -1,0 +1,252 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2021 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from keeper_secrets_manager_ansible import KeeperAnsible
+from keeper_secrets_manager_helper.record_type import RecordType
+from keeper_secrets_manager_helper.record import Record
+from keeper_secrets_manager_helper.field import Field, FieldSectionEnum
+from ansible.utils.display import Display
+import json
+
+display = Display()
+
+DOCUMENTATION = r'''
+---
+module: keeper_create
+
+short_description: Create a new Keeper record
+
+version_added: "1.1.2"
+
+description:
+    - Create a new keeper record in your vault.
+author:
+    - John Walstra
+options:
+  shared_folder_uid:
+    description:
+    - The UID of shared folder in your Keeper application.
+    type: str
+    required: yes
+  record_type:
+    description:
+    - The type if record to create.
+    type: str
+    required: yes
+  generate_password:
+    description:
+    - Generate any blank passwords.
+    type: bool
+    required: no
+  title:
+    description:
+    - The title of the record.
+    type: str
+    required: yes
+  note:
+    description:
+    - Attach a note to the record.
+    type: str
+    required: no
+  fields:
+    description:
+    - The label, or type, of the standard field in record that contains the value.
+    - If the value has a complex value, use notation to get the specific value from the complex value.
+    type: dict
+    required: no
+    suboptions:
+      value:
+         description: Value
+         required: yes 
+      type:
+        description: Field type
+        type: str
+        required: yes
+        choices:
+          - text
+          - url
+          - pinCode
+          - multiline
+          - fileRef
+          - email
+          - phone
+          - name
+          - address
+          - addressRef
+          - accountNumber
+          - login
+          - secret
+          - password
+          - securityQuestion
+          - otp
+          - oneTimeCode
+          - cardRef
+          - paymentCard
+          - date
+          - birthDate
+          - expirationDate
+          - bankAccount
+          - keyPair
+          - host
+          - licenseNumber
+          - note
+  custom_fields:
+    description:
+    - The label, or type, of the user added customer field in record that contains the value.
+    - If the value has a complex value, use notation to get the specific value from the complex value.
+    type: str
+    required: no
+    suboptions:
+      value:
+        description: Value
+        required: yes
+      label:
+        description: Field label
+        type: str
+        required: no        
+      type:
+        description: Field type
+        type: str
+        required: yes
+        choices:
+          - text
+          - url
+          - pinCode
+          - multiline
+          - fileRef
+          - email
+          - phone
+          - name
+          - address
+          - addressRef
+          - accountNumber
+          - login
+          - secret
+          - password
+          - securityQuestion
+          - otp
+          - oneTimeCode
+          - cardRef
+          - paymentCard
+          - date
+          - birthDate
+          - expirationDate
+          - bankAccount
+          - keyPair
+          - host
+          - licenseNumber
+          - note
+'''
+
+EXAMPLES = r'''
+- name: Create a new record
+  keeper_create:
+    share_folder_uid: XXX
+    record_type: login
+    title: My Title
+    note: This record was created from Ansible
+    generate_password: True
+    fields:
+      - type: login
+        value: john.doe@nowhere.com
+      - type: url
+        value: https://nowhere.com/login
+    custom_fields:
+      - type: text
+        label: Custom Field
+        value: This is a value is a custom field.
+  register: my_new_record
+'''
+
+RETURN = r'''
+value:
+  description: The new record uid.
+  returned: success
+  sample: |
+    { "record_uid": "XXXX" }
+'''
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        super(ActionModule, self).run(tmp, task_vars)
+
+        if task_vars is None:
+            task_vars = {}
+
+        keeper = KeeperAnsible(task_vars=task_vars)
+
+        shared_folder_uid = self._task.args.get("shared_folder_uid")
+        if shared_folder_uid is None:
+            raise AnsibleError("The shared_folder_uid is blank. keeper_create requires this value to be set.")
+        record_type = self._task.args.get("record_type")
+        if record_type is None:
+            raise AnsibleError("The record_type is blank. keeper_create requires this value to be set.")
+        if record_type not in RecordType.get_record_type_list():
+            raise AnsibleError("The record_type {} is not a valid record type.".format(record_type))
+        title = self._task.args.get("title")
+        if title is None:
+            raise AnsibleError("The title is blank. keeper_create requires this value to be set.")
+        version = self._task.args.get("version", "v3")
+
+        # If there are custom record type, load them
+        keeper_record_types = task_vars.get("keeper_record_types")
+        if keeper_record_types is not None:
+            if isinstance(keeper_record_types, list) is False:
+                raise AnsibleError("The Keeper record types is not a list.")
+            for keeper_record_type in keeper_record_types:
+                if isinstance(keeper_record_type, str) is True:
+                    keeper_record_type = json.loads(keeper_record_type)
+                    if isinstance(keeper_record_type, dict) is True:
+                        keeper_record_type = [keeper_record_type]
+                RecordType.load_commander_record_types(keeper_record_type)
+
+        fields = []
+
+        try:
+            for field in self._task.args.get("fields", []):
+                fields.append(Field(
+                    field_section=FieldSectionEnum.STANDARD,
+                    type=field.get("type"),
+                    label=field.get("label"),
+                    value=field.get("value")
+                ))
+                keeper.stash_secret_value(str(field.get("value")))
+
+            for field in self._task.args.get("custom_fields", []):
+                fields.append(Field(
+                    field_section=FieldSectionEnum.CUSTOM,
+                    type=field.get("type"),
+                    label=field.get("label"),
+                    value=field.get("value", "text")
+                ))
+                keeper.stash_secret_value(str(field.get("value")))
+
+            record = Record(version=version).create_from_field_list(
+                record_type=record_type,
+                title=title,
+                notes=self._task.args.get("note"),
+                fields=fields,
+                password_generate=self._task.args.get("generate_password")
+            )
+            record_create = record[0].get_record_create_obj()
+            record_uid = keeper.create_record(record_create, shared_folder_uid=shared_folder_uid)
+        except Exception as err:
+            raise AnsibleError("Could not create record: {}".format(err))
+
+        result = {
+            "record_uid": record_uid
+        }
+
+        return result

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_info.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_info.py
@@ -1,0 +1,99 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2021 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from keeper_secrets_manager_ansible import KeeperAnsible
+from keeper_secrets_manager_helper.record_type import RecordType
+from keeper_secrets_manager_helper.field_type import FieldType
+from ansible.utils.display import Display
+import importlib_metadata
+import json
+
+display = Display()
+
+DOCUMENTATION = r'''
+---
+module: keeper_info
+
+short_description: Get information about the Keeper plugins.
+
+version_added: "1.1.2"
+
+description:
+    - Get information about the Keeper plugins.
+author:
+    - John Walstra
+'''
+
+EXAMPLES = r'''
+- name: Get Keeper info
+  keeper_info:
+'''
+
+RETURN = r'''
+value:
+  description: List of various Keeper related information.
+  returned: success
+  sample: |
+    { 
+        "record_type_list": ["record_type_1", "record_type_N" ],
+        "field_type_list": ["field_type_1", "field_type_N" ],
+    }
+'''
+
+
+class ActionModule(ActionBase):
+
+
+    @staticmethod
+    def get_versions():
+
+        # Unit test do not know their version
+        versions = {
+            "keeper-secrets-manager-core": "Unknown",
+            "keeper-secrets-manager-ansible": "Unknown",
+            "keeper-secrets-manager-helper": "Unknown"
+        }
+
+        for module in versions:
+            try:
+                versions[module] = importlib_metadata.version(module)
+            except importlib_metadata.PackageNotFoundError:
+                pass
+
+        return versions
+
+    def run(self, tmp=None, task_vars=None):
+        super(ActionModule, self).run(tmp, task_vars)
+
+        if task_vars is None:
+            task_vars = {}
+
+        KeeperAnsible(task_vars=task_vars)
+
+        # If there are custom record type, load them
+        keeper_record_types = task_vars.get("keeper_record_types")
+        if keeper_record_types is not None:
+            if isinstance(keeper_record_types, list) is False:
+                raise AnsibleError("The Keeper record types is not a list.")
+            for keeper_record_type in keeper_record_types:
+                if isinstance(keeper_record_type, str) is True:
+                    keeper_record_type = json.loads(keeper_record_type)
+                RecordType.load_commander_record_types(keeper_record_type)
+
+        result = {
+            "versions": ActionModule.get_versions(),
+            "record_type_list": list(RecordType.get_record_type_list()),
+            "field_type_list": list(FieldType.get_field_type_list())
+        }
+
+        return result

--- a/integration/keeper_secrets_manager_ansible/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/requirements.txt
@@ -1,3 +1,4 @@
 ansible
 importlib_metadata
-keeper-secrets-manager-core>=16.2.0
+keeper-secrets-manager-core>=16.2.2
+keeper-secrets-manager-helper>=1.0.3

--- a/integration/keeper_secrets_manager_ansible/setup.py
+++ b/integration/keeper_secrets_manager_ansible/setup.py
@@ -9,14 +9,15 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=16.2.0',
+    'keeper-secrets-manager-core>=16.2.2',
+    'keeper-secrets-manager-helper>=1.0.3',
     'importlib_metadata',
     'ansible'
 ]
 
 setup(
     name="keeper-secrets-manager-ansible",
-    version='1.1.1',
+    version='1.1.2',
     description="Keeper Secrets Manager plugins for Ansible.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_create.yml
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_create.yml
@@ -1,0 +1,28 @@
+# vim: set shiftwidth=2 tabstop=2 softtabstop=-1 expandtab:
+---
+- name: Keeper Create
+  hosts: "my_systems"
+
+  tasks:
+  - name: "Create Record"
+    keeper_create:
+      shared_folder_uid: "{{ shared_folder_uid }}"
+      record_type: login
+      generate_password: True
+      title: "My New Record"
+      note: "This is my note"
+      fields:
+        - type: login
+          value: "johndoe@localhost"
+        - type: url
+          value: "https://localhost"
+      custom_fields:
+        - type: text
+          label: "My Custom Label"
+          valye: "This is custom text"
+    register: "new_record"
+
+  - name: "Print Record UID"
+    debug:
+      var: new_record.record_uid
+      verbosity: 0

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_info.yml
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_info.yml
@@ -1,0 +1,15 @@
+# vim: set shiftwidth=2 tabstop=2 softtabstop=-1 expandtab:
+---
+- name: Keeper Info
+  hosts: "my_systems"
+  vars:
+    keeper_record_types:
+      - |
+        {
+          "recordTypeId": 35,
+          "content": "{\"$id\":\"CUSTOM\",\"fields\":[{\"$ref\":\"fileRef\",\"label\":\"File or Photo\"},{\"$ref\":\"login\",\"label\":\"Login\"},{\"$ref\":\"password\",\"label\":\"Password\",\"required\":true,\"enforceGeneration\":false,\"privacyScreen\":false,\"complexity\":{\"length\":8,\"caps\":0,\"lowercase\":0,\"digits\":0,\"special\":0}},{\"$ref\":\"text\",\"label\":\"System Login\",\"required\":true},{\"$ref\":\"secret\",\"label\":\"System Password / Pin Code\"},{\"$ref\":\"url\",\"label\":\"Keeper VPN Wiki\",\"required\":true},{\"$ref\":\"url\",\"label\":\"Password Best Practices FAQ's and Tips\",\"required\":true}]}"
+        }
+
+  tasks:
+  - name: "Get Info"
+    keeper_info:

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_test_framework.py
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_test_framework.py
@@ -6,6 +6,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.inventory.manager import InventoryManager
 from ansible.vars.manager import VariableManager
 from ansible.plugins.loader import add_all_plugin_dirs
+from ansible.plugins.callback.default import CallbackModule
 from ansible.utils.display import Display
 from keeper_secrets_manager_core.dto.dtos import Record
 from keeper_secrets_manager_core.crypto import CryptoUtils
@@ -101,7 +102,15 @@ class AnsibleTestFramework:
                 passwords={}
             )
 
-            Display.verbosity = 4
+            callback = CallbackModule()
+
+            # Still not there. Trying to get display to show debug or v{1,5} messages
+            callback._display.verbosity = 4
+            callback.display_ok_hosts = True
+            callback.display_skipped_hosts = False
+            callback.show_per_host_start = False
+            callback.display_failed_stderr = True
+            playbook_exec._tqm._stdout_callback = callback
 
             playbook_exec.run()
             stats = playbook_exec._tqm._stats

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_ansible_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_ansible_test.py
@@ -100,7 +100,7 @@ class KeeperAnsibleTest(unittest.TestCase):
 
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            main(["--keeper_token", "US:MY_TOKEN"])
+            main(["--token", "US:MY_TOKEN"])
         content = stdout.getvalue()
         self.assertRegex(content, r'Config file created', 'did not find expected text')
         with open("client-config.json", "r") as fh:

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_create_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_create_test.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import patch
+import os
+from .ansible_test_framework import AnsibleTestFramework, RecordMaker
+import keeper_secrets_manager_ansible.plugins
+import tempfile
+
+
+records = {
+    "TRd_567FkHy-CeGsAzs8aA": RecordMaker.make_record(
+        uid="TRd_567FkHy-CeGsAzs8aA",
+        title="JW-F1-R1",
+        fields={
+          "password": "ddd"
+        }
+    )
+}
+
+
+def mocked_get_secrets(*args):
+
+    if len(args) > 0:
+        uid = args[0][0]
+        ret = [records[uid]]
+    else:
+        ret = [records[x] for x in records]
+    return ret
+
+
+def mocked_create_secret(*args):
+    create_record = args[0]
+    return create_record
+
+
+class KeeperCreateTest(unittest.TestCase):
+
+    def setUp(self):
+
+        # Add in addition Python libs. This includes the base
+        # module for Keeper Ansible and the Keeper SDK.
+        self.base_dir = os.path.dirname(os.path.realpath(__file__))
+        self.ansible_base_dir = os.path.join(self.base_dir, "ansible_example")
+
+    def _common(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            a = AnsibleTestFramework(
+                base_dir=self.ansible_base_dir,
+                playbook=os.path.join("playbooks", "keeper_create.yml"),
+                inventory=os.path.join("inventory", "all"),
+                plugin_base_dir=os.path.join(os.path.dirname(keeper_secrets_manager_ansible.plugins.__file__)),
+                vars={
+                    "shared_folder_uid": "XXXXX"
+                }
+            )
+            r, out, err = a.run()
+            result = r[0]["localhost"]
+            print("OUT", out)
+            print("ERR", err)
+            self.assertEqual(result["ok"], 3, "3 things didn't happen")
+            self.assertEqual(result["failures"], 0, "failures was not 0")
+            self.assertEqual(result["changed"], 0, "0 things didn't change")
+
+    # @unittest.skip
+    @patch("keeper_secrets_manager_core.core.SecretsManager.get_secrets", side_effect=mocked_get_secrets)
+    @patch("keeper_secrets_manager_core.core.SecretsManager.create_secret", side_effect=mocked_create_secret)
+    def test_keeper_create_mock(self, mock_create, mock_get):
+        self._common()
+
+    @unittest.skip
+    def test_keeper_create_live(self):
+        self._common()

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_info_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_info_test.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+import os
+from .ansible_test_framework import AnsibleTestFramework, RecordMaker
+import keeper_secrets_manager_ansible.plugins
+import tempfile
+
+
+records = {
+    "TRd_567FkHy-CeGsAzs8aA": RecordMaker.make_record(
+        uid="TRd_567FkHy-CeGsAzs8aA",
+        title="JW-F1-R1",
+        fields={
+          "password": "ddd"
+        }
+    )
+}
+
+
+def mocked_get_secrets(*args):
+
+    if len(args) > 0:
+        uid = args[0][0]
+        ret = [records[uid]]
+    else:
+        ret = [records[x] for x in records]
+    return ret
+
+
+class KeeperInfoTest(unittest.TestCase):
+
+    def setUp(self):
+
+        # Add in addition Python libs. This includes the base
+        # module for Keeper Ansible and the Keeper SDK.
+        self.base_dir = os.path.dirname(os.path.realpath(__file__))
+        self.ansible_base_dir = os.path.join(self.base_dir, "ansible_example")
+
+    def _common(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            a = AnsibleTestFramework(
+                base_dir=self.ansible_base_dir,
+                playbook=os.path.join("playbooks", "keeper_info.yml"),
+                inventory=os.path.join("inventory", "all"),
+                plugin_base_dir=os.path.join(os.path.dirname(keeper_secrets_manager_ansible.plugins.__file__))
+            )
+            r, out, err = a.run()
+            result = r[0]["localhost"]
+            print("OUT", out)
+            print("ERR", err)
+            self.assertEqual(result["ok"], 2, "2 things didn't happen")
+            self.assertEqual(result["failures"], 0, "failures was not 0")
+            self.assertEqual(result["changed"], 0, "0 things didn't change")
+
+    # @unittest.skip
+    @patch("keeper_secrets_manager_core.core.SecretsManager.get_secrets", side_effect=mocked_get_secrets)
+    def test_keeper_info_mock(self, _):
+        self._common()
+
+    @unittest.skip
+    def test_keeper_info_live(self):
+        self._common()


### PR DESCRIPTION
The `keeper_create` plugin allows the creation of a vault record from
Ansible. The result is the record uid. This plugin will allow custom
record type if they are defined in the vars.

The `keeper_info` plugin gives information about the KSM plugins. This
is handy for debugging or getting information about the installed plugins.
For example, the ability to see what record types (including custom types)
are available.

Also shorten'd the param name for initializing a token. And removed the
hostname param since the token has that.

And figured out how to get more stdout/stderr with the test framework.