### PR TITLE
KSM-774: Add missing UID logging in decryption error messages

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -167,6 +167,11 @@ All notable changes to this project will be documented in this file.
 - **env_logger dependency** - Added missing `env_logger = "0.11"` to Cargo.toml
   - Fixes compilation error in `main.rs`
   - Allows binary target to compile successfully
+- **KSM-774**: Missing UID logging in bad encryption error handling
+  - Added record UID to "Error decrypting record data" message
+  - Added folder UID to "Error decrypting folder key" message
+  - Matches existing pattern from record key decryption error
+  - Improves debugging when encryption issues occur
 
 ### Links
 

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -633,7 +633,10 @@ impl Record {
                         decrypted_data = json_to_dict(&record_data_json).unwrap();
                     }
                     Err(err) => {
-                        error!("Error decrypting record data: {}", err);
+                        error!(
+                            "Error decrypting record data: {} - Record UID: {}",
+                            err, record.uid
+                        );
                     }
                 }
             }
@@ -1399,7 +1402,11 @@ impl Folder {
                         }
                     }
                     Err(err) => {
-                        log::error!("Error decrypting folder key: {:?}", err);
+                        log::error!(
+                            "Error decrypting folder key: {:?} - Folder UID: {}",
+                            err,
+                            folder.uid
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Improves debugging by adding record and folder UIDs to decryption error messages. When encryption issues occur, developers can now immediately identify which specific record or folder is causing problems.

## Changes

- Added record UID to "Error decrypting record data" message in `src/dto/dtos.rs`
- Added folder UID to "Error decrypting folder key" message in `src/dto/dtos.rs`
- Both messages now follow the same pattern as the existing record key decryption error
- Updated CHANGELOG.md with fix under [17.1.0]

## Testing

- `cargo fmt --check` - Passed
- `cargo check` - Passed (7.75s)
- `cargo clippy -- -D warnings` - Passed (3.41s)
- `cargo test` - 200 tests passed, 0 failed

No functional changes, only improved error messages. Existing test suite validates no regressions.

## Related Issues

- Jira: [KSM-774](https://keeper.atlassian.net/browse/KSM-774)

[KSM-774]: https://keeper.atlassian.net/browse/KSM-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ