### PR TITLE
KSM-733: Fix notation lookup with record shortcuts (duplicate UID bug)

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -873,8 +873,10 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
     if (recordToken.matches(Regex("""^[A-Za-z0-9_-]{22}$"""))) {
         val secrets = getSecrets(options, listOf<String>(recordToken))
         records = secrets.records
-        if (records.size > 1)
-            throw Exception("Notation error - found multiple records with same UID '$recordToken'")
+        // Remove duplicate UIDs - shortcuts/linked records both shared to same KSM App
+        if (records.size > 1) {
+            records = records.distinctBy { it.recordUid }
+        }
     }
 
     // If RecordUID is not found - pull all records and search by title


### PR DESCRIPTION
Fixes notation lookup failure when KSM application has access to both a record and its shortcut.

**JIRA**: [KSM-733](https://keeper.atlassian.net/browse/KSM-733)
**GitHub Issue**: #881
**Reference PR**: #883 (.NET fix)

## Problem

When multiple records share the same UID (shortcuts/linked records), notation-based retrieval throws "Notation error - found multiple records with same UID" even though the UIDs are identical (not ambiguous).

## Solution

- Remove duplicate UID exception for UID-based lookups
- Add deduplication logic using Kotlin's `distinctBy` to keep one record per unique UID
- Preserve "multiple records" check for title-based lookups (genuinely ambiguous)

## Changes

**File**: `sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt` (line 877)

```kotlin
// Remove duplicate UIDs - shortcuts/linked records both shared to same KSM App
if (records.size > 1) {
    records = records.distinctBy { it.recordUid }
}
```

## Testing

- ✅ Added test case `handlesDuplicateUIDs` in `sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/NotationTest.kt`
- ✅ Test creates two `KeeperRecord` objects with identical UID
- ✅ Verifies notation resolution via `getValue()` succeeds
- ✅ All existing tests pass
- ✅ Test documents expected behavior for duplicate UIDs

## Files Changed

- `sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt` - Added deduplication before ambiguity check
- `sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/NotationTest.kt` - Added test case for shortcuts

Resolves #881

[KSM-733]: https://keeper.atlassian.net/browse/KSM-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ