### PR TITLE
KSM-762: fix CVE-2026-23949 (jaraco.context path traversal) in SBOM generation

### DIFF
--- a/.github/workflows/reusable.sbom.workflow.yml
+++ b/.github/workflows/reusable.sbom.workflow.yml
@@ -449,7 +449,10 @@ jobs:
             
             echo "Upgrading pip and installing build tools..."
             ./scan-venv/bin/pip install --upgrade pip setuptools wheel
-            
+
+            echo "Upgrading jaraco.context to fix CVE-2026-23949..."
+            ./scan-venv/bin/pip install --upgrade "jaraco.context>=6.1.0"
+
             echo "Installing package and all dependencies..."
             ./scan-venv/bin/pip install .
             


### PR DESCRIPTION
## Summary

Fixes CVE-2026-23949 by upgrading jaraco.context to 6.1.0+ in SBOM generation workflow.

## CVE Details

- **CVE ID**: CVE-2026-23949
- **GHSA ID**: GHSA-58pv-8j8x-9vj2
- **Severity**: HIGH (CVSS 8.6)
- **Issue**: Zip Slip path traversal vulnerability in jaraco.context < 6.1.0
- **Impact**: Build-time dependency only (not runtime), affects SBOM scans on Manifest Cyber
- **Fixed Version**: jaraco.context >= 6.1.0
- **Published**: 2026-01-20

## Changes

Updated `.github/workflows/reusable.sbom.workflow.yml` to explicitly upgrade jaraco.context after setuptools installation:

```yaml
echo "Upgrading jaraco.context to fix CVE-2026-23949..."
./scan-venv/bin/pip install --upgrade "jaraco.context>=6.1.0"
```

This ensures the SBOM generation environment uses the patched version.

## SBOM Verification

Tested locally with before/after SBOM comparison:

- **BEFORE**: jaraco-context 5.3.0 (vulnerable, CVE present)
- **AFTER**: jaraco-context 6.1.0 (fixed, CVE resolved)

The fix successfully removes CVE-2026-23949 from SBOM scans.

## Testing

To verify this fix in CI/CD:

1. Merge this PR to release branch
2. Trigger manual publish workflow (workflow_dispatch)
3. Check SBOM generation job logs for `jaraco.context 6.1.0`
4. Verify CVE-2026-23949 no longer appears in Manifest Cyber scans

## Related Tickets

- **Epic**: [KSM-759](https://keeper.atlassian.net/browse/KSM-759) - CVE-2026-23949: Fix jaraco.context path traversal vulnerability across KSM Python packages
- **Task**: [KSM-762](https://keeper.atlassian.net/browse/KSM-762) - Ansible Integration: CVE-2026-23949 - upgrade jaraco.context

## Compliance

Resolves 30-day compliance requirement for CVE-2026-23949 (published 2026-01-20).

[KSM-759]: https://keeper.atlassian.net/browse/KSM-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ