### PR TITLE
Bumping Java SDK version to 16.3.3

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -6,7 +6,7 @@ import java.util.*
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "16.3.2"
+version = "16.3.3"
 
 plugins {
     `java-library`
@@ -40,7 +40,7 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
 
@@ -51,7 +51,7 @@ dependencies {
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
-    testImplementation("org.bouncycastle:bc-fips:1.0.2.1")
+    testImplementation("org.bouncycastle:bc-fips:1.0.2.3")
 
 //    testImplementation("org.bouncycastle:bcprov-jdk15on:1.70")
 }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/CryptoUtilsTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/CryptoUtilsTest.kt
@@ -167,11 +167,17 @@ internal class CryptoUtilsTest {
 
     @Test
     fun testWebSafe64FromBytes() {
-        val urlSafeRegex = "^[a-zA-Z0-9._~-]*\$".toRegex()
+        val urlSafeRegex = "^[a-zA-Z0-9_-]*\$".toRegex()
 
         for (i in 1..3){
             val paddedStr = webSafe64FromBytes(getRandomBytes(i))
             assertTrue(urlSafeRegex.containsMatchIn(paddedStr))
         }
+
+        assertEquals("YQ", webSafe64FromBytes("a".toByteArray()))
+        assertEquals("YWE", webSafe64FromBytes("aa".toByteArray()))
+        assertEquals("YWFh", webSafe64FromBytes("aaa".toByteArray()))
+        assertEquals("YWFhYQ", webSafe64FromBytes("aaaa".toByteArray()))
+        assertEquals("8J-Ygw", webSafe64FromBytes("\uD83D\uDE03".toByteArray())) // encoded 😃 and will produce padded string along with the hyphen =>  `8J-Ygw==`
     }
 }


### PR DESCRIPTION
Bumping dependency versions
- org.jetbrains.kotlinx:kotlinx-serialization-json 1.3.2 -> 1.3.3
- org.bouncycastle:bc-fips 1.0.2.1 -> 1.0.2.3

Fixed unit test to test WebSafe64FromBytes to generate correct UID format