### PR TITLE
KSM-781: Fix Jinja2 templating for keeper_config_file

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -20,6 +20,9 @@ For more information see our official documentation page https://docs.keeper.io/
 # Changes
 
 ## 1.3.0
+* KSM-781: Fixed Jinja2 templating for `keeper_config_file` and `keeper_cache_dir` variables
+  - Variables like `{{ playbook_dir }}/keeper-config.yml` are now resolved before use
+  - Lookup plugins (no action_module) are unaffected
 * **Security**: KSM-762 - Fixed CVE-2026-23949 (jaraco.context path traversal) in SBOM generation workflow
   - Upgraded jaraco.context to >= 6.1.0 in SBOM generation workflow
   - Build-time dependency only, does not affect runtime or published packages


### PR DESCRIPTION
## Summary
- Fix `keeper_config_file` and `keeper_cache_dir` not resolving Jinja2 expressions (e.g. `{{ playbook_dir }}/keeper-config.yml`)

## Changes
- Add `_template_value()` helper that uses Ansible's `_templar.template()` to resolve expressions
- Template `keeper_config_file` before the `os.path.isfile()` check
- Template `keeper_cache_dir` before setting `KSM_CACHE_DIR` env var
- Lookup plugins (no `action_module`) are unaffected — helper returns value unchanged

## Test plan
- 34 existing unit tests pass
- Live QA: Jinja2 expression `{{ playbook_dir }}/keeper-config.json` resolves and connects to vault
- Live QA: Literal path still works (no regression)

Closes KSM-781