### PR TITLE
KSM-741: add transmission public key #18 for Gov Cloud Dev support

### DIFF
--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -1418,7 +1418,8 @@ namespace SecretsManager
                     "BJFF8j-dH7pDEw_U347w2CBM6xYM8Dk5fPPAktjib-opOqzvvbsER-WDHM4ONCSBf9O_obAHzCyygxmtpktDuiE",
                     "BDKyWBvLbyZ-jMueORl3JwJnnEpCiZdN7yUvT0vOyjwpPBCDf6zfL4RWzvSkhAAFnwOni_1tQSl8dfXHbXqXsQ8",
                     "BDXyZZnrl0tc2jdC5I61JjwkjK2kr7uet9tZjt8StTiJTAQQmnVOYBgbtP08PWDbecxnHghx3kJ8QXq1XE68y8c",
-                    "BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU"
+                    "BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU",
+                    "BNhngQqTT1bPKxGuB6FhbPTAeNVFl8PKGGSGo5W06xWIReutm6ix6JPivqnbvkydY-1uDQTr-5e6t70G01Bb5JA"
                 }
                 .ToDictionary(_ => keyId++, CryptoUtils.WebSafe64ToBytes);
         }


### PR DESCRIPTION
## Summary

Adds transmission public key #18 to enable .NET SDK connectivity to Gov Cloud Dev environment.

## Changes

• Added public key #18 to SecretsManagerClient.cs InitKeeperKeys() array (line 1422)

## Technical Details

Gov Cloud Dev environment ( govcloud.dev.keepersecurity.us ) is configured with transmission public key ID 18. The SDK previously only supported keys 7-17, causing connection failures with error "Key number 18 is not supported".