### PR TITLE
KSM-763: fix file upload/download SSL and proxy settings

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -634,13 +634,14 @@ class SecretsManager:
         return ksm_rs
 
     @staticmethod
-    def __upload_file_function(url, upload_parameters, encrypted_file_data, proxy_url=None):
+    def __upload_file_function(url, upload_parameters, encrypted_file_data, verify_ssl_certs=True, proxy_url=None):
         """Upload file to the server"""
         files = {'file': encrypted_file_data}
 
         rs = requests.post(url,
                            data=upload_parameters,
                            files=files,
+                           verify=verify_ssl_certs,
                            proxies=SecretsManager.__get_proxies(proxy_url)
                            )
 
@@ -1094,7 +1095,7 @@ class SecretsManager:
         parameters_dict = json_to_dict(parameters_json_str)
 
         self.logger.debug(f"Uploading file data: upload url=[{upload_url}], file name: [{file.Name}], encrypted file size: [{len(encrypted_file_data)}]")
-        upload_result = SecretsManager.__upload_file_function(upload_url, parameters_dict, encrypted_file_data, proxy_url=self.proxy_url)
+        upload_result = SecretsManager.__upload_file_function(upload_url, parameters_dict, encrypted_file_data, verify_ssl_certs=self.verify_ssl_certs, proxy_url=self.proxy_url)
 
         self.logger.debug(f"Finished uploading file data. Status code: {upload_result.get('statusCode')}, response data: {upload_result.get('data')}")
 
@@ -1280,7 +1281,7 @@ class SecretsManager:
             if len(files) < 1:
                 raise ValueError(f"Notation error - Record {record_token} has no files matching the search criteria '{parameter}'")
             if isinstance(files[0], KeeperFile):
-                return files[0].get_file_data()
+                return files[0].get_file_data(verify_ssl_certs=self.verify_ssl_certs, proxy_url=self.proxy_url)
             else:
                 raise ValueError(f"Notation error - Record {record_token} has corrupted KeeperFile data.")
         elif selector.lower() in ("field", "custom_field"):
@@ -1604,7 +1605,7 @@ class SecretsManager:
             if len(files) < 1:
                 raise ValueError(f"Notation error - Record {record_token} has no files matching the search criteria '{parameter}'")
             if isinstance(files[0], KeeperFile):
-                contents = files[0].get_file_data()
+                contents = files[0].get_file_data(verify_ssl_certs=self.verify_ssl_certs, proxy_url=self.proxy_url)
                 text = CryptoUtils.bytes_to_url_safe_str(contents)
                 result.append(text)
             else:

--- a/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
+++ b/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
@@ -373,7 +373,7 @@ class KeeperFile:
 
         return self.meta_dict
 
-    def get_file_data(self):
+    def get_file_data(self, verify_ssl_certs=True, proxy_url=None):
         """
         Return decrypted raw file data
         """
@@ -381,7 +381,8 @@ class KeeperFile:
             file_key = self.__decrypt_file_key()
             file_url = self.f.get('url')
 
-            rs = requests.get(file_url)
+            proxies = {"https": proxy_url} if proxy_url else None
+            rs = requests.get(file_url, verify=verify_ssl_certs, proxies=proxies)
 
             file_encrypted_data = rs.content
 
@@ -389,7 +390,7 @@ class KeeperFile:
 
         return self.file_data
 
-    def save_file(self, path, create_folders=False):
+    def save_file(self, path, create_folders=False, verify_ssl_certs=True, proxy_url=None):
         """
         Save decrypted file data to the provided path
         """
@@ -397,7 +398,7 @@ class KeeperFile:
         if create_folders:
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
-        file_data = self.get_file_data()
+        file_data = self.get_file_data(verify_ssl_certs=verify_ssl_certs, proxy_url=proxy_url)
 
         dir_path = os.path.dirname(os.path.abspath(path))
 


### PR DESCRIPTION
## Summary
Fixes file upload and download operations failing when using proxy with `verify_ssl_certs=False`.

## Problem
When using the Python SDK with a proxy server and `verify_ssl_certs=False`, file upload and download operations failed with SSL certificate verification errors because the SSL verification setting was not being passed to the underlying `requests` library calls.

## Root Cause
Three functions were not passing SSL/proxy settings:
1. `__upload_file_function` (core.py:637) - Missing `verify` parameter in `requests.post()`
2. `KeeperFile.get_file_data()` (dtos.py:376) - Missing both `verify` and `proxies` parameters in `requests.get()`
3. `KeeperFile.save_file()` (dtos.py:393) - Didn't pass parameters through to `get_file_data()`

## Solution
- Added `verify_ssl_certs` parameter to `__upload_file_function()` and pass to `requests.post()`
- Added `verify_ssl_certs` and `proxy_url` parameters to `KeeperFile.get_file_data()` and `save_file()`
- Updated all callers to pass these parameters from `SecretsManager` instance

## Testing
- ✅ All 57 unit tests pass (55 existing + 2 new)
- ✅ Added `test_verify_ssl_certs_passed_to_upload_file` - Verifies upload respects SSL settings
- ✅ Added `test_verify_ssl_certs_passed_to_file_download` - Verifies download respects SSL settings
- ✅ In vitro test: Verified both upload and download work through mitmproxy with `verify_ssl_certs=False`

## Files Changed
- `sdk/python/core/keeper_secrets_manager_core/core.py` - 9 lines changed
- `sdk/python/core/keeper_secrets_manager_core/dto/dtos.py` - 9 lines changed
- `sdk/python/core/tests/proxy_test.py` - Added 2 comprehensive tests

## Related
- Jira: KSM-763
- Related to: KSM-533 (Python SDK Proxy Support)
- Fix version: 17.1.0