### PR TITLE
KSM-442 - Python - KSM Helper: Update pyyaml version requirement in requirements.txt

### DIFF
--- a/sdk/python/helper/requirements.txt
+++ b/sdk/python/helper/requirements.txt
@@ -1,3 +1,3 @@
 keeper-secrets-manager-core>=16.2.2
-pyyaml
+pyyaml>=6.0.1
 iso8601


### PR DESCRIPTION
Updated the version requirement for 'pyyaml' in requirements.txt to be at least 6.0.1. The previous lack of version specification could result in the use of outdated or incompatible versions of pyyaml. Now the effective version of 'pyyaml' is explicitly defined to avoid any possible issues.