### PR TITLE
Add `--raw` flag for `secret get` to be used with `--query`

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -8,7 +8,9 @@ For more information see our official documentation page https://docs.keeper.io/
 
 ## 1.0.14
 
-* Accept JSON via the KSM_CONFIG environmental variable. K8S secrets will show up as JSON in the enviromental variable.
+* Accept JSON via the KSM_CONFIG environmental variable. K8S secrets will show up as JSON in the environmental variable.
+* Add `--raw` parameter to `secret get` command. When using `--query` this flag will remove the double quotes around 
+the value, if a string.
 
 ## 1.0.13
 

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -421,9 +421,10 @@ def secret_list_command(ctx, uid, json):
 @click.option('--force-array', is_flag=True, help="Return secrets as array even if a single record.")
 @click.option('--unmask', is_flag=True, help="Show password like values in table views.")
 @click.option('--inflate/--deflate', default=True, help="Load in outside records.")
+@click.option('--raw', is_flag=True, help='Remove surrounding quotes on value when using query.')
 @click.argument('extra-uid', type=str, nargs=-1)
 @click.pass_context
-def secret_get_command(ctx, uid, title, field, query, json, force_array, unmask, inflate, extra_uid):
+def secret_get_command(ctx, uid, title, field, query, json, force_array, unmask, inflate, extra_uid, raw):
     """Get secret record(s)"""
 
     uid_list = []
@@ -456,7 +457,8 @@ def secret_get_command(ctx, uid, title, field, query, json, force_array, unmask,
         load_references=True,
         unmask=unmask,
         use_color=ctx.obj["cli"].use_color,
-        inflate=inflate
+        inflate=inflate,
+        raw=raw
     )
 
 


### PR DESCRIPTION
When performing a JSON Path query using `--query` the results
are JSON. Thew problem is when a string value is returned. JSON
will encode the string surrounded by quotes. If you are piping
the results into a shell env var, it include the quotes. The
`--raw` flag will remove surrounding double quotes from the
value, if they exist.

```shell
$ ksm secret get -u XXXXX -q '$.fields[?(@.type=='login')].value[0]'
"john.smith@localhost"

$ ksm secret get -u XXXXX -q '$.fields[?(@.type=='login')].value[0]' --raw
john.smith@localhost
```

While is would be nice for the default behavior to be remove the quotes, the
historic behavior is to return quoted values. Also JSON path language normally
return strings quoted.