### PR TITLE
#336 - keeper ansible keeper_create does not use custom record types

### DIFF
--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action_plugins/keeper_create.py
@@ -234,8 +234,6 @@ class ActionModule(ActionBase):
         record_type = self._task.args.get("record_type")
         if record_type is None:
             raise AnsibleError("The record_type is blank. keeper_create requires this value to be set.")
-        if record_type not in RecordType.get_record_type_list():
-            raise AnsibleError("The record_type {} is not a valid record type.".format(record_type))
         title = self._task.args.get("title")
         if title is None:
             raise AnsibleError("The title is blank. keeper_create requires this value to be set.")
@@ -252,6 +250,9 @@ class ActionModule(ActionBase):
                     if isinstance(keeper_record_type, dict) is True:
                         keeper_record_type = [keeper_record_type]
                 RecordType.load_commander_record_types(keeper_record_type)
+
+        if record_type not in RecordType.get_record_type_list():
+            raise AnsibleError("The record_type {} is not a valid record type.".format(record_type))
 
         fields = []
 


### PR DESCRIPTION
Record type test is done now AFTER the load of the custom record types
Fix #336 