### PR TITLE
KSM-751: Fix Azure Storage documentation and remove malformed SBOM file

### DIFF
--- a/sdk/javascript/packages/azure/README.md
+++ b/sdk/javascript/packages/azure/README.md
@@ -122,17 +122,17 @@ azure_keyvault_example_custom.ts
 
 ## decrypt config
 
-To decrypt the config file and save it again in plaintext, you can call the `decryptConfig` method on the `OciKeyValueStorage` instance.
+To decrypt the config file and save it again in plaintext, you can call the `decryptConfig` method on the `AzureKeyValueStorage` instance.
 Note: this will compromise the security of the config file.
 ```
-    const storage = await new OciKeyValueStorage(keyId, keyVersionId, config_path, ociSessionConfig).init();
+    const storage = await new AzureKeyValueStorage(keyId, config_path, azureSessionConfig).init();
     await storage.decryptConfig(true); // Saves to file
     const decryptedConfig = await storage.decryptConfig(true); // returns the decrypted config
 ```
 
 
 ## Logging
-We support logging for the Oracle Key Vault integration. Supported log levels are as follows
+We support logging for the Azure Key Vault integration. Supported log levels are as follows
 * trace
 * debug
 * info

--- a/sdk/javascript/packages/azure/azure-storage-sbom.json
+++ b/sdk/javascript/packages/azure/azure-storage-sbom.json
@@ -1,8 +1,0 @@
-[0001] ERROR [31mcould not determine source: errors occurred attempting to resolve 'sdk/javascript/packages/azure':
-  - snap: snap file "sdk/javascript/packages/azure" does not exist
-  - docker: pull failed: Error response from daemon: pull access denied for sdk/javascript/packages/azure, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
-  - podman: podman not available: no host address
-  - containerd: containerd not available: no grpc connection or services is available: unavailable
-  - oci-registry: failed to get image descriptor from registry: GET https://index.docker.io/v2/sdk/javascript/packages/azure/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:sdk/javascript/packages/azure Type:repository]]
-  - snap: no snap found with name 'sdk/javascript/packages/azure'
-  - additionally, the following providers failed with file does not exist: docker-archive, oci-archive, oci-dir, singularity, oci-dir, local-file, local-directory[0m


### PR DESCRIPTION
## Summary
Fixes two critical issues in the Azure Key Vault Storage integration preventing v1.0.0 release:

1. **Removed malformed SBOM file** (`sdk/javascript/packages/azure/azure-storage-sbom.json`)
   - File contained scanner error messages instead of valid SBOM data
   - Scanner incorrectly attempted to treat npm package directory as Docker/OCI container
   - Would block security compliance checks in CI/CD
   - Correct SBOM is generated at root level by GitHub Actions workflow

2. **Fixed README documentation errors** (lines 125-141)
   - Replaced `OciKeyValueStorage` references with correct `AzureKeyValueStorage`
   - Fixed constructor parameters (removed Oracle-specific `keyVersionId`, `ociSessionConfig`)
   - Changed "Oracle Key Vault integration" to "Azure Key Vault integration"
   - Examples now copy-paste correctly without runtime errors

## Changes
- `sdk/javascript/packages/azure/README.md`: Corrected decrypt config section and logging documentation
- `sdk/javascript/packages/azure/azure-storage-sbom.json`: Removed malformed SBOM artifact

## Testing
- Manual review of README examples
- Verified SBOM generation happens correctly in workflow (`.github/workflows/publish.npm.storage.azure.kms.yml`)

## Related Issues
- Closes KSM-751
- Related to KSM-706 (Azure Key Vault Configuration Encryption Storage implementation)