### PR TITLE
Bump ansible version to release.

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -11,3 +11,29 @@ This module contains plugins that allow your Ansible automations to use Keeper S
 * `keeper_redact` - Stdout Callback plugin to redact secrets from logs.
 
 For more information see our official documentation page https://docs.keeper.io/secrets-manager/secrets-manager/integrations/ansible-plugin
+
+# Changes
+
+## 1.1.4
+
+* Move check for custom record type in `keeper_create` plugin.
+* Keeper Secret Manager SDK version pinned to 16.3.5 or greater. Allows extra field parameters
+that come from Keeper Commander.
+
+## 1.1.3
+
+* Per PEP 263, added `# -*- coding: utf-8 -*-` to top of file to prevent errors on system that are not UTF-8.
+
+## 1.1.2
+
+* Added `keeper_create`, `keeper_password`, `keeper_info` action plugins.
+* Fixed complex strings not regular expressions escaping properly for 
+`keeper_redact`. 
+* Added `keeper_app_owner_public_key` to the `keeper_init` plugin configuration
+generation. `keeper_app_owner_public_key` also added to Ansible variables.
+
+## 1.1.1
+* Fixed misspelled collection name in `README.md`
+
+## 1.1.0
+* First Ansible Galaxy release

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
@@ -116,6 +116,12 @@ configuration file or even a playbook.
 
 # Changes
 
+## 1.1.4
+
+* Move check for custom record type in `keeper_create` plugin.
+* Keeper Secret Manager SDK version pinned to 16.3.5 or greater. Allows extra field parameters
+that come from Keeper Commander.
+
 ## 1.1.3
 
 * Per PEP 263, added `# -*- coding: utf-8 -*-` to top of file to prevent errors on system that are not UTF-8.

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
@@ -1,3 +1,3 @@
 importlib_metadata
-keeper-secrets-manager-core>=16.2.2
+keeper-secrets-manager-core>=16.3.5
 keeper-secrets-manager-helper>=1.0.4

--- a/integration/keeper_secrets_manager_ansible/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/requirements.txt
@@ -1,4 +1,4 @@
 ansible
 importlib_metadata
-keeper-secrets-manager-core>=16.2.2
+keeper-secrets-manager-core>=16.3.5
 keeper-secrets-manager-helper>=1.0.4

--- a/integration/keeper_secrets_manager_ansible/setup.py
+++ b/integration/keeper_secrets_manager_ansible/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=16.2.2',
+    'keeper-secrets-manager-core>=16.3.5',
     'keeper-secrets-manager-helper>=1.0.4',
     'importlib_metadata',
     'ansible'
@@ -17,7 +17,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-ansible",
-    version='1.1.3',
+    version='1.1.4',
     description="Keeper Secrets Manager plugins for Ansible.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The release is a PR that fixed `keeper_create` for public records.
The Python SDK also needed updates to handle Keeper Commander
custom record field parameters. That is why the pinned version
has been updated.