### PR TITLE
Add urllib3>=2.6.0 requirement to keep core secure (#878)

### DIFF
--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -4,6 +4,9 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
+## 17.1.0
+* Added an explicit dependency on `urllib3` to align with upstream requirements.
+
 ## 17.0.0
 * KSM-566 - Added parsing for KSM tokens with prefix
 * KSM-631 - Added links2Remove parameter for files removal

--- a/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
+++ b/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
@@ -19,7 +19,7 @@ def get_client_version(hardcode=False):
     """Get the version of the client
 
     The version # comes from metadata. In a unit test, there is metadata, so the version will
-    be the defined major and 0.0 (ie 17.0.0.).
+    be the defined major and 0.0 (ie 17.1.0.).
 
     If installed, the method can get the real version number. For the client version number
     we use the defined major and minor and revision numbers of the module version.
@@ -31,7 +31,9 @@ def get_client_version(hardcode=False):
     """
     # Get the version of the keeper secrets manager core
     version_major = "17"
-    version = "{}.0.0".format(version_major)
+    version_minor_default = "1"
+    version_revision_default = "0"
+    version = "{}.{}.{}".format(version_major, version_minor_default, version_revision_default)
 
     # Allow the default version to be hard coded. If not build the client version from the module
     # version.

--- a/sdk/python/core/requirements.txt
+++ b/sdk/python/core/requirements.txt
@@ -2,3 +2,4 @@ cryptography>=39.0.1
 requests>=2.28.2
 pytest>=7.2.1
 importlib_metadata>=6.0.0
+urllib3>=2.6.0

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -13,12 +13,13 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
 install_requires = [
     'requests',
     'cryptography>=39.0.1',
-    'importlib_metadata'
+    'importlib_metadata',
+    'urllib3>=2.6.0',
 ]
 
 setup(
     name="keeper-secrets-manager-core",
-    version="17.0.0",
+    version="17.1.0",
     description="Keeper Secrets Manager for Python 3",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -202,4 +202,4 @@ class SmokeTest(unittest.TestCase):
             self.assertEqual("17.2.24", client_version, "did not get the correct client version from 0.2.24")
 
         client_version = get_client_version(hardcode=True)
-        self.assertEqual("17.0.0", client_version, "did not get the correct client version for hardcoded")
+        self.assertEqual("17.1.0", client_version, "did not get the correct client version for hardcoded")


### PR DESCRIPTION
This highlights the dependency change and ties it directly to Issue #878.