### PR TITLE
KSM-770: fix keeper_get with notes parameter

### DIFF
--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
@@ -664,7 +664,8 @@ class KeeperAnsible:
         for key in KeeperAnsible.ALLOWED_FIELDS:
             if args.get(key) is not None:
                 field_type.append(key)
-                field_key = args.get(key)
+                # Notes is a singleton field (no lookup needed), others use the value as a lookup key
+                field_key = None if key == "notes" else args.get(key)
 
         if len(field_type) == 0:
             raise AnsibleError("Either field, custom_field, file, or notes needs to set to a non-blank value for keeper_copy.")

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_get_notes_empty.yml
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_get_notes_empty.yml
@@ -1,0 +1,18 @@
+# vim: set shiftwidth=2 tabstop=2 softtabstop=-1 expandtab:
+---
+- name: Keeper Get Notes (Empty/Missing)
+  hosts: "my_systems"
+  gather_facts: no
+
+  tasks:
+    - name: "Get Notes By UID (Should Fail)"
+      keeper_get:
+        uid: "{{ uid }}"
+        notes: yes
+      register: "my_notes"
+      ignore_errors: yes
+
+    - name: "Verify Error Occurred"
+      fail:
+        msg: "Expected error when notes field is empty"
+      when: my_notes is not failed


### PR DESCRIPTION
## Summary
Fixes bug where `keeper_get` task with `notes: yes` parameter fails with error **"Cannot find key True"**.

## Problem
The `notes` field is architecturally different from other field types:
- **field/custom_field/file** - Multiple can exist per record, require lookup key (e.g., `field: "login"`)
- **notes** - Only ONE per record, singleton field, no lookup key needed (just `notes: yes`)

The `get_field_type_enum_and_key()` method incorrectly treated the boolean value `True` as a lookup key for notes.

## Solution
Changed `__init__.py:667` to set `field_key = None` for notes field instead of using the boolean value.

```python
# Notes is a singleton field (no lookup needed), others use the value as a lookup key
field_key = None if key == "notes" else args.get(key)
```

## Changes
- Fixed `keeper_secrets_manager_ansible/__init__.py` - Properly handle notes field
- Added `test_keeper_get_notes_empty()` - Edge case test for missing notes field
- Created `keeper_get_notes_empty.yml` - Test playbook for edge case

## Testing
All existing tests pass + new edge case test:
```
tests/keeper_get_test.py::KeeperGetTest::test_keeper_get PASSED
tests/keeper_get_test.py::KeeperGetTest::test_keeper_get_cache PASSED
tests/keeper_get_test.py::KeeperGetTest::test_keeper_get_notes PASSED
tests/keeper_get_test.py::KeeperGetTest::test_keeper_get_notes_empty PASSED
```

## Related
- Jira: KSM-770
- Release: Ansible Integration v1.3.0