### PR TITLE
KSM-660 - Handle broken encryption in records, folders and files

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1134,24 +1134,36 @@ private fun fetchAndDecryptSecrets(
     val records: MutableList<KeeperRecord> = mutableListOf()
     if (response.records != null) {
         response.records.forEach {
-            val recordKey = decrypt(it.recordKey, appKey)
-            val decryptedRecord = decryptRecord(it, recordKey, options)
-            if (decryptedRecord != null) {
-                records.add(decryptedRecord)
+            try {
+                val recordKey = decrypt(it.recordKey, appKey)
+                val decryptedRecord = decryptRecord(it, recordKey, options)
+                if (decryptedRecord != null) {
+                    records.add(decryptedRecord)
+                }
+            } catch (e: Exception) {
+                System.err.println("Record ${it.recordUid} skipped due to error: ${e.javaClass.simpleName}, ${e.message}")
             }
         }
     }
     if (response.folders != null) {
         response.folders.forEach { folder ->
-            val folderKey = decrypt(folder.folderKey, appKey)
-            folder.records!!.forEach { record ->
-                val recordKey = decrypt(record.recordKey, folderKey)
-                val decryptedRecord = decryptRecord(record, recordKey, options)
-                if (decryptedRecord != null) {
-                    decryptedRecord.folderUid = folder.folderUid
-                    decryptedRecord.folderKey = folderKey
-                    records.add(decryptedRecord)
+            try {
+                val folderKey = decrypt(folder.folderKey, appKey)
+                folder.records!!.forEach { record ->
+                    try {
+                        val recordKey = decrypt(record.recordKey, folderKey)
+                        val decryptedRecord = decryptRecord(record, recordKey, options)
+                        if (decryptedRecord != null) {
+                            decryptedRecord.folderUid = folder.folderUid
+                            decryptedRecord.folderKey = folderKey
+                            records.add(decryptedRecord)
+                        }
+                    } catch (e: Exception) {
+                        System.err.println("Record ${record.recordUid} in folder ${folder.folderUid} skipped due to error: ${e.javaClass.simpleName}, ${e.message}")
+                    }
                 }
+            } catch (e: Exception) {
+                System.err.println("Folder ${folder.folderUid} skipped due to error: ${e.javaClass.simpleName}, ${e.message}")
             }
         }
     }
@@ -1175,17 +1187,21 @@ private fun decryptRecord(record: SecretsManagerResponseRecord, recordKey: ByteA
 
     if (record.files != null) {
         record.files.forEach {
-            val fileKey = decrypt(it.fileKey, recordKey)
-            val decryptedFile = decrypt(it.data, fileKey)
-            files.add(
-                KeeperFile(
-                    fileKey,
-                    it.fileUid,
-                    Json.decodeFromString(bytesToString(decryptedFile)),
-                    it.url,
-                    it.thumbnailUrl
+            try {
+                val fileKey = decrypt(it.fileKey, recordKey)
+                val decryptedFile = decrypt(it.data, fileKey)
+                files.add(
+                    KeeperFile(
+                        fileKey,
+                        it.fileUid,
+                        Json.decodeFromString(bytesToString(decryptedFile)),
+                        it.url,
+                        it.thumbnailUrl
+                    )
                 )
-            )
+            } catch (e: Exception) {
+                System.err.println("File ${it.fileUid} skipped due to error: ${e.javaClass.simpleName}, ${e.message}")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #816

Add error handling to gracefully skip records, folders, and files with broken encryption instead of failing the entire request. This matches the Python SDK implementation from KSM-529.

- Wrap decryption operations in try-catch blocks
- Log errors for skipped items
- Continue processing valid items
- Return partial results successfully