### PR TITLE
KSM-768: add notes field retrieval support to keeper_get

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -21,11 +21,15 @@ For more information see our official documentation page https://docs.keeper.io/
 
 ## 1.3.0
 * **Security**: KSM-762 - Fixed CVE-2026-23949 (jaraco.context path traversal) in SBOM generation workflow
-  - Upgraded jaraco.context to >= 6.1.0 in SBOM build environment
+  - Upgraded jaraco.context to >= 6.1.0 in SBOM generation workflow
   - Build-time dependency only, does not affect runtime or published packages
 * KSM-714: Added notes field update support
   - Added `NOTES` to `KeeperFieldType` enum
   - Users can now update record notes via `keeper_set` tasks with `field_type: notes`
+* KSM-768: Added notes field retrieval support
+  - Added `notes` parameter to `keeper_get` action (boolean, default: no)
+  - Users can now retrieve record notes via `keeper_get` tasks with `notes: yes`
+  - Example: `keeper_get: uid: "XXX" notes: yes`
 * **Dependency Update**: Updated Python SDK requirement to v17.1.0
   - Ensures compatibility with security fixes and latest features
 

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
@@ -543,6 +543,13 @@ class KeeperAnsible:
                 display.vvvvvv(f"found the file: {key}")
             else:
                 display.vvvvvv(f"cannot find the file: {key}")
+        elif field_type == KeeperFieldType.NOTES:
+            notes_value = record.dict.get('notes')
+            if notes_value is not None:
+                values = [notes_value]
+                display.vvvvvv(f"found notes field")
+            else:
+                display.vvvvvv(f"notes field is empty or not present")
         else:
             raise AnsibleError("Cannot get_value. The field type ENUM of {} is invalid.".format(field_type))
 
@@ -660,10 +667,10 @@ class KeeperAnsible:
                 field_key = args.get(key)
 
         if len(field_type) == 0:
-            raise AnsibleError("Either field, custom_field or file needs to set to a non-blank value for keeper_copy.")
+            raise AnsibleError("Either field, custom_field, file, or notes needs to set to a non-blank value for keeper_copy.")
         if len(field_type) > 1:
             raise AnsibleError("Found multiple field types. Only one of the following key can be set: field, "
-                               "custom_field or file.")
+                               "custom_field, file, or notes.")
 
         return KeeperFieldType.get_enum(field_type[0]), field_key
 

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_get.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_get.py
@@ -63,6 +63,14 @@ options:
     - The file name of the file that contains the value.
     type: str
     required: no
+  notes:
+    description:
+    - Set to yes to retrieve the notes field from the record.
+    - The notes field contains text notes attached to the record.
+    type: bool
+    default: no
+    required: no
+    version_added: '1.3.0'
   allow_array:
     description:
     - Allow array of values instead of taking the first value.
@@ -116,6 +124,11 @@ EXAMPLES = r'''
     uid: XXX
     custom_field: Custom Label
   register: my_custom_value
+- name: Get notes field
+  keeper_get:
+    uid: XXX
+    notes: yes
+  register: my_notes_value
 '''
 
 RETURN = r'''

--- a/integration/keeper_secrets_manager_ansible/test_notes_unit.py
+++ b/integration/keeper_secrets_manager_ansible/test_notes_unit.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Unit test for notes retrieval functionality - tests the specific code we modified
+"""
+
+import sys
+import os
+
+# Add the package to Python path
+sys.path.insert(0, os.path.dirname(__file__))
+
+from keeper_secrets_manager_ansible import KeeperFieldType
+from keeper_secrets_manager_core.dto.dtos import Record as KeeperRecord
+from keeper_secrets_manager_core.crypto import CryptoUtils
+from keeper_secrets_manager_core import utils
+
+def create_mock_record_with_notes():
+    """Create a mock Keeper record with notes for testing"""
+
+    # Create a minimal record dict
+    record_dict = {
+        'recordUid': 'test123',
+        'data': None,  # We'll mock the encrypted data
+        'revision': 1,
+        'isEditable': True,
+    }
+
+    # Create fake secret key for encryption
+    fake_secret_key = bytes([0] * 32)  # 32 bytes of zeros
+
+    # Create the decrypted record data
+    record_data = {
+        'title': 'Test Record',
+        'type': 'login',
+        'fields': [
+            {
+                'type': 'password',
+                'value': ['TESTPASSWORD']
+            }
+        ],
+        'notes': 'These are my test notes'
+    }
+
+    # Convert to JSON
+    record_json = utils.dict_to_json(record_data)
+
+    # Encrypt the record data
+    encrypted_data = CryptoUtils.encrypt_aes(utils.string_to_bytes(record_json), fake_secret_key)
+    record_dict['data'] = utils.bytes_to_base64(encrypted_data)
+
+    # Create the Record object
+    record = KeeperRecord(record_dict, fake_secret_key)
+
+    return record
+
+def test_notes_field_type_enum():
+    """Test that NOTES field type is properly defined"""
+    print("Testing NOTES field type enum...")
+
+    # Check that NOTES enum exists
+    assert hasattr(KeeperFieldType, 'NOTES'), "NOTES not found in KeeperFieldType enum"
+    assert KeeperFieldType.NOTES.value == 'notes', f"NOTES value should be 'notes', got '{KeeperFieldType.NOTES.value}'"
+
+    # Check that get_enum works with 'notes'
+    enum_value = KeeperFieldType.get_enum('notes')
+    assert enum_value == KeeperFieldType.NOTES, f"get_enum('notes') should return NOTES enum, got {enum_value}"
+
+    print("✓ NOTES enum is properly defined")
+    return True
+
+def test_notes_in_record():
+    """Test that notes can be accessed from a Keeper record"""
+    print("\nTesting notes access from record...")
+
+    # Create a mock record with notes
+    record = create_mock_record_with_notes()
+
+    # Verify the record has notes
+    assert hasattr(record, 'dict'), "Record should have 'dict' attribute"
+    assert 'notes' in record.dict, "Record dict should contain 'notes' field"
+
+    notes_value = record.dict.get('notes')
+    assert notes_value == 'These are my test notes', f"Expected 'These are my test notes', got '{notes_value}'"
+
+    print(f"✓ Successfully accessed notes from record: '{notes_value}'")
+    return True
+
+def test_allowed_fields():
+    """Test that 'notes' is in ALLOWED_FIELDS"""
+    print("\nTesting ALLOWED_FIELDS includes notes...")
+
+    from keeper_secrets_manager_ansible import KeeperAnsible
+
+    assert 'notes' in KeeperAnsible.ALLOWED_FIELDS, "notes should be in ALLOWED_FIELDS"
+    print(f"✓ ALLOWED_FIELDS contains: {KeeperAnsible.ALLOWED_FIELDS}")
+
+    return True
+
+def main():
+    """Run all tests"""
+    print("="*60)
+    print("NOTES FIELD UNIT TESTS")
+    print("="*60)
+
+    try:
+        # Run all tests
+        all_passed = True
+        all_passed &= test_notes_field_type_enum()
+        all_passed &= test_notes_in_record()
+        all_passed &= test_allowed_fields()
+
+        print("\n" + "="*60)
+        if all_passed:
+            print("✅ ALL UNIT TESTS PASSED")
+            print("="*60)
+            return 0
+        else:
+            print("❌ SOME TESTS FAILED")
+            print("="*60)
+            return 1
+
+    except Exception as e:
+        print(f"\n❌ Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_get_notes.yml
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_get_notes.yml
@@ -1,0 +1,17 @@
+# vim: set shiftwidth=2 tabstop=2 softtabstop=-1 expandtab:
+---
+- name: Keeper Get Notes
+  hosts: "my_systems"
+  gather_facts: no
+
+  tasks:
+    - name: "Get Notes By UID"
+      keeper_get:
+        uid: "{{ uid }}"
+        notes: yes
+      register: "my_notes"
+
+    - name: "Print Notes"
+      debug:
+        msg: "NOTES: {{ my_notes.value }}"
+        verbosity: 0

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_get_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_get_test.py
@@ -48,3 +48,29 @@ class KeeperGetTest(unittest.TestCase):
             self.assertEqual(result["failed"], 0, "failed was not 0")
             self.assertEqual(result["changed"], 0, "0 things didn't change")
             self.assertRegex(out, r'MYPASSWORD', "Did not find the password in the stdout")
+
+    def test_keeper_get_notes(self):
+        """Test retrieving notes field from a record"""
+
+        # Create a mock response with a record containing notes
+        notes_response = Response()
+        notes_record = Record(title="Record With Notes", record_type="login")
+        notes_record.field("password", "TESTPASSWORD")
+        notes_record.notes = "These are my secret notes"
+        notes_response.add_record(record=notes_record)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            a = AnsibleTestFramework(
+                playbook="keeper_get_notes.yml",
+                vars={
+                    "tmp_dir": temp_dir,
+                    "uid": notes_record.uid,
+                    "title": notes_record.title
+                },
+                mock_responses=[notes_response]
+            )
+            result, out, err = a.run()
+            self.assertEqual(result["ok"], 2, "2 things didn't happen")
+            self.assertEqual(result["failed"], 0, "failed was not 0")
+            self.assertEqual(result["changed"], 0, "0 things didn't change")
+            self.assertRegex(out, r'NOTES: These are my secret notes', "Did not find the notes in the stdout")


### PR DESCRIPTION
## Summary

Adds support for retrieving the `notes` field from Keeper records using the `keeper_get` Ansible action.

This complements [KSM-714](https://keeper.atlassian.net/browse/KSM-714) which added notes field **update** support in v1.3.0. Users can now both read and write notes fields in Ansible tasks.

## Changes

- Added `notes` parameter to `keeper_get` action plugin (boolean, default: no)
- Implemented notes field retrieval in `KeeperAnsible.get_value()` method
- Added documentation and usage examples
- Updated error messages to include notes field type
- Added comprehensive tests (unit + live integration)

## Usage Example

```yaml
- name: Get notes from record
  keeper_get:
    uid: "XXX"
    notes: yes
  register: my_notes
```

## Testing

✅ Unit tests pass - verified enum, field access, and ALLOWED_FIELDS
✅ Live integration test pass - tested with real KSM credential:
  - Created/updated record with notes
  - Retrieved notes using Python SDK
  - Retrieved notes using KeeperAnsible.get_value()
  - All values matched expected results

## Related Issues

- Resolves: [KSM-768](https://keeper.atlassian.net/browse/KSM-768)
- Related: [KSM-714](https://keeper.atlassian.net/browse/KSM-714) (notes update support)

## Changelog

Updated `README.md` v1.3.0 section with KSM-768 entry.

[KSM-714]: https://keeper.atlassian.net/browse/KSM-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSM-768]: https://keeper.atlassian.net/browse/KSM-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ