### PR TITLE
Add ability to pass in password complexity for record.

### DIFF
--- a/sdk/python/helper/keeper_secrets_manager_helper/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/record.py
@@ -29,12 +29,15 @@ class Record:
         except ImportError as err:
             raise Exception(f"Version {self.version} is not supported: " + str(err))
 
-    def create_from_field_list(self, record_type, fields, title=None, notes=None, password_generate=None):
+    def create_from_field_list(self, record_type, fields, title=None, notes=None,
+                               password_generate=None, password_complexity=None):
         return [getattr(self.record_mod, "Record")(
             record_type=record_type,
             title=title,
             notes=notes,
-            fields=fields
+            fields=fields,
+            password_generate=password_generate,
+            password_complexity=password_complexity
         )]
 
     def create_from_field_args(self, **kwargs):

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
@@ -5,6 +5,7 @@ import json
 from importlib import import_module
 import inspect
 import sys
+import random
 
 
 UID_REGEX = r'^[a-zA-Z0-9\-_]{22}$'
@@ -83,7 +84,7 @@ def get_field_type_schema(field_type):
 
 class PasswordComplexity:
 
-    def __init__(self, value=None, length=64, caps=0, lowercase=0, digits=0, special=0):
+    def __init__(self, value=None, length=64, caps=0, lowercase=0, digits=0, special=0, filter_characters=None):
 
         # If a dictionary is passed in, use that get the attributes.
         if value is not None and type(value) is dict:
@@ -92,12 +93,18 @@ class PasswordComplexity:
             lowercase = value.get("lowercase", lowercase)
             digits = value.get("digits", digits)
             special = value.get("special", special)
+            filter_characters = value.get("filter_characters", filter_characters)
 
         self.length = length
         self.caps = caps
         self.lowercase = lowercase
         self.digits = digits
         self.special = special
+
+        self.filter_characters = filter_characters
+        if isinstance(self.filter_characters, str):
+            self.filter_characters = []
+            self.filter_characters.extend(filter_characters)
 
     def to_dict(self):
 
@@ -106,8 +113,58 @@ class PasswordComplexity:
             "caps": self.caps,
             "lowercase": self.lowercase,
             "digits": self.digits,
-            "special": self.special
+            "special": self.special,
+            "filter_characters": self.filter_characters
         }
+
+    def replacement_char(self):
+
+        """
+        Get a replacement character that doesn't match the bad character.
+        """
+
+        new_char = None
+        all_true = (self.lowercase + self.caps + self.digits + self.special) == 0
+
+        attempt = 0
+        while True:
+            # If allow everything, then just get a lowercase letter
+            if all_true is True:
+                new_char = "abcdefghijklmnopqrstuvwxyz"[random.randint(0, 25)]
+
+            # Else we need to find the first allowed character set.
+            else:
+                pick_one = random.randint(0, 3)
+                if pick_one == 0 and self.lowercase > 0:
+                    new_char = "abcdefghijklmnopqrstuvwxyz"[random.randint(0, 25)]
+                if pick_one == 1 and self.caps > 0:
+                    new_char = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[random.randint(0, 25)]
+                if pick_one == 2 and self.digits > 0:
+                    new_char = "0123456789"[random.randint(0, 9)]
+                if pick_one == 3 and self.special > 0:
+                    new_char = "!@#$%^&*()"[random.randint(0, 9)]
+
+                if new_char is None:
+                    continue
+
+            # If our new character is not in the list of bad characters, break out of the while
+            if new_char not in self.filter_characters:
+                break
+
+            # Ok, some user might go crazy and filter out every letter, digit, and symbol and cause an invite loop.
+            # If we can't find a good character after 25 attempts, error out.
+            attempt += 1
+            if attempt > 25:
+                raise ValueError("Cannot filter character from password. The password complexity is too complex.")
+
+        return new_char
+
+    def filter_password(self, password):
+
+        for bad_char in self.filter_characters:
+            while bad_char in password:
+                password = password.replace(bad_char, self.replacement_char(), 1)
+        return password
 
     def generate_password(self):
         try:
@@ -119,6 +176,11 @@ class PasswordComplexity:
                 digits=self.digits,
                 special_characters=self.special
             )
+
+            # If we have a character filter, remove bad characters
+            if self.filter_characters is not None:
+                password = self.filter_password(password)
+
         except ImportError as _:
             raise Exception("Cannot generate a random password. Requires keeper-secrets-manager-core module.")
 

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/record.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/record.py
@@ -114,6 +114,7 @@ class Record:
         }
 
         self.password_generate = kwargs.get("password_generate", False)
+        self.password_complexity = kwargs.get("password_complexity", None)
 
         self.valid_fields = []
 
@@ -303,6 +304,8 @@ class Record:
             field_type_kwargs = field.to_dict()
             self._remove_private_keys(field_type_kwargs.get("value"))
             field_type_kwargs["password_generate"] = self.password_generate
+            if self.password_complexity is not None:
+                field_type_kwargs["complexity"] = self.password_complexity
             field_type_obj = get_field_type_class(field.type)(**field_type_kwargs)
             self.fields.append(field_type_obj.to_dict())
 
@@ -312,6 +315,8 @@ class Record:
             field_type_kwargs = field.to_dict()
             self._remove_private_keys(field_type_kwargs.get("value"))
             field_type_kwargs["password_generate"] = self.password_generate
+            if self.password_complexity is not None:
+                field_type_kwargs["complexity"] = self.password_complexity
             field_type_obj = get_field_type_class(field.type)(**field_type_kwargs)
             self.custom_fields.append(field_type_obj.to_dict())
 

--- a/sdk/python/helper/setup.py
+++ b/sdk/python/helper/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-helper",
-    version="1.0.3",
+    version="1.0.4",
     description="Keeper Secrets Manager SDK helper for managing records.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/helper/tests/record_test.py
+++ b/sdk/python/helper/tests/record_test.py
@@ -1,11 +1,12 @@
 import unittest
 from keeper_secrets_manager_helper.record import Record
 from keeper_secrets_manager_core.dto.dtos import RecordCreate
+from keeper_secrets_manager_helper.field import Field, FieldSectionEnum
 
 
 class RecordTest(unittest.TestCase):
 
-    def test_build_record_simple(self):
+    def test_build_record_field_args(self):
 
         """Test the ingress in the helper create record
 
@@ -45,3 +46,85 @@ class RecordTest(unittest.TestCase):
                              {"number": "5551111111", "type": "Home"}])
         self.assertListEqual(record_create_obj.fields[4].value, ["PpR0AKIZAtUiyvq1r2BC1w"])
         self.assertNotEqual(0, len(record_create_obj.custom[0].value))
+
+    def test_build_record_field_obj(self):
+
+        field_list = [
+            Field(
+                type="login",
+                field_section=FieldSectionEnum.STANDARD,
+                value="john.smith@localhost"
+            ),
+            Field(
+                type="url",
+                field_section=FieldSectionEnum.STANDARD,
+                value="https://localhost"
+            ),
+            Field(
+                type="text",
+                field_section=FieldSectionEnum.CUSTOM,
+                label="Custom Label",
+                value="custom value"
+            )
+        ]
+
+        kwargs = dict(
+            record_type='login',
+            title="Login Record",
+            fields=field_list,
+            password_generate=True,
+            password_complexity={
+                "length": 64,
+            }
+        )
+
+        r = Record(version="v3").create_from_field_list(**kwargs)
+        record_create_obj = r[0].get_record_create_obj()
+        self.assertIsInstance(record_create_obj, RecordCreate)
+        self.assertEqual("Login Record", record_create_obj.title)
+        self.assertIsNone(record_create_obj.notes)
+        self.assertListEqual(record_create_obj.fields[0].value, ["john.smith@localhost"])
+        self.assertIsNotNone(record_create_obj.fields[1].value[0])
+        self.assertListEqual(record_create_obj.fields[2].value, ["https://localhost"])
+        self.assertListEqual(record_create_obj.custom[0].value, ["custom value"])
+
+    def test_build_record_field_obj_no_password(self):
+
+        field_list = [
+            Field(
+                type="login",
+                field_section=FieldSectionEnum.STANDARD,
+                value="john.smith@localhost"
+            ),
+            Field(
+                type="url",
+                field_section=FieldSectionEnum.STANDARD,
+                value="https://localhost"
+            ),
+            Field(
+                type="text",
+                field_section=FieldSectionEnum.CUSTOM,
+                label="Custom Label",
+                value="custom value"
+            )
+        ]
+
+        kwargs = dict(
+            record_type='login',
+            title="Login Record",
+            fields=field_list
+        )
+
+        r = Record(version="v3").create_from_field_list(**kwargs)
+        record_create_obj = r[0].get_record_create_obj()
+        self.assertIsInstance(record_create_obj, RecordCreate)
+        self.assertEqual("Login Record", record_create_obj.title)
+        self.assertIsNone(record_create_obj.notes)
+        self.assertListEqual(record_create_obj.fields[0].value, ["john.smith@localhost"])
+        # Make sure no password is set
+        self.assertListEqual(record_create_obj.fields[1].value, [])
+        self.assertListEqual(record_create_obj.fields[2].value, ["https://localhost"])
+        self.assertListEqual(record_create_obj.custom[0].value, ["custom value"])
+
+
+

--- a/sdk/python/helper/tests/v3/v3_field_type_test.py
+++ b/sdk/python/helper/tests/v3/v3_field_type_test.py
@@ -36,6 +36,20 @@ class FieldTypeTest(unittest.TestCase):
         password = pc.generate_password()
         self.assertEqual(9, len(password), "password is too short")
 
+    def test_password_filter(self):
+
+        # Only the filter_characters is used, the rest of the params don't mean anything for this test beside flags
+        pc = PasswordComplexity(length=20, caps=0, lowercase=0, digits=10, special=10, filter_characters=["$", "%"])
+        password = pc.filter_password("123$$123%123")
+        self.assertNotEqual("$$", password[3:5])
+        self.assertNotEqual("%", password[8:9])
+
+        pc = PasswordComplexity(length=64, caps=22, lowercase=22, digits=22, special=22,
+                                filter_characters="abcdefghijklmnopqrstuvwxyz")
+        password = pc.filter_password("abc123xyz$$!!")
+        self.assertNotEqual("abc", password[0:3])
+        self.assertNotEqual("xyz", password[6:9])
+
     def test_load_map(self):
         get_field_type_map()
 

--- a/sdk/python/helper/tests/v3/v3_record_test.py
+++ b/sdk/python/helper/tests/v3/v3_record_test.py
@@ -25,7 +25,7 @@ class ParserTest(unittest.TestCase):
             record_type='login',
             title="My Login Record",
             notes="This is my note",
-            fields=fields
+            fields=fields,
         )
         # Passing fields in on the constructor will automatically call build_record.
         # r.build_record()
@@ -119,7 +119,11 @@ class ParserTest(unittest.TestCase):
             record_type='login',
             title="Custom Fields",
             fields=fields,
-            password_generate=True
+            password_generate=True,
+            password_complexity={
+                "length": 64,
+                "filter_characters": ["$", "!"]
+            }
         )
 
         self.assertEqual(2, len(r.custom_fields), "there were not 2 custom fields")


### PR DESCRIPTION
This is record wide, not per field.

This is based on the record format for the complexity. It does
include an optional param `filter_characters` which will allow
a selection of characters to be replaced in the password. For
example, '%' is an special character in PostgreSQL. Generating
a password containing it would cause a failure. The filter will
prevent a password containing '%'.