### PR TITLE
Fix GitHub Actions naming

### DIFF
--- a/.github/workflows/publish.maven.storage.gcp.kms.yml
+++ b/.github/workflows/publish.maven.storage.gcp.kms.yml
@@ -1,4 +1,4 @@
-name: Publish Java GCP KMS Storage to Maven
+name: Publish to Maven (Java Storage GCP KMS)
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Fix GitHub Actions naming consistency: Publish to Maven (Java Storage GCP KMS)