### PR TITLE
Fix file permissions for Rust SDK config files

### DIFF
--- a/sdk/rust/src/storage.rs
+++ b/sdk/rust/src/storage.rs
@@ -230,13 +230,36 @@ impl KeyValueStorage for FileKeyValueStorage {
         // Check if the configuration file exists, if not, create it.
         let config_path = Path::new(&self.config_file_location);
         if !config_path.exists() {
-            let mut file = File::create(config_path)
-                .map_err(|e| KSMRError::FileCreationError(config_path.display().to_string(), e))?;
+            // Create file with secure permissions (0600) on Unix
+            #[cfg(unix)]
+            {
+                use std::fs::OpenOptions;
+                use std::os::unix::fs::OpenOptionsExt;
 
-            // Attempt to write an empty JSON object to the file
-            let empty_json_string = b"{}";
-            file.write_all(empty_json_string)
-                .map_err(|e| KSMRError::FileWriteError(config_path.display().to_string(), e))?;
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .mode(0o600)
+                    .open(config_path)
+                    .map_err(|e| KSMRError::FileCreationError(config_path.display().to_string(), e))?;
+
+                // Attempt to write an empty JSON object to the file
+                let empty_json_string = b"{}";
+                file.write_all(empty_json_string)
+                    .map_err(|e| KSMRError::FileWriteError(config_path.display().to_string(), e))?;
+            }
+
+            // On Windows, use default file creation (no POSIX permissions)
+            #[cfg(not(unix))]
+            {
+                let mut file = File::create(config_path)
+                    .map_err(|e| KSMRError::FileCreationError(config_path.display().to_string(), e))?;
+
+                // Attempt to write an empty JSON object to the file
+                let empty_json_string = b"{}";
+                file.write_all(empty_json_string)
+                    .map_err(|e| KSMRError::FileWriteError(config_path.display().to_string(), e))?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
  Jira: https://keeper.atlassian.net/browse/KSM-700

  Problem

  The Rust SDK created configuration files (client-config.json) with default permissions (0644 - world-readable) on Unix systems, exposing sensitive
  credentials to all users:

```rust
  let mut file = OpenOptions::new()
      .write(true)
      .create(true)
      .open(config_path)?;
  // No mode specified - defaults to 0644
```

  Changes

  File: sdk/rust/src/storage.rs (lines 233-263)

  Implementation:
  - Added .mode(0o600) to OpenOptions for Unix systems
  - Used conditional compilation to handle platform differences:
    - #[cfg(unix)]: Applies secure permissions using OpenOptionsExt trait
    - #[cfg(not(unix))]: Uses standard File::create() for Windows (relies on OS defaults)
  - Imported std::os::unix::fs::OpenOptionsExt trait for Unix mode support

  Security Impact

  Before: 0644 = rw-r--r-- (owner rw, group/others read)
  After: 0600 = rw------- (owner read/write only)

  Config files now created with owner-only permissions on Unix systems, preventing unauthorized access to sensitive credentials (privateKey, appKey,
  clientId, hostname, serverPublicKeyId).

  Testing

  - Ran full test suite: cargo test
  - 1 pre-existing doctest failure (unrelated - documentation example has type mismatch, not a security or runtime issue)

  Platform Support

  - Unix/Linux/macOS: Secure permissions enforced atomically during file creation
  - Windows: Uses OS default permissions (typically restrictive for newly created files)

  Additional Notes

  - No breaking API changes
  - Purely internal security improvement
  - Conditional compilation ensures cross-platform compatibility
  - Atomic permission setting prevents race conditions