### PR TITLE
KSM-743: add transmission public key #18 for Gov Cloud Dev support

### DIFF
--- a/sdk/ruby/lib/keeper_secrets_manager/keeper_globals.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/keeper_globals.rb
@@ -28,7 +28,8 @@ module KeeperSecretsManager
       '14' => 'BJFF8j-dH7pDEw_U347w2CBM6xYM8Dk5fPPAktjib-opOqzvvbsER-WDHM4ONCSBf9O_obAHzCyygxmtpktDuiE',
       '15' => 'BDKyWBvLbyZ-jMueORl3JwJnnEpCiZdN7yUvT0vOyjwpPBCDf6zfL4RWzvSkhAAFnwOni_1tQSl8dfXHbXqXsQ8',
       '16' => 'BDXyZZnrl0tc2jdC5I61JjwkjK2kr7uet9tZjt8StTiJTAQQmnVOYBgbtP08PWDbecxnHghx3kJ8QXq1XE68y8c',
-      '17' => 'BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU'
+      '17' => 'BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU',
+      '18' => 'BNhngQqTT1bPKxGuB6FhbPTAeNVFl8PKGGSGo5W06xWIReutm6ix6JPivqnbvkydY-1uDQTr-5e6t70G01Bb5JA'
     }.freeze
 
     # Keeper servers by region


### PR DESCRIPTION
## Summary

Adds transmission public key #18 to enable Ruby SDK connectivity to Gov Cloud Dev environment.

## Changes

• Added public key #18 to keeper_globals.rb KEEPER_PUBLIC_KEYS hash (line 32)

## Technical Details

Gov Cloud Dev environment ( govcloud.dev.keepersecurity.us ) is configured with transmission public key ID 18. The SDK previously only supported keys 1-17, causing connection failures with error "Key number 18 is not supported".