### PR TITLE
KSM-453 - Java - Upgrade kotlin-stdlib-jdk8 dependency scope to api

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
     // Use the Kotlin JDK 8 standard library.
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
 


### PR DESCRIPTION
The scope for kotlin-stdlib-jdk8 library dependency has been updated from 'implementation' to 'api' in build.gradle.kts. This change was necessary to expose the standard library to the consumers of our library, thereby facilitating the usage of JDK 8 specific features offered by Kotlin.