### PR TITLE
Pin the Python SDK >= 16.4.1 for OpenSSL fix

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -6,6 +6,10 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change History
 
+## 1.0.15
+
+* Update pinned KSM SDK version. The KSM SDK has been updated to use OpenSSL 3.0.7 which fixes CVE-2022-3602, CVE-2022-3786.
+
 ## 1.0.14
 
 * Accept JSON via the KSM_CONFIG environmental variable. K8S secrets will show up as JSON in the environmental variable.

--- a/integration/keeper_secrets_manager_cli/requirements.txt
+++ b/integration/keeper_secrets_manager_cli/requirements.txt
@@ -1,4 +1,4 @@
-keeper-secrets-manager-core>=16.2.2
+keeper-secrets-manager-core>=16.4.1
 keeper-secrets-manager-helper
 prompt-toolkit~=2.0
 jsonpath-rw-ext

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=16.2.2',
+    'keeper-secrets-manager-core>=16.4.1',
     'keeper-secrets-manager-helper',
     'prompt-toolkit~=2.0',
     'click',
@@ -25,7 +25,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.0.14",
+    version="1.0.15",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -45,7 +45,7 @@ setup(
         "Source Code": "https://github.com/Keeper-Security/secrets-manager",
     },
     classifiers=[
-        "Development Status :: 1 - Planning",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
@@ -55,6 +55,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Security",
     ],
     entry_points={


### PR DESCRIPTION
KSM-333

Python SDK includes update of cryptography module which ...

    Updated Windows, macOS, and Linux wheels to be compiled with
    OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.

This pins the SDK version in order to get those fixes. OpenSSL 3.0.7 still needs to be updated on the hosting operating system.