### PR TITLE
Upgrade kotlin and gradle-wrapper properties version

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -6,12 +6,12 @@ import java.util.*
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "16.5.3"
+version = "16.5.4"
 
 plugins {
     `java-library`
-    kotlin("jvm") version "1.6.10"
-    kotlin("plugin.serialization") version "1.6.10"
+    kotlin("jvm") version "1.6.21"
+    kotlin("plugin.serialization") version "1.6.21"
     `maven-publish`
     signing
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"

--- a/sdk/java/core/gradle/wrapper/gradle-wrapper.properties
+++ b/sdk/java/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The version property for the gradle file has been upgraded from 16.5.3 to 16.5.4. Also, the kotlin and gradle-wrapper version have been updated from 1.6.10 to 1.6.21 and 6.2.2 to 8.1.1 correspondingly in the build.gradle.kt file and gradle-wrapper.properties file.