### PR TITLE
Update mock.py with Record.revision

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/mock.py
+++ b/sdk/python/core/keeper_secrets_manager_core/mock.py
@@ -331,6 +331,7 @@ class Record:
         self.notes = ""
         self.is_editable = False
         self.files = {}
+        self.revision = kwargs.get("revision", 1)
 
         self._fields = []
         self._custom_fields = []


### PR DESCRIPTION
Adding missing revision attribute to Record mock. It is consumed via kwarg for maximum compatibility