### PR TITLE
KSM-742: add transmission public key #18 for Gov Cloud Dev support

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.1.3"
+version = "17.1.4"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.*
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.1.3"
+const val KEEPER_CLIENT_VERSION = "mj17.1.4"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
@@ -1581,7 +1581,8 @@ private val keeperPublicKeys = listOf(
     "BJFF8j-dH7pDEw_U347w2CBM6xYM8Dk5fPPAktjib-opOqzvvbsER-WDHM4ONCSBf9O_obAHzCyygxmtpktDuiE",
     "BDKyWBvLbyZ-jMueORl3JwJnnEpCiZdN7yUvT0vOyjwpPBCDf6zfL4RWzvSkhAAFnwOni_1tQSl8dfXHbXqXsQ8",
     "BDXyZZnrl0tc2jdC5I61JjwkjK2kr7uet9tZjt8StTiJTAQQmnVOYBgbtP08PWDbecxnHghx3kJ8QXq1XE68y8c",
-    "BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU"
+    "BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU",
+    "BNhngQqTT1bPKxGuB6FhbPTAeNVFl8PKGGSGo5W06xWIReutm6ix6JPivqnbvkydY-1uDQTr-5e6t70G01Bb5JA"
 ).associateBy({ keyId++ }, { webSafe64ToBytes(it) })
 
 private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {


### PR DESCRIPTION
## Summary

Adds transmission public key #18 to enable Java SDK connectivity to Gov Cloud Dev environment.

## Changes

• Added public key #18 to SecretsManager.kt keeperPublicKeys list (line 1585)
• Bumped version from 17.1.3 → 17.1.4 in build.gradle.kts (line 8)
• Updated KEEPER_CLIENT_VERSION from "mj17.1.3" → "mj17.1.4" in SecretsManager.kt (line 22)

## Technical Details

Gov Cloud Dev environment ( govcloud.dev.keepersecurity.us ) is configured with transmission public key ID 18. The SDK previously only supported keys 7-17, causing connection failures with error "Key number 18 is not supported".