### PR TITLE
KSM-779: fix GraphSync Record.links always empty

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -99,7 +99,7 @@ All notable changes to this project will be documented in this file.
   - Error scenario tests
   - URL and endpoint validation tests
   - Sequential update tests
-- **`tests/feature_validation_tests.rs`** (317 lines) - 15 validation tests
+- **`tests/feature_validation_tests.rs`** - 17 validation tests
   - UpdateOptions struct validation
   - DTO field validation (links, is_editable, inner_folder_uid)
   - QueryOptions.request_links validation
@@ -174,6 +174,11 @@ All notable changes to this project will be documented in this file.
   - Fixed `Record::new_from_json()` to return `CryptoError` on decryption failures
   - Corrupt records now filtered out of results (not included with blank title/empty fields)
   - Error messages logged with record UID for debugging
+- **KSM-779**: GraphSync `Record.links` always empty when fetching with `request_links=true`
+  - Fixed `request_links` field on `GetPayload` not being public, blocking assignment from `core.rs`
+  - Fixed `prepare_get_payload()` not transferring `request_links` from `QueryOptions` to `GetPayload`
+  - Fixed `Record::new_from_json()` not parsing `links` array from server response envelope
+  - All three bugs together prevented GraphSync linked records from working end-to-end
 - **KSM-776**: File removal via `links2Remove` ignored when `UpdateTransactionType::General` specified
   - Backend ignores `links2Remove` parameter when `transactionType: "general"` is set
   - SDK now auto-overrides to `UpdateTransactionType::None` when `links_to_remove` is not empty

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -580,6 +580,7 @@ impl SecretsManager {
                 .set_optional_field("records_filter", query_options_data.get_records_filter());
             get_payload
                 .set_optional_field("folders_filter", query_options_data.get_folders_filter());
+            get_payload.request_links = query_options_data.request_links;
         }
         Ok(get_payload)
     }

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -733,6 +733,20 @@ impl Record {
             record.files = _files;
         }
 
+        // Parse links from server response envelope (GraphSync linked records)
+        if let Some(Value::Array(links_array)) = record_dict.get("links") {
+            record.links = links_array
+                .iter()
+                .filter_map(|link| {
+                    link.as_object().map(|obj| {
+                        obj.iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect::<HashMap<String, Value>>()
+                    })
+                })
+                .collect();
+        }
+
         Ok(record)
     }
 

--- a/sdk/rust/src/dto/payload.rs
+++ b/sdk/rust/src/dto/payload.rs
@@ -129,7 +129,7 @@ pub struct GetPayload {
     public_key: Option<String>,
     requested_records: Option<Vec<String>>,
     requested_folders: Option<Vec<String>>,
-    request_links: Option<bool>, // Request linked records (v16.7.0+)
+    pub request_links: Option<bool>, // Request linked records (v16.7.0+)
 }
 
 impl GetPayload {


### PR DESCRIPTION
## Summary

Fixes `Record.links` always being empty when fetching records with `request_links=true` in the Rust SDK. Three bugs formed a chain that prevented GraphSync links from working end-to-end.

## Bug Chain

| # | Bug | File | Fix |
|---|-----|------|-----|
| 1 | `request_links` field on `GetPayload` was private | `payload.rs:132` | Added `pub` visibility |
| 2 | `prepare_get_payload()` never copied `request_links` from `QueryOptions` | `core.rs:583` | Added transfer line |
| 3 | `Record::new_from_json()` never parsed `links` from server response | `dtos.rs:736` | Added links parsing block |

## Changes

- **`sdk/rust/src/dto/payload.rs`** - Make `request_links` field public (1 line)
- **`sdk/rust/src/core/core.rs`** - Transfer `request_links` from QueryOptions to GetPayload (1 line)
- **`sdk/rust/src/dto/dtos.rs`** - Parse `links` array from raw server response envelope (~10 lines)
- **`sdk/rust/CHANGELOG.md`** - Add KSM-779 fix entry
- **`sdk/rust/tests/feature_validation_tests.rs`** - 2 new tests for links parsing via `new_from_json`

## Test plan

- [x] `cargo check` - compiles clean
- [x] `cargo fmt --check` - formatted correctly
- [x] `cargo clippy --all-features --lib -- -D warnings` - no warnings
- [x] `cargo test` - all 200 unit + 59 doc + 17 feature validation tests pass
- [x] QA live vault: SDK connects, `request_links=true` sent to server, null links handled correctly
- [x] QA live vault: PAM records (pamMachine + pamUser) created and fetched via Rust SDK
- [ ] QA: verify `Record.links` populated with vault-UI-linked PAM records (requires Keeper Gateway)

**Note:** GraphSync links are established server-side through PAM infrastructure (vault UI / Commander), not through `pamResources.resourceRef` data fields. Full end-to-end validation with populated links requires PAM records linked through the vault UI with a configured Gateway.

Closes KSM-779