### PR TITLE
Pin the Python SDK >= 16.4.1 for OpenSSL fix

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -14,6 +14,10 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Changes
 
+## 1.1.5
+
+* Update pinned KSM SDK version. The KSM SDK has been updated to use OpenSSL 3.0.7 which resolves CVE-2022-3602, CVE-2022-3786.
+
 ## 1.1.4
 
 * Move check for custom record type in `keeper_create` plugin.

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
@@ -116,6 +116,10 @@ configuration file or even a playbook.
 
 # Changes
 
+## 1.1.5
+
+* Update pinned KSM SDK version. The KSM SDK has been updated to use OpenSSL 3.0.7 which resolves CVE-2022-3602, CVE-2022-3786.
+
 ## 1.1.4
 
 * Move check for custom record type in `keeper_create` plugin.

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
@@ -1,3 +1,3 @@
 importlib_metadata
-keeper-secrets-manager-core>=16.3.5
+keeper-secrets-manager-core>=16.4.1
 keeper-secrets-manager-helper>=1.0.4

--- a/integration/keeper_secrets_manager_ansible/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/requirements.txt
@@ -1,4 +1,4 @@
 ansible
 importlib_metadata
-keeper-secrets-manager-core>=16.3.5
+keeper-secrets-manager-core>=16.4.1
 keeper-secrets-manager-helper>=1.0.4

--- a/integration/keeper_secrets_manager_ansible/setup.py
+++ b/integration/keeper_secrets_manager_ansible/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=16.3.5',
+    'keeper-secrets-manager-core>=16.4.1',
     'keeper-secrets-manager-helper>=1.0.4',
     'importlib_metadata',
     'ansible'
@@ -17,7 +17,7 @@ install_requires = [
 
 setup(
     name="keeper-secrets-manager-ansible",
-    version='1.1.4',
+    version='1.1.5',
     description="Keeper Secrets Manager plugins for Ansible.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -37,7 +37,7 @@ setup(
         "Source Code": "https://github.com/Keeper-Security/secrets-manager",
     },
     classifiers=[
-        "Development Status :: 1 - Planning",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",
@@ -48,6 +48,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Security",
         "Topic :: System :: Installation/Setup",
         "Topic :: System :: Systems Administration"


### PR DESCRIPTION
KSM-336

Python SDK includes update of cryptography module which ...

    Updated Windows, macOS, and Linux wheels to be compiled with
    OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.

This pins the SDK version in order to get those fixes. OpenSSL 3.0.7 still needs to be updated on the hosting operating system.