### PR TITLE
KSM-780: fix backward compatibility for note parameter in keeper_create

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -43,6 +43,12 @@ For more information see our official documentation page https://docs.keeper.io/
   - Changed `set_value()` method to use `value` parameter instead of `key` (which is None for singleton notes field)
   - Prevents silent data loss of existing notes content
   - Added test for setting notes field values
+* KSM-773: Standardized `notes` parameter name across all actions (`keeper_create`, `keeper_set`, `keeper_copy`)
+  - Renamed `note` to `notes` for consistency across all actions
+* KSM-780: Fixed backward compatibility for `note` parameter in `keeper_create`
+  - The `note` (singular) parameter is now accepted as a deprecated alias for `notes`
+  - Playbooks using the old `note:` parameter will continue to work with a deprecation warning
+  - The `note` alias will be removed in version 2.0.0
 * **Dependency Update**: Updated Python SDK requirement to v17.1.0
   - Ensures compatibility with security fixes and latest features
 

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_create.py
@@ -97,8 +97,10 @@ options:
   notes:
     description:
     - Attach a note to the record.
+    - C(note) (singular) is accepted as a deprecated alias.
     type: str
     required: no
+    aliases: [ note ]
   version:
     description:
     - The record schema version to use.
@@ -286,6 +288,17 @@ class ActionModule(ActionBase):
                 ))
                 keeper.stash_secret_value(str(field.get("value")))
 
+            notes = self._task.args.get("notes")
+            if notes is None:
+                notes = self._task.args.get("note")
+                if notes is not None:
+                    display.deprecated(
+                        "The 'note' parameter for keeper_create has been renamed to 'notes'. "
+                        "Please update your playbooks.",
+                        version="2.0.0",
+                        collection_name="keepersecurity.keeper_secrets_manager"
+                    )
+
             password_complexity = self._task.args.get("password_complexity")
             if password_complexity is not None:
                 password_complexity = keeper.password_complexity_translation(**password_complexity)
@@ -293,7 +306,7 @@ class ActionModule(ActionBase):
             record = Record(version=version).create_from_field_list(
                 record_type=record_type,
                 title=title,
-                notes=self._task.args.get("notes"),
+                notes=notes,
                 fields=fields,
                 password_generate=self._task.args.get("generate_password"),
                 password_complexity=password_complexity

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/modules/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/modules/keeper_create.py
@@ -83,11 +83,13 @@ options:
     - The title of the record.
     type: str
     required: yes
-  note:
+  notes:
     description:
     - Attach a note to the record.
+    - C(note) (singular) is accepted as a deprecated alias.
     type: str
     required: no
+    aliases: [ note ]
   fields:
     description:
     - The label, or type, of the standard field in record that contains the value.
@@ -184,7 +186,7 @@ EXAMPLES = r'''
     share_folder_uid: XXX
     record_type: login
     title: My Title
-    note: This record was created from Ansible
+    notes: This record was created from Ansible
     generate_password: True
     fields:
       - type: login

--- a/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_create.yml
+++ b/integration/keeper_secrets_manager_ansible/tests/ansible_example/playbooks/keeper_create.yml
@@ -15,7 +15,7 @@
         # Filter out all the lower case letters for out test.
         filter_characters: "abcdefghijklmnopqrstuvwxyz"
       title: "My New Record"
-      note: "This is my note"
+      notes: "This is my note"
       fields:
         - type: login
           value: "johndoe@localhost"


### PR DESCRIPTION
## Summary

KSM-773 renamed the `note` parameter to `notes` in `keeper_create` for consistency, but broke backward compatibility — the old `note:` parameter was silently ignored, causing notes to be dropped without any warning.

## Changes

- **Action plugin** (`keeper_create.py`): Added fallback logic that checks `note` (singular) when `notes` is not provided, with `display.deprecated()` warning targeting removal in v2.0.0
- **DOCUMENTATION** (action + module): Added `aliases: [ note ]` and deprecation notice to `notes` parameter
- **Module definition**: Renamed `note:` → `notes:` with alias to sync with action plugin
- **Test playbook**: Updated to use canonical `notes:` parameter name
- **Changelog**: Added KSM-773 and KSM-780 entries to 1.3.0 section

## QA Verification

Tested against live Keeper vault:

1. `notes: "text"` (canonical) — record created with notes attached
2. `note: "text"` (deprecated alias) — record created with notes attached + deprecation warning:
   ```
   [DEPRECATION WARNING]: The 'note' parameter for keeper_create has been renamed to 'notes'.
   Please update your playbooks. This feature will be removed from collection
   'keepersecurity.keeper_secrets_manager' version 2.0.0.
   ```
3. Existing unit test passes (`keeper_create_test.py`)
4. Test records cleaned up from vault after verification

## Test plan

- [x] Unit test: `pytest tests/keeper_create_test.py -v` passes
- [x] Live QA: `notes:` (canonical) creates record with notes
- [x] Live QA: `note:` (deprecated) creates record with notes + deprecation warning
- [x] Live QA: Verified notes content on created records via SDK read-back