### PR TITLE
KSM-734: Fix notation lookup with record shortcuts (Ruby)

### DIFF
--- a/sdk/ruby/lib/keeper_secrets_manager/notation.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/notation.rb
@@ -44,6 +44,10 @@ module KeeperSecretsManager
           records = all_records.select { |r| r.title == record_token }
         end
 
+        # Remove duplicate UIDs - shortcuts/linked records both shared to same KSM App
+        records = records.uniq { |r| r.uid } if records.size > 1
+
+        # Now check for genuine ambiguity (different records with same title)
         raise NotationError, "Multiple records match '#{record_token}'" if records.size > 1
         raise NotationError, "No records match '#{record_token}'" if records.empty?
 


### PR DESCRIPTION
## Summary

Fix notation lookup failure when record shortcuts exist in Ruby SDK (same issue as #881 for .NET).

## Problem

When a KSM application has access to both an original record and its shortcut, the same UID appears multiple times in the records list, causing notation lookup to fail with an ambiguity error.

## Solution

Deduplicate records by UID before checking for ambiguity. Multiple references to the same UID (due to shortcuts) are not genuinely ambiguous since they point to the same underlying record.

## Changes

- Add deduplication logic using `uniq { |r| r.uid }` in notation.rb
- Preserve genuine ambiguity check for different records with same title
- Add test case for duplicate UID handling in notation_spec.rb

## Testing

- Added unit test in `notation_spec.rb` for duplicate UID scenario
- Existing tests continue to pass

## Related Issues

Addresses #881

## Files Changed

- `sdk/ruby/lib/keeper_secrets_manager/notation.rb` (+4 lines)
- `sdk/ruby/spec/keeper_secrets_manager/unit/notation_spec.rb` (+22 lines test)