### PR TITLE
KSM-582: fix NPE use safe cast in KeeperRecordData.getField()

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -15,7 +15,7 @@ data class KeeperRecordData @JvmOverloads constructor(
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
-        return (fields + custom).find { x -> x is T } as T
+        return (fields + (custom ?: listOf())).find { x -> x is T } as? T
     }
 
     fun getField(clazz: Class<out KeeperRecordField>): KeeperRecordField? {


### PR DESCRIPTION
Replace unsafe cast (`as T`) with safe cast operator (`as? T`) in `getField()` to prevent NPE when uploading files to records without FileRef field.

This fixes an issue where attempting to upload a file to a record without an initialized FileRef field would throw:
"null cannot be cast to non-null type FileRef"

Fixes #698