### PR TITLE
KSM-769: fix(rust): support custom_field notation selector

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -3045,8 +3045,16 @@ impl SecretsManager {
                 KSMRError::NotationError("Notation error - Missing required parameter for the field (type or label): ex. /field/type or /custom_field/MyLabel.".to_string())
             })?;
 
+                // Determine which array to search based on selector
+                // Standard fields are in "fields", custom fields are in "custom"
+                let field_source = if selector.to_lowercase() == "custom_field" {
+                    "custom"
+                } else {
+                    "fields"
+                };
+
                 // Find the field in the record
-                let fields_option = record.record_dict.get("fields");
+                let fields_option = record.record_dict.get(field_source);
                 let fields = match fields_option {
                     Some(val) if val.is_array() => val.as_array().unwrap(),
                     _ => &Vec::new(),


### PR DESCRIPTION
Fix bug where `custom_field` notation always searched in wrong array. The Rust SDK was searching in `fields` array for both field and `custom_field` selectors. Custom fields are stored in `custom` array.

Changes:
- Add conditional logic to check selector type
- Use `custom` array for `custom_field` selector
- Use `fields` array for field selector
- Aligns with Python, JavaScript, and Java SDK implementations

Before: `keeper://UID/custom_field/LABEL` always failed
After: `keeper://UID/custom_field/LABEL` works correctly

Refs: KSM-769