### PR TITLE
KSM-731: Fix notation lookup with record shortcuts (duplicate UID bug)

### DIFF
--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -839,8 +839,15 @@ export const getNotationResults = async (options: SecretManagerOptions, notation
     if (/^[A-Za-z0-9_-]{22}$/.test(recordToken)) {
         const secrets = await getSecrets(options, [recordToken])
         records = secrets.records
-        if (records.length > 1)
-            throw new Error(`Notation error - found multiple records with same UID '${recordToken}'`)
+        // Remove duplicate UIDs - shortcuts/linked records both shared to same KSM App
+        if (records.length > 1) {
+            const seen = new Set<string>()
+            records = records.filter(r => {
+                if (seen.has(r.recordUid)) return false
+                seen.add(r.recordUid)
+                return true
+            })
+        }
     }
 
     // If RecordUID is not found - pull all records and search by title


### PR DESCRIPTION
Fixes notation lookup failure when KSM application has access to both a record and its shortcut.

**JIRA**: [KSM-731](https://keeper.atlassian.net/browse/KSM-731)
**GitHub Issue**: #881
**Reference PR**: #883 (.NET fix)

## Problem

When multiple records share the same UID (shortcuts/linked records), notation-based retrieval throws "Notation error - found multiple records with same UID" even though the UIDs are identical (not ambiguous).

## Solution

- Remove duplicate UID exception for UID-based lookups
- Add deduplication logic using `Set` to keep one record per unique UID
- Preserve "multiple records" check for title-based lookups (genuinely ambiguous)

## Changes

**File**: `sdk/javascript/packages/core/src/keeper.ts` (line 842)

```typescript
// Remove duplicate UIDs - shortcuts/linked records both shared to same KSM App
if (records.length > 1) {
    const seen = new Set<string>()
    records = records.filter(r => {
        if (seen.has(r.recordUid)) return false
        seen.add(r.recordUid)
        return true
    })
}
```

## Testing

- ✅ Added test case `getValue handles duplicate UIDs (shortcuts/linked records)` in `test/notation.test.ts`
- ✅ Test creates two records with identical UID and verifies notation resolution succeeds
- ✅ All existing tests pass
- ✅ Test would fail if deduplication logic is removed

## Files Changed

- `sdk/javascript/packages/core/src/keeper.ts` - Added deduplication before ambiguity check
- `sdk/javascript/packages/core/test/notation.test.ts` - Added test case for shortcuts

Resolves #881

[KSM-731]: https://keeper.atlassian.net/browse/KSM-731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ