### PR TITLE
KSM-485 - KSM CLI: Added sub-folder support to ksm secret add command

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -812,7 +812,7 @@ def secret_add_command():
     help_options_color='blue'
 )
 @click.pass_context
-@click.option('--shared-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
+@click.option('--storage-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
 @click.option('--record-type', '--rt', required=True, type=str, help="Record type")
 @click.option('--password-generate', '-p', is_flag=True, help='Generate passwords for empty password fields.')
 @click.option('--title', '-t', type=str, help="Record title")
@@ -821,13 +821,13 @@ def secret_add_command():
               help='File format to display in editor.')
 @click.option('--editor', '-e', type=str, help='Application to use to edit record data.')
 @click.option('--version', type=click.Choice(['v3'], case_sensitive=False), default='v3', help='Record version.')
-def secret_add_editor_command(ctx, shared_folder_uid, record_type, password_generate, title, notes,
+def secret_add_editor_command(ctx, storage_folder_uid, record_type, password_generate, title, notes,
                               output_format, editor, version):
     """Add a secret record via a text editor"""
 
     ctx.obj["secret"].add_record_interactive(
         version=version,
-        folder_uid=shared_folder_uid,
+        folder_uid=storage_folder_uid,
         record_type=record_type,
         output_format=output_format,
         password_generate_flag=password_generate,
@@ -844,14 +844,14 @@ def secret_add_editor_command(ctx, shared_folder_uid, record_type, password_gene
     help_options_color='blue'
 )
 @click.pass_context
-@click.option('--shared-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
+@click.option('--storage-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
 @click.option('--file', '-f', required=True, type=str, help='Add records from record script file.')
 @click.option('--password-generate', '-p', is_flag=True, help='Generate passwords for empty password fields.')
-def secret_add_file_command(ctx, shared_folder_uid, file, password_generate):
+def secret_add_file_command(ctx, storage_folder_uid, file, password_generate):
     """Add a secret record(s) from a file"""
 
     ctx.obj["secret"].add_record_from_file(
-        folder_uid=shared_folder_uid,
+        folder_uid=storage_folder_uid,
         file=file,
         password_generate_flag=password_generate,
     )
@@ -864,20 +864,20 @@ def secret_add_file_command(ctx, shared_folder_uid, file, password_generate):
     help_options_color='blue'
 )
 @click.pass_context
-@click.option('--shared-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
+@click.option('--storage-folder-uid', '--sf', required=True, type=str, help="Place record in folder with UID.")
 @click.option('--record-type', '--rt', required=True, type=str, help="Record type")
 @click.option('--title', '-t', required=True, type=str, help="Record title")
 @click.option('--password-generate', '-p', is_flag=True, help='Generate passwords for empty password fields.')
 @click.option('--notes', '-n', type=str, help="Record simple note")
 @click.option('--version', type=click.Choice(['v3'], case_sensitive=False), default='v3', help='Record version.')
 @click.argument('field_args', type=str, nargs=-1)
-def secret_add_field_command(ctx, shared_folder_uid, record_type, title, password_generate, notes, version,
+def secret_add_field_command(ctx, storage_folder_uid, record_type, title, password_generate, notes, version,
                              field_args):
     """Add a secret record from a command line field arguments"""
 
     ctx.obj["secret"].add_record_from_field_args(
         version=version,
-        folder_uid=shared_folder_uid,
+        folder_uid=storage_folder_uid,
         password_generate_flag=password_generate,
         record_type=record_type,
         title=title,
@@ -1170,7 +1170,7 @@ def quit_command():
 @click.option('--credentials', '-c', type=str, metavar="UID", help="Keeper record with credentials to access destination key/value store.",
     cls=Mutex,
     # not_required_if=[('type','json')],
-    required_if=[('type','azure'), ('type','aws'), ('type','gcp')]
+    required_if=[('type', 'azure'), ('type', 'aws'), ('type', 'gcp')]
 )
 @click.option('--type', '-t', type=click.Choice(['aws', 'azure', 'gcp', 'json']), default='json', help="Type of the target key/value storage (aws, azure, gcp, json).", show_default=True)
 @click.option('--dry-run', '-n', is_flag=True, help='Perform a trial run with no changes made.')

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -14,17 +14,18 @@ import json
 import yaml
 import os
 import re
-from jsonpath_rw_ext import parse
 import sys
 from colorama import Fore, Style
+from jsonpath_rw_ext import parse
 from keeper_secrets_manager_cli.exception import KsmCliException
 from keeper_secrets_manager_cli.common import launch_editor
-from keeper_secrets_manager_core.core import SecretsManager
+from keeper_secrets_manager_core.core import SecretsManager, CreateOptions, KeeperFolder
 from keeper_secrets_manager_core.utils import get_totp_code, generate_password as sdk_generate_password
 from keeper_secrets_manager_helper.record import Record
 from keeper_secrets_manager_helper.field_type import FieldType
 from keeper_secrets_manager_helper.exception import FileSyntaxException
 from .table import Table, ColumnAlign
+from typing import List, Tuple
 import uuid
 import tempfile
 
@@ -705,11 +706,13 @@ class Secret:
         self._check_if_can_add_records()
 
         try:
+            folders = self.cli.client.get_folders()
             records = Record.create_from_file(file, password_generate=password_generate_flag)
             record_uids = []
             for record in records:
                 record_create_obj = record.get_record_create_obj()
-                record_uid = self.cli.client.create_secret(folder_uid, record_create_obj)
+                folder_options, folders = self.build_folder_options(folder_uid, folders)
+                record_uid = self.cli.client.create_secret_with_options(folder_options, record_create_obj, folders)
                 record_uids.append(record_uid)
         except FileSyntaxException as err:
             raise KsmCliException(str(err))
@@ -734,12 +737,34 @@ class Secret:
             )
             record = records[0]
             record_create_obj = record.get_record_create_obj()
-            record_uid = self.cli.client.create_secret(folder_uid, record_create_obj)
+
+            folder_options, folders = self.build_folder_options(folder_uid)
+            record_uid = self.cli.client.create_secret_with_options(folder_options, record_create_obj, folders)
         except Exception as err:
             raise KsmCliException(f"{err}")
 
         print("The following is the new record UID ...", file=sys.stderr)
         return self.cli.output(record_uid)
+
+    def build_folder_options(self, folder_uid: str, folders: List[KeeperFolder] = []) -> Tuple[CreateOptions, List[KeeperFolder]]:
+        """ Build and return folder create options and folders list """
+
+        # find closest shared folder parent
+        if not folders:
+            folders = self.cli.client.get_folders() or []
+
+        shared_folder = next((x for x in folders if x.folder_uid == folder_uid), None)
+        while shared_folder and shared_folder.parent_uid:
+            shared_folder = next((x for x in folders if x.folder_uid == shared_folder.parent_uid), shared_folder)
+
+        if shared_folder is None:
+            raise KsmCliException(f'Unable to find the shared folder for {folder_uid}')
+        if not shared_folder.folder_key:
+            raise KsmCliException(f'Unable to find folder key for folder {shared_folder.folder_uid}')
+
+        # create folder options
+        create_options = CreateOptions(shared_folder.folder_uid, folder_uid)
+        return create_options, folders
 
     def generate_password(self, length, lowercase, uppercase, digits, special_characters):
 


### PR DESCRIPTION
Added sub-folder support to `ksm secret add` command
renamed `--shared-folder-uid` option to `--storage-folder-uid`