### PR TITLE
Fix file permissions for Ruby SDK config files

### DIFF
--- a/sdk/ruby/lib/keeper_secrets_manager/storage.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/storage.rb
@@ -160,14 +160,15 @@ module KeeperSecretsManager
 
         # Write atomically to avoid corruption
         temp_file = "#{@filename}.tmp"
-        File.open(temp_file, 'w') do |f|
+        # Create temp file with secure permissions (0600)
+        File.open(temp_file, 'w', 0o600) do |f|
           f.write(JSON.pretty_generate(@data))
         end
 
         # Move atomically
         File.rename(temp_file, @filename)
 
-        # Set restrictive permissions (owner read/write only)
+        # Ensure final file has restrictive permissions (owner read/write only)
         File.chmod(0o600, @filename)
       rescue StandardError => e
         raise Error, "Failed to save config file: #{e.message}"


### PR DESCRIPTION
Jira: https://keeper.atlassian.net/browse/KSM-696

  Problem

  The Ruby SDK used an atomic file write pattern (write to temp file, then rename) but created the temporary file with default permissions (0644 -
  world-readable), exposing sensitive credentials during the write operation:

```ruby
  File.open(temp_file, 'w') do |f|
    f.write(JSON.pretty_generate(@data))
  end
```

  This creates a race condition window where credentials are world-readable between temp file creation and the final rename.

  Changes

  File: sdk/ruby/lib/keeper_secrets_manager/storage.rb (line 164)

  Implementation:
  # Create temp file with secure permissions (0600)
  File.open(temp_file, 'w', 0o600) do |f|
    f.write(JSON.pretty_generate(@data))
  end

  - Added third parameter 0o600 to File.open() for atomic permission setting
  - Permissions set during creation (no race condition)
  - Ruby's atomic rename pattern now secure throughout entire operation

  Security Impact

  Before: 0644 = rw-r--r-- (owner rw, group/others read) with race condition
  After: 0600 = rw------- (owner read/write only) set atomically

  Config files now created with owner-only permissions from the moment of creation, eliminating the race condition window where credentials could be
  exposed.

  Testing

  - Ran full test suite: bundle exec rake spec
  - 311 examples, 0 failures, 13 pending 
  - Comprehensive coverage:
    - File operations, folder hierarchy, TOTP, caching
    - Cryptography, notation parsing, storage backends
    - Password generation, convenience methods
  - 13 pending tests are intentionally skipped (require real API, marked "Skipping in mock mode")