### PR TITLE
Update module and assembly version to 16.6.7

### DIFF
--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>SecretManagement.Keeper</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AssemblyVersion>16.6.6</AssemblyVersion>
-        <FileVersion>16.6.6</FileVersion>
+        <AssemblyVersion>16.6.7</AssemblyVersion>
+        <FileVersion>16.6.7</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.psd1
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '16.6.6'
+    ModuleVersion = '16.6.7'
     CompatiblePSEditions = @('Core')
     GUID = '20ab89cb-f0dd-4e8e-b276-f3a7708c1eb2'
     Author = 'Sergey Aldoukhov'


### PR DESCRIPTION
Increased the ModuleVersion, AssemblyVersion, and FileVersion from 16.6.6 to 16.6.7 in the SecretManagement.Keeper.psd1 and SecretManagement.Keeper.csproj files. This ensures the latest changes are reflected in the module and assembly metadata.