### PR TITLE
KSM-659 - Handle broken encryption in records, folders and files

### DIFF
--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -1000,9 +1000,16 @@ namespace SecretsManager
             {
                 foreach (var record in response.records)
                 {
-                    var recordKey = CryptoUtils.Decrypt(record.recordKey, appKey);
-                    var decryptedRecord = DecryptRecord(record, recordKey);
-                    records.Add(decryptedRecord);
+                    try
+                    {
+                        var recordKey = CryptoUtils.Decrypt(record.recordKey, appKey);
+                        var decryptedRecord = DecryptRecord(record, recordKey);
+                        records.Add(decryptedRecord);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Record {record.recordUid} skipped due to error: {ex.GetType().Name}, {ex.Message}");
+                    }
                 }
             }
 
@@ -1010,12 +1017,26 @@ namespace SecretsManager
             {
                 foreach (var folder in response.folders)
                 {
-                    var folderKey = CryptoUtils.Decrypt(folder.folderKey, appKey);
-                    foreach (var record in folder.records)
+                    try
                     {
-                        var recordKey = CryptoUtils.Decrypt(record.recordKey, folderKey);
-                        var decryptedRecord = DecryptRecord(record, recordKey, folder.folderUid, folderKey);
-                        records.Add(decryptedRecord);
+                        var folderKey = CryptoUtils.Decrypt(folder.folderKey, appKey);
+                        foreach (var record in folder.records)
+                        {
+                            try
+                            {
+                                var recordKey = CryptoUtils.Decrypt(record.recordKey, folderKey);
+                                var decryptedRecord = DecryptRecord(record, recordKey, folder.folderUid, folderKey);
+                                records.Add(decryptedRecord);
+                            }
+                            catch (Exception ex)
+                            {
+                                Console.Error.WriteLine($"Record {record.recordUid} in folder {folder.folderUid} skipped due to error: {ex.GetType().Name}, {ex.Message}");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Folder {folder.folderUid} skipped due to error: {ex.GetType().Name}, {ex.Message}");
                     }
                 }
             }
@@ -1039,9 +1060,16 @@ namespace SecretsManager
             {
                 foreach (var file in record.files)
                 {
-                    var fileKey = CryptoUtils.Decrypt(file.fileKey, recordKey);
-                    var decryptedFile = CryptoUtils.Decrypt(file.data, fileKey);
-                    files.Add(new KeeperFile(fileKey, file.fileUid, JsonUtils.ParseJson<KeeperFileData>(decryptedFile), file.url, file.thumbnailUrl));
+                    try
+                    {
+                        var fileKey = CryptoUtils.Decrypt(file.fileKey, recordKey);
+                        var decryptedFile = CryptoUtils.Decrypt(file.data, fileKey);
+                        files.Add(new KeeperFile(fileKey, file.fileUid, JsonUtils.ParseJson<KeeperFileData>(decryptedFile), file.url, file.thumbnailUrl));
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"File {file.fileUid} skipped due to error: {ex.GetType().Name}, {ex.Message}");
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes [#816](https://github.com/Keeper-Security/secrets-manager/issues/816)

Add error handling to gracefully skip records, folders, and files with broken encryption instead of failing the entire request. This matches the Python SDK implementation from KSM-529.

- Wrap decryption operations in try-catch blocks
- Log errors for skipped items
- Continue processing valid items
- Return partial results successfully