### PR TITLE
Replace Buffer with Uint8Array in js browser bundle

### DIFF
--- a/sdk/javascript/packages/core/src/browser/localConfigStorage.ts
+++ b/sdk/javascript/packages/core/src/browser/localConfigStorage.ts
@@ -72,7 +72,7 @@ export function createCachingFunction(storage: KeyValueStorage): (url: string, t
                 Authorization: `Signature ${platform.bytesToBase64(payload.signature)}`
             })
             if (response.statusCode == 200) {
-                await storage.saveBytes('cache', Buffer.concat([transmissionKey.key, response.data]))
+                await storage.saveBytes('cache', new Uint8Array([...transmissionKey.key, ...response.data]))
             }
             return response
         } catch (e) {


### PR DESCRIPTION
The browser bundle uses Buffer but doesn't specify any sort of dependency upon it. Replace Buffer with Uint8Array.