### PR TITLE
fix: correct security error misclassification in interpolate command

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
@@ -563,7 +563,14 @@ class Interpolate:
                     else:
                         # Better error message with suggestions (inlined for simplicity)
                         error_str = str(e).lower()
-                        if "not found" in error_str:
+
+                        # Check for security errors FIRST (before generic "access" check)
+                        # Security errors contain "access" in "Keeper write access" which would
+                        # cause false matches with the "access denied" check below
+                        if "security error" in error_str:
+                            # Show security errors as-is (they already have detailed explanations)
+                            error_msg = f"Line {line_num}: {str(e)}"
+                        elif "not found" in error_str:
                             if "record" in error_str:
                                 error_msg = f"Line {line_num}: Record '{uid}' not found (check UID and sharing)"
                             else:


### PR DESCRIPTION
When passwords contained shell metacharacters (backtick, dollar sign, etc.), the security error was incorrectly displayed as "Access denied" instead of showing the actual security warning.

Root cause: The error handler checked for "access" keyword in exception messages, but security errors contain "Keeper write access" which triggered a false match.

Fix: Check for "security error" keyword BEFORE checking for generic "access" keyword to prevent misclassification.

Changes:
- interpolate.py: Added security error check before access check (line 570)
- interpolate_test.py: Added 3 regression tests in TestBugFixes class
  - test_security_error_not_misclassified_as_access_denied
  - test_all_dangerous_chars_show_security_error
  - test_real_access_denied_still_works

All 22 tests pass. No breaking changes or security regressions.