### PR TITLE
KSM-783: fix panic when initialized with empty JSON config

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -186,6 +186,11 @@ All notable changes to this project will be documented in this file.
   - Fixed `prepare_get_payload()` not transferring `request_links` from `QueryOptions` to `GetPayload`
   - Fixed `Record::new_from_json()` not parsing `links` array from server response envelope
   - All three bugs together prevented GraphSync linked records from working end-to-end
+- **KSM-783**: SDK panics when initialized with empty JSON config (`{}`) and no token
+  - Fixed `load_secret_key()` to use `if let Some(key)` instead of `.unwrap()` on `config.get(KeyClientKey)`
+  - Empty config now returns proper `Err` instead of panicking with `None.unwrap()`
+  - Hardened all `.unwrap()` calls on `config.get()`/`config.set()` in the initialization path to use `map_err()?`
+  - Prevents panics with `FileKeyValueStorage` on I/O errors during initialization
 - **KSM-776**: File removal via `links2Remove` ignored when `UpdateTransactionType::General` specified
   - Backend ignores `links2Remove` parameter when `transactionType: "general"` is set
   - SDK now auto-overrides to `UpdateTransactionType::None` when `links_to_remove` is not empty

--- a/sdk/rust/tests/empty_config_test.rs
+++ b/sdk/rust/tests/empty_config_test.rs
@@ -1,0 +1,111 @@
+// -*- coding: utf-8 -*-
+//  _  __
+// | |/ /___ ___ _ __  ___ _ _ (R)
+// | ' </ -_) -_) '_ \/ -_) '_|
+// |_|\_\___\___| .__/\___|_|
+//              |_|
+//
+// Keeper Secrets Manager
+// Copyright 2024-2026 Keeper Security Inc.
+// Contact: sm@keepersecurity.com
+//
+
+#[cfg(test)]
+mod empty_config_tests {
+    use keeper_secrets_manager_core::cache::KSMCache;
+    use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+    use keeper_secrets_manager_core::enums::KvStoreType;
+    use keeper_secrets_manager_core::storage::InMemoryKeyValueStorage;
+    use log::Level;
+
+    /// Test: Empty JSON config ({}) without token returns Err, not panic (KSM-783)
+    ///
+    /// This is the primary regression test. Before the fix, initializing with
+    /// an empty JSON config would panic at load_secret_key() due to
+    /// None.unwrap() when no KeyClientKey exists in config.
+    #[test]
+    fn test_empty_json_config_returns_error_not_panic() {
+        let storage = InMemoryKeyValueStorage::new(Some("{}".to_string()))
+            .expect("InMemoryKeyValueStorage should accept empty JSON");
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            String::new(),
+            config,
+            Level::Error,
+            None,
+            None,
+            KSMCache::None,
+        );
+
+        let result = SecretsManager::new(options);
+
+        assert!(
+            result.is_err(),
+            "Empty config without token should return Err, not Ok"
+        );
+
+        if let Err(err) = &result {
+            let err_msg = format!("{}", err);
+            assert!(
+                err_msg.contains("secret key") || err_msg.contains("One time password"),
+                "Error should mention missing secret key or token, got: {}",
+                err_msg
+            );
+        }
+    }
+
+    /// Test: Empty string config returns Err, not panic (KSM-783)
+    #[test]
+    fn test_empty_string_config_returns_error_not_panic() {
+        let storage_result = InMemoryKeyValueStorage::new(Some(String::new()));
+
+        // Empty string may fail at storage creation or at SecretsManager::new
+        match storage_result {
+            Ok(storage) => {
+                let config = KvStoreType::InMemory(storage);
+                let options = ClientOptions::new(
+                    String::new(),
+                    config,
+                    Level::Error,
+                    None,
+                    None,
+                    KSMCache::None,
+                );
+
+                let result = SecretsManager::new(options);
+                assert!(
+                    result.is_err(),
+                    "Empty string config without token should return Err, not Ok"
+                );
+            }
+            Err(_) => {
+                // Also acceptable: storage creation itself returns Err for empty string
+            }
+        }
+    }
+
+    /// Test: None config (InMemoryKeyValueStorage::new(None)) returns Err, not panic (KSM-783)
+    #[test]
+    fn test_none_config_returns_error_not_panic() {
+        let storage =
+            InMemoryKeyValueStorage::new(None).expect("InMemoryKeyValueStorage should accept None");
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            String::new(),
+            config,
+            Level::Error,
+            None,
+            None,
+            KSMCache::None,
+        );
+
+        let result = SecretsManager::new(options);
+
+        assert!(
+            result.is_err(),
+            "None config without token should return Err, not Ok"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fix Rust SDK panic when initialized with empty JSON config (`{}`) and no token/env var
- Replace `None.unwrap()` with proper error handling so the SDK returns `Err` instead of panicking
- Harden all `.unwrap()` calls on `config.get()`/`config.set()` in the initialization path

## Changes

### Fixed (`core.rs`)
- **Primary fix (line 512)**: `load_secret_key()` used `.unwrap()` on `config.get(KeyClientKey)` which returned `None` for empty configs. Replaced with `if let Some(key)` pattern.
- **Secondary hardening (9 locations)**: Replaced all `.unwrap()` on `config.get()`/`config.set()` in `new()` and `_init()` with `.map_err(|e| KSMRError::SecretManagerCreationError(...))?`. Prevents panics with `FileKeyValueStorage` on I/O errors.

### Added
- `tests/empty_config_test.rs` — 3 regression tests:
  1. Empty JSON config `{}` without token → `Err` (not panic)
  2. Empty string config → `Err` (not panic)
  3. `None` config → `Err` (not panic)
- `CHANGELOG.md` — KSM-783 entry in `[17.1.0]` Fixed section

## Test plan

- `cargo test` — all 206 unit + 112 integration + 59 doc tests pass
- `cargo clippy --all-features --lib -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- Verify new tests exercise the exact panic path (line 512)

Closes KSM-783