### PR TITLE
KSM-465: Add ksm interpolate command for shell built-in compatibility

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -6,6 +6,9 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change History
 
+## 1.2.0
+- KSM-465 Added `ksm interpolate` command, resolves GitHub issue #543
+
 ## 1.1.7
 - KSM-668 Restored ? command to cli
 

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -47,6 +47,7 @@ class AliasedGroup(HelpColorsGroup):
         "color",
         "show",
         "exec",
+        "interpolate",
         "profile",
         "active",
         "export",
@@ -1139,6 +1140,53 @@ def exec_command(ctx, capture_output, inline, cmd):
     ex.execute(cmd=cmd, capture_output=capture_output, inline=inline)
 
 
+# INTERPOLATE COMMAND
+@click.command(
+    name='interpolate',
+    cls=HelpColorsCommand,
+    help_options_color='blue'
+)
+@click.argument('input_file', type=click.Path(exists=True, readable=True))
+@click.option('--output', '-o',
+              type=click.Path(dir_okay=False, writable=True),
+              help='Output file path (stdout if not specified)')
+@click.pass_context
+def interpolate_command(ctx, input_file, output):
+    """
+    Interpolate Keeper notation in a file.
+
+    Reads INPUT_FILE, replaces all keeper:// notation with secret values,
+    and outputs the result to stdout or a file.
+
+    Supports custom fields and file names.
+
+    Examples:
+
+    \b
+    # Output to stdout
+    ksm interpolate secrets.env
+
+    \b
+    # Save to file
+    ksm interpolate secrets.env --output /tmp/resolved.env
+
+    \b
+    # Load environment variables (bash/zsh)
+    eval "$(ksm interpolate secrets.env)"
+
+    \b
+    # Use with process substitution (bash/zsh)
+    source <(ksm interpolate secrets.env)
+
+    \b
+    # Process YAML config template
+    ksm interpolate config.template.yaml -o config.yaml
+    """
+    from keeper_secrets_manager_cli.interpolate import Interpolate
+    interpolator = Interpolate(cli=ctx.obj["cli"])
+    interpolator.interpolate_file(input_file, output)
+
+
 # CONFIG COMMAND
 @click.group(
     name='config',
@@ -1418,6 +1466,7 @@ cli.add_command(sync_command)
 cli.add_command(folder_command)
 cli.add_command(secret_command)
 cli.add_command(exec_command)
+cli.add_command(interpolate_command)
 cli.add_command(config_command)
 cli.add_command(init_command)
 cli.add_command(version_command)

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ (R)
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2021 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+import os
+import sys
+import re
+import json
+import logging
+from keeper_secrets_manager_cli.exception import KsmCliException
+from keeper_secrets_manager_core.core import SecretsManager
+from keeper_secrets_manager_core.keeper_globals import logger_name
+
+
+class Interpolate:
+    """
+    Interpolate Keeper notation in text files.
+
+    Reads files, replaces all keeper:// notation with secret values from
+    Keeper Secrets Manager, and outputs the result.
+    """
+
+    def __init__(self, cli):
+        """
+        Initialize Interpolate instance.
+
+        Args:
+            cli: KeeperCli instance for SDK access
+        """
+        self.cli = cli
+        self.logger = logging.getLogger(logger_name)
+        # Cache notation lookups to reduce SDK calls
+        self.local_cache = {}
+
+    def _get_secret(self, notation):
+        """
+        Fetch secret value using notation, with caching.
+
+        Args:
+            notation: Keeper notation string (keeper://uid/field/label)
+
+        Returns:
+            Secret value as string
+
+        Raises:
+            ValueError: If notation is invalid or secret not found
+        """
+        # If not in the cache, fetch from SDK and cache it
+        if notation not in self.local_cache:
+            value = self.cli.client.get_notation(notation)
+            # Convert dict/list to JSON string
+            if type(value) is dict or type(value) is list:
+                value = json.dumps(value)
+            self.local_cache[notation] = str(value)
+
+        return self.local_cache[notation]
+
+    def _interpolate_content(self, content):
+        """
+        Replace all keeper:// notation in content string.
+
+        Respects .env file syntax - skips comment lines (lines starting with #).
+
+        Args:
+            content: File content as string
+
+        Returns:
+            Content with all notation replaced
+        """
+        # Use SDK constant for consistency with exec.py
+        prefix = SecretsManager.notation_prefix
+        # Pattern matches keeper notation: keeper://UID/TYPE/NAME
+        # UID and TYPE segments cannot contain spaces or slashes
+        # NAME segment (field/file name) CAN contain spaces
+        # Stops at: quotes, newlines, or # (comment character)
+        pattern = rf'{prefix}://[^\s/]+/[^\s/]+/[^"\'\n#]+'
+
+        def replace_notation(match):
+            notation = match.group().strip()  # Strip any trailing whitespace
+            try:
+                return self._get_secret(notation)
+            except ValueError as err:
+                error_str = str(err)
+                # Match error handling pattern from exec.py:54-56
+                # Skip invalid notation (might not be actual notation)
+                if (error_str.startswith("Invalid format of Keeper notation") or
+                    error_str.startswith("Keeper notation is invalid") or
+                    error_str.startswith("Keeper url missing") or
+                    error_str.startswith("Keeper notation URI missing")):
+                    self.logger.info(f"Skipping invalid notation '{notation}': {error_str}")
+                    return notation  # Leave original text unchanged
+                else:
+                    # Unexpected error (network, access denied, etc.)
+                    raise KsmCliException(f"Failed to fetch notation '{notation}': {error_str}")
+
+        # Process line by line to respect .env file comment syntax
+        lines = content.split('\n')
+        processed_lines = []
+
+        for line in lines:
+            # Check if line is a comment (starts with # after stripping leading whitespace)
+            stripped = line.lstrip()
+            if stripped.startswith('#'):
+                # Skip processing comments - keep original line
+                processed_lines.append(line)
+            else:
+                # Process non-comment lines for notation replacement
+                processed_lines.append(re.sub(pattern, replace_notation, line))
+
+        return '\n'.join(processed_lines)
+
+    def interpolate_file(self, input_path, output_path=None):
+        """
+        Read file, replace keeper:// notation, output result.
+
+        Args:
+            input_path: Path to input file
+            output_path: Optional path to write output (stdout if None)
+
+        Raises:
+            KsmCliException: On file errors or secret fetch failures
+        """
+        # Security: Resolve absolute path and follow symlinks
+        input_path = os.path.realpath(os.path.abspath(input_path))
+
+        # Security: Check file exists and is a regular file
+        if not os.path.isfile(input_path):
+            raise KsmCliException(f"File not found: {input_path}")
+
+        # Security: Check file size (10MB limit)
+        file_size = os.path.getsize(input_path)
+        max_size = 10 * 1024 * 1024  # 10MB
+        if file_size > max_size:
+            raise KsmCliException(
+                f"File too large: {file_size} bytes (limit: {max_size} bytes / 10MB)"
+            )
+
+        # Read input file with explicit UTF-8 encoding
+        try:
+            with open(input_path, 'r', encoding='utf-8', errors='strict') as f:
+                content = f.read()
+        except UnicodeDecodeError:
+            raise KsmCliException(
+                f"Cannot read {input_path}: File must be UTF-8 encoded text. "
+                "Binary files are not supported."
+            )
+        except FileNotFoundError:
+            raise KsmCliException(f"File not found: {input_path}")
+        except PermissionError:
+            raise KsmCliException(f"Permission denied: {input_path}")
+        except OSError as err:
+            raise KsmCliException(f"Error reading file: {err}")
+
+        # Replace all keeper:// notation
+        interpolated = self._interpolate_content(content)
+
+        # Output to file or stdout
+        if output_path:
+            # Security: Resolve output path
+            output_path = os.path.realpath(os.path.abspath(output_path))
+
+            try:
+                with open(output_path, 'w', encoding='utf-8') as f:
+                    f.write(interpolated)
+                # Status message to stderr (won't interfere with pipes)
+                sys.stderr.write(f"Interpolated file written to: {output_path}\n")
+            except PermissionError:
+                raise KsmCliException(f"Permission denied writing to: {output_path}")
+            except OSError as err:
+                raise KsmCliException(f"Failed to write output file: {err}")
+        else:
+            # Content to stdout (for eval/source/pipes)
+            # Use sys.stdout.write to preserve exact content (no added newlines)
+            sys.stdout.write(interpolated)

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 # Version set in the keeper_secrets_manager_cli.version file.
 setup(
     name="keeper-secrets-manager-cli",
-    version="1.1.7",
+    version="1.2.0",
     description="Command line tool for Keeper Secrets Manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/integration/keeper_secrets_manager_cli/tests/interpolate_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/interpolate_test.py
@@ -1,0 +1,601 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+from conftest import CliRunner
+import tempfile
+import re
+
+from keeper_secrets_manager_core.core import SecretsManager
+from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
+from keeper_secrets_manager_core import mock
+from keeper_secrets_manager_core.mock import MockConfig
+from keeper_secrets_manager_cli.__main__ import cli
+from keeper_secrets_manager_cli.profile import Profile
+
+
+class InterpolateTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.orig_dir = os.getcwd()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.temp_dir.name)
+        self.delete_me = []
+
+    def tearDown(self) -> None:
+        os.chdir(self.orig_dir)
+
+        # Manually delete temp files to avoid issues
+        for item in self.delete_me:
+            try:
+                os.unlink(item)
+            except:
+                pass
+
+    def test_interpolate_basic(self):
+        """Test basic file interpolation to stdout"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "SecretPassword123")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create temp file with notation
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"PASSWORD=keeper://{record.uid}/field/password\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "PASSWORD=SecretPassword123" in result.output
+            assert "keeper://" not in result.output
+
+    def test_interpolate_output_file(self):
+        """Test interpolate and save to file"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("login", "testuser")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create input file
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"USER=keeper://{record.uid}/field/login\n")
+                input_path = f.name
+                self.delete_me.append(input_path)
+
+            # Create output file path
+            output_path = os.path.join(self.temp_dir.name, 'output.env')
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', input_path, '--output', output_path])
+
+            assert result.exit_code == 0
+            assert os.path.exists(output_path)
+
+            with open(output_path, 'r') as f:
+                content = f.read()
+                assert "USER=testuser" in content
+                assert "keeper://" not in content
+
+    def test_interpolate_env_format(self):
+        """Test with KEY=value format"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "Pass123")
+        record.field("login", "User123")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create env file with multiple entries
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"DB_PASSWORD=keeper://{record.uid}/field/password\n")
+                f.write(f"DB_USER=keeper://{record.uid}/field/login\n")
+                f.write("DB_HOST=localhost\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "DB_PASSWORD=Pass123" in result.output
+            assert "DB_USER=User123" in result.output
+            assert "DB_HOST=localhost" in result.output
+
+    def test_interpolate_multiple_notations(self):
+        """Test multiple secrets in one file"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res1 = mock.Response()
+        record1 = res1.add_record(title="Record 1")
+        record1.field("password", "Secret1")
+
+        res2 = mock.Response()
+        record2 = res2.add_record(title="Record 2")
+        record2.field("password", "Secret2")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res1)
+        queue.add_response(res1)
+        queue.add_response(res2)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with multiple different notations
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"SECRET1=keeper://{record1.uid}/field/password\n")
+                f.write(f"SECRET2=keeper://{record2.uid}/field/password\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "SECRET1=Secret1" in result.output
+            assert "SECRET2=Secret2" in result.output
+
+    def test_interpolate_mixed_content(self):
+        """Test mix of notation and regular text"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "MySecret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with mixed content
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as f:
+                f.write("# Configuration file\n")
+                f.write(f"password=keeper://{record.uid}/field/password\n")
+                f.write("# End of config\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "# Configuration file" in result.output
+            assert "password=MySecret" in result.output
+            assert "# End of config" in result.output
+
+    def test_interpolate_caching(self):
+        """Verify caching reduces SDK calls"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "CachedSecret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)  # Only one additional call despite multiple notations
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with same notation repeated
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                notation = f"keeper://{record.uid}/field/password"
+                f.write(f"VAR1={notation}\n")
+                f.write(f"VAR2={notation}\n")
+                f.write(f"VAR3={notation}\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            # All three should have the value
+            assert result.output.count("CachedSecret") == 3
+
+    def test_interpolate_invalid_notation(self):
+        """Handle malformed notation gracefully"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "ValidSecret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with invalid and valid notation
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write("INVALID=keeper://invalid\n")
+                f.write(f"VALID=keeper://{record.uid}/field/password\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            # Should continue despite invalid notation
+            assert result.exit_code == 0 or "VALID=ValidSecret" in result.output
+
+    def test_interpolate_missing_file(self):
+        """Error on non-existent input file"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', '/nonexistent/file.env'])
+
+            # Should fail with appropriate error
+            assert result.exit_code != 0
+
+    def test_interpolate_empty_file(self):
+        """Handle empty file"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create empty file
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert result.output == ""
+
+    def test_interpolate_no_notation(self):
+        """File with no keeper:// patterns"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with no notation
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write("PLAIN_VAR=plain_value\n")
+                f.write("ANOTHER_VAR=another_value\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "PLAIN_VAR=plain_value" in result.output
+            assert "ANOTHER_VAR=another_value" in result.output
+
+    def test_interpolate_custom_fields(self):
+        """Test custom field notation"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.custom_field("api_key", "CustomSecret123")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with custom field notation
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"API_KEY=keeper://{record.uid}/custom_field/api_key\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "API_KEY=CustomSecret123" in result.output
+
+    def test_interpolate_unicode(self):
+        """Test file with non-ASCII characters"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "Пароль123")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with unicode content
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env', encoding='utf-8') as f:
+                f.write(f"# Комментарий\n")
+                f.write(f"PASSWORD=keeper://{record.uid}/field/password\n")
+                f.write("ДРУГОЕ=значение\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "Пароль123" in result.output
+            assert "Комментарий" in result.output
+
+    def test_interpolate_quoted_notation(self):
+        """Test notation inside quotes"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "QuotedSecret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with quoted notation
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f'VAR1="keeper://{record.uid}/field/password"\n')
+                f.write(f"VAR2='keeper://{record.uid}/field/password'\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            # Quotes should be preserved, notation replaced
+            assert 'VAR1="QuotedSecret"' in result.output
+            assert "VAR2='QuotedSecret'" in result.output
+
+    def test_interpolate_binary_file(self):
+        """Test rejection of binary files"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create binary file (PNG header)
+            with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.png') as f:
+                f.write(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR')
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            # Should fail with encoding error
+            assert result.exit_code != 0
+            assert "UTF-8" in result.output or "encoding" in result.output.lower()
+
+    def test_interpolate_preserves_newlines(self):
+        """Test that file ending is preserved"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "Secret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Test file WITH trailing newline
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"VAR=keeper://{record.uid}/field/password\n")
+                temp_path1 = f.name
+                self.delete_me.append(temp_path1)
+
+            # Test file WITHOUT trailing newline
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"VAR=keeper://{record.uid}/field/password")
+                temp_path2 = f.name
+                self.delete_me.append(temp_path2)
+
+            runner = CliRunner()
+            result1 = runner.invoke(cli, ['interpolate', temp_path1])
+            result2 = runner.invoke(cli, ['interpolate', temp_path2])
+
+            assert result1.exit_code == 0
+            assert result2.exit_code == 0
+            # First should end with newline, second should not
+            assert result1.output.endswith('\n')
+            assert not result2.output.endswith('\n') or result2.output == "VAR=Secret"
+
+    def test_interpolate_large_file(self):
+        """Test performance with large file"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("password", "Secret")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create large file (1000 lines) with notation scattered throughout
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                for i in range(1000):
+                    if i % 100 == 0:
+                        f.write(f"SECRET_{i}=keeper://{record.uid}/field/password\n")
+                    else:
+                        f.write(f"VAR_{i}=value_{i}\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            # Should have 10 secrets replaced
+            assert result.output.count("Secret") == 10
+
+    def test_interpolate_custom_field_with_spaces(self):
+        """Test custom field with spaces in label"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.custom_field("My Custom Field", "CustomValueWithSpaces123")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with custom field that has spaces in the label
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"FIELD_WITH_SPACES=keeper://{record.uid}/custom_field/My Custom Field\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "FIELD_WITH_SPACES=CustomValueWithSpaces123" in result.output
+            assert "keeper://" not in result.output
+
+    def test_interpolate_caching_efficiency(self):
+        """Test caching reduces redundant SDK calls"""
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+        res = mock.Response()
+        record = res.add_record(title="Test Record")
+        record.field("login", "user")
+        record.field("password", "pass")
+        record.field("host", "localhost")
+
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+        queue.add_response(res)
+
+        with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client:
+            mock_client.return_value = secrets_manager
+
+            Profile.init(token='MY_TOKEN')
+
+            # Create file with multiple fields from same record
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.env') as f:
+                f.write(f"USER=keeper://{record.uid}/field/login\n")
+                f.write(f"PASS=keeper://{record.uid}/field/password\n")
+                f.write(f"HOST=keeper://{record.uid}/field/host\n")
+                temp_path = f.name
+                self.delete_me.append(temp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ['interpolate', temp_path])
+
+            assert result.exit_code == 0
+            assert "USER=user" in result.output
+            assert "PASS=pass" in result.output
+            assert "HOST=localhost" in result.output
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Release/tool/cli/v1.2.0

### Summary

Adds new `ksm interpolate` command to KSM CLI v1.2.0.

closes #543 
MINOR version bump: 1.1.7 → 1.2.0

### Solution

New `ksm interpolate` command that reads files, replaces all keeper:// notation with actual secret values, and outputs the result to stdout or a file. This enables users to leverage standard shell mechanisms (eval, process substitution) to load secrets.

### Usage Examples

**Main use case (solves #543):**
```bash
# Load environment file into shell
eval "$(ksm interpolate secrets.env)"

# Or using process substitution
source <(ksm interpolate secrets.env)
```

**Other use cases:**
```bash
# Output to stdout
ksm interpolate secrets.env

# Save to file
ksm interpolate secrets.env --output /tmp/resolved.env
ksm interpolate config.yaml -o config.yaml

# Use in shell mode
ksm shell
> interpolate secrets.env
```

### Example Input/Output

**Input file (secrets.env):**
```bash
DATABASE_PASSWORD=keeper://abc123xyz/field/password
DATABASE_USER=keeper://abc123xyz/field/login
API_KEY=keeper://def456uvw/custom_field/My Custom Field
# Comment with keeper://fake/notation - preserved, not processed
APP_NAME=my-app
```

**Output:**
```bash
DATABASE_PASSWORD=MySecretP@ssw0rd
DATABASE_USER=admin@database.com
API_KEY=CustomFieldValueHere
# Comment with keeper://fake/notation - preserved, not processed
APP_NAME=my-app
```
