### PR TITLE
Fix Permission denied error when exporting profile

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -6,6 +6,10 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change History
 
+## 1.0.12
+
+* Fix problem with the same temp file being opened when exporting profile. Was causing a `Permission denied` error.
+
 ## 1.0.11
 
 * Fix missing linefeed when selecting `immutable` for k8s token init.

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.11",
+    version="1.0.12",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_secrets_manager_cli/tests/config_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/config_test.py
@@ -19,7 +19,7 @@ class ConfigTest(unittest.TestCase):
         # Make a fake keeper.ini file.
         export = Export(config=MockConfig().make_config(), file_format="ini", plain=True)
         with open("keeper.ini", "w") as fh:
-            fh.write(export.run().decode())
+            fh.write(export.run())
             fh.close()
 
     def tearDown(self) -> None:


### PR DESCRIPTION
https://github.com/Keeper-Security/secrets-manager/issues/277

On Windows, the temp file was being opened twice which caused a
`Permission denied` error. The solution was to create a temp file,
close it, then pass the file name of the closed file. To make sure
it was removed, a `finally` statement is used to remove the temp
file, if it exists.