### PR TITLE
Fixing web safe UID in Java SDK

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -63,7 +63,7 @@ internal fun webSafe64ToBytes(data: String): ByteArray {
 }
 
 internal fun webSafe64FromBytes(data: ByteArray): String {
-    return Base64.getUrlEncoder().encodeToString(data)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(data)
 }
 
 internal fun bytesToString(data: ByteArray): String {

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/CryptoUtilsTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/CryptoUtilsTest.kt
@@ -164,4 +164,14 @@ internal class CryptoUtilsTest {
         assertTrue { password.length == 32 }
         assertTrue { password.filter { "\"!@#$%()+;<>=?[\\]{}^.,".contains(it) }.length == password.length }
     }
+
+    @Test
+    fun testWebSafe64FromBytes() {
+        val urlSafeRegex = "^[a-zA-Z0-9._~-]*\$".toRegex()
+
+        for (i in 1..3){
+            val paddedStr = webSafe64FromBytes(getRandomBytes(i))
+            assertTrue(urlSafeRegex.containsMatchIn(paddedStr))
+        }
+    }
 }


### PR DESCRIPTION
Removed padding when converting bytes to web safe string. In Keeper UIDs are not padded.

Added unit test to test proper conversion of bytes to the web-safe string