### PR TITLE
Correct Puppet module naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fg# Keeper Secrets Manager
+# Keeper Secrets Manager
 
 Keeper Secrets Manager is a component of the Keeper Enterprise platform. It provides your DevOps, IT Security and
 software development teams with a fully cloud-based, Zero-Knowledge platform for managing all of your

--- a/integration/keeper_secrets_manager_puppet/README.md
+++ b/integration/keeper_secrets_manager_puppet/README.md
@@ -1,4 +1,4 @@
-# Puppet Keeper Secret Manager
+# Puppet Keeper Secrets Manager
 
 ## Table of Contents
 

--- a/integration/keeper_secrets_manager_puppet/lib/puppet/functions/keeper_secrets_manager_puppet/lookup.rb
+++ b/integration/keeper_secrets_manager_puppet/lib/puppet/functions/keeper_secrets_manager_puppet/lookup.rb
@@ -125,7 +125,7 @@ Puppet::Functions.create_function(:'keeper_secrets_manager_puppet::lookup') do
       require 'open3'
       _stdout, _stderr, status = Open3.capture3(python_executable, '-c', 'import keeper_secrets_manager_core')
       unless status.success?
-        raise Puppet::Error, 'keeper-secrets-manager-core not installed. Ensure keeper_secret_manager_puppet class is applied first.'
+        raise Puppet::Error, 'keeper-secrets-manager-core not installed. Ensure keeper_secrets_manager_puppet class is applied first.'
       end
     rescue => e
       raise Puppet::Error, "Failed to validate keeper-secrets-manager-core installation: #{e.message}"

--- a/integration/keeper_secrets_manager_puppet/manifests/config.pp
+++ b/integration/keeper_secrets_manager_puppet/manifests/config.pp
@@ -34,7 +34,7 @@ class keeper_secrets_manager_puppet::config {
   }
 
   # first Check if KEEPER_CONFIG is set in the environment
-  $auth_value_from_env = keeper_secret_manager_puppet::lookup_env_value($authentication_config[1])
+  $auth_value_from_env = keeper_secrets_manager_puppet::lookup_env_value($authentication_config[1])
 
   # if auth_value_from_env is nil/undef and $authentication_config[1] value starts with 'ENV:'
   if $auth_value_from_env == undef and $authentication_config[1] =~ String and $authentication_config[1] =~ /^ENV:/ {
@@ -151,7 +151,7 @@ class keeper_secrets_manager_puppet::config {
     owner   => $owner_value,
     group   => $group_value,
     mode    => $python_script_mode,
-    source  => "puppet:///modules/keeper_secret_manager_puppet/${python_script_name}",
+    source  => "puppet:///modules/keeper_secrets_manager_puppet/${python_script_name}",
     require => File[$config_dir_path],
   }
 

--- a/integration/keeper_secrets_manager_puppet/metadata.json
+++ b/integration/keeper_secrets_manager_puppet/metadata.json
@@ -2,7 +2,7 @@
   "name": "keepersecurity-keeper_secrets_manager_puppet",
   "version": "1.0.0",
   "author": "Keeper Security",
-  "summary": "Puppet module for Keeper Secrets Manager integration with deferred functions for secure runtime secret retrieval",
+  "summary": "Puppet module for Keeper Secrets Manager integration with deferred functions for secure runtime secrets retrieval",
   "source": "https://github.com/Keeper-Security/secrets-manager",
   "project_page": "https://github.com/Keeper-Security/secrets-manager/tree/master/integration/keeper_secrets_manager_puppet",
   "issues_url": "https://github.com/Keeper-Security/secrets-manager/issues",


### PR DESCRIPTION
Fix:
- updated module name from `keeper_secret_manager_puppet ` to `keeper_secrets_manager_puppet ` in `lookup.rb` and `config.pp`
- updated text `secret` to `secrets` in some files
- fixed main heading in `secrets-manager/README.md`