### PR TITLE
KSM Python SDK v16.3.3

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
+++ b/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
@@ -104,7 +104,8 @@ class Record:
 
         # Find the password in the field and update the password attribute
         password_field = next((item for item in self.dict["fields"] if item["type"] == "password"), None)
-        self.password = password_field.get('value')[0]
+        if password_field is not None and len(password_field.get('value', [])) > 0:
+            self.password = password_field.get('value')[0]
 
         self.raw_json = utils.dict_to_json(self.dict)
 

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-core",
-    version="16.3.2",
+    version="16.3.3",
     description="Keeper Secrets Manager for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Check if a password value exists before setting (#306)

If there is no password field, or if there is no password value, the prior
code would throw an index exception. Check before setting the obj
attribute.

* Bump version to 16.3.3