### PR TITLE
KSM-724 Fixed duplicate UID issue with GetNotation

### DIFF
--- a/sdk/dotNet/SecretsManager.Test.Core/SecretsManager.Test.Core.csproj
+++ b/sdk/dotNet/SecretsManager.Test.Core/SecretsManager.Test.Core.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="NUnit" Version="4.3.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.0.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -22,9 +22,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.1" />
-      <PackageReference Include="System.Text.Json" Version="9.0.7" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.7" />
+      <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
+      <PackageReference Include="System.Text.Json" Version="10.0.1" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="10.0.1" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(SignKSM)'=='True'">


### PR DESCRIPTION
- fixed duplicate UID issue with GetNotation
- updated package dependencies

Resolves [Issue#881](https://github.com/Keeper-Security/secrets-manager/issues/881) _(after upgrading the PowerShell module to use the latest SDK - no need to update Octopus Deploy, not anchored to a specific version and should pick latest)_