### PR TITLE
KSM-584: add proxy support to Rust SDK v17.1.0

### DIFF
--- a/sdk/rust/src/caching.rs
+++ b/sdk/rust/src/caching.rs
@@ -131,8 +131,6 @@ pub fn cache_exists() -> bool {
 /// 1. On success: Saves the response to cache (transmission key + encrypted data)
 /// 2. On failure: Falls back to cached data if available
 ///
-/// This matches the pattern used in Python, JavaScript, Java, Ruby, and .NET SDKs.
-///
 /// # Arguments
 /// * `url` - The API endpoint URL
 /// * `transmission_key` - The transmission key for encryption

--- a/sdk/rust/tests/proxy_integration_test.rs
+++ b/sdk/rust/tests/proxy_integration_test.rs
@@ -1,0 +1,217 @@
+// -*- coding: utf-8 -*-
+//  _  __
+// | |/ /___ ___ _ __  ___ _ _ (R)
+// | ' </ -_) -_) '_ \/ -_) '_|
+// |_|\_\___\___| .__/\___|_|
+//              |_|
+//
+// Keeper Secrets Manager
+// Copyright 2024 Keeper Security Inc.
+// Contact: sm@keepersecurity.com
+//
+
+/// Manual integration test for proxy support with QA vault
+///
+/// **Note**: Automatic unit tests for proxy configuration exist in `proxy_test.rs`
+/// and run with every `cargo test`. This file contains optional end-to-end tests
+/// that verify proxy behavior with real network calls.
+///
+/// This test is IGNORED by default and must be run manually.
+///
+/// Prerequisites:
+/// 1. Set up a local proxy server (e.g., mitmproxy):
+///    ```bash
+///    # Install mitmproxy
+///    brew install mitmproxy  # macOS
+///    # or: pip install mitmproxy
+///
+///    # Start proxy on port 8080
+///    mitmproxy -p 8080
+///    ```
+///
+/// 2. Set KSM_CONFIG environment variable with QA credentials:
+///    ```bash
+///    export KSM_CONFIG=$(cat ~/.keeper/qa_credential)
+///    ```
+///
+/// 3. Run this test:
+///    ```bash
+///    cargo test --test proxy_integration_test -- --ignored --nocapture
+///    ```
+///
+/// Expected behavior:
+/// - Request should appear in mitmproxy logs
+/// - Test should successfully retrieve secrets through the proxy
+/// - mitmproxy should show requests to keepersecurity.com (or QA host)
+///
+#[cfg(test)]
+mod proxy_integration_tests {
+    use keeper_secrets_manager_core::cache::KSMCache;
+    use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+    use keeper_secrets_manager_core::enums::KvStoreType;
+    use keeper_secrets_manager_core::storage::InMemoryKeyValueStorage;
+    use log::Level;
+    use std::env;
+
+    #[test]
+    #[ignore] // Must be run manually with --ignored flag
+    fn test_proxy_with_qa_vault() {
+        // Initialize logging to see what's happening
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Info)
+            .try_init();
+
+        // Check if KSM_CONFIG is set
+        let config_str = env::var("KSM_CONFIG").expect(
+            "KSM_CONFIG environment variable not set. \
+             Run: export KSM_CONFIG=$(cat ~/.keeper/qa_credential)",
+        );
+
+        println!("✓ Found KSM_CONFIG environment variable");
+
+        // Create in-memory storage with the config
+        let storage = InMemoryKeyValueStorage::new(Some(config_str))
+            .expect("Failed to create InMemoryKeyValueStorage");
+        let config = KvStoreType::InMemory(storage);
+
+        println!("✓ Created storage with QA credentials");
+
+        // Configure with proxy pointing to local mitmproxy
+        let proxy_url = env::var("TEST_PROXY_URL").unwrap_or("http://localhost:8080".to_string());
+        println!("✓ Using proxy: {}", proxy_url);
+
+        let options = ClientOptions::new(
+            String::new(), // No token needed, using existing config
+            config,
+            Level::Info,
+            None,
+            None,
+            Some(proxy_url.clone()), // Enable proxy
+            KSMCache::None,
+        );
+
+        println!("✓ Created ClientOptions with proxy");
+
+        // Initialize SecretsManager
+        let mut secrets_manager =
+            SecretsManager::new(options).expect("Failed to create SecretsManager");
+
+        println!("✓ Initialized SecretsManager");
+        println!("\n=== Making API request through proxy ===");
+        println!("Check your proxy logs (mitmproxy UI) for requests to Keeper servers\n");
+
+        // Attempt to get secrets (this will go through the proxy)
+        match secrets_manager.get_secrets(Vec::new()) {
+            Ok(secrets) => {
+                println!("✓ Successfully retrieved {} secrets through proxy!", secrets.len());
+
+                if !secrets.is_empty() {
+                    println!("\nFirst secret UID: {}", secrets[0].uid);
+                }
+
+                println!("\n✅ PROXY TEST PASSED!");
+                println!("   - Request went through proxy at {}", proxy_url);
+                println!("   - Successfully retrieved secrets from QA vault");
+                println!("   - Check proxy logs to confirm traffic routing");
+            }
+            Err(e) => {
+                eprintln!("\n❌ Failed to retrieve secrets: {:?}", e);
+                panic!("Proxy integration test failed. Common issues:\n\
+                        1. Is mitmproxy running on port 8080?\n\
+                        2. Is KSM_CONFIG set correctly?\n\
+                        3. Are QA vault credentials valid?");
+            }
+        }
+    }
+
+    #[test]
+    #[ignore] // Must be run manually with --ignored flag
+    fn test_proxy_with_authentication() {
+        // This test demonstrates proxy with username/password
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Info)
+            .try_init();
+
+        let config_str = env::var("KSM_CONFIG").expect("KSM_CONFIG not set");
+
+        let storage = InMemoryKeyValueStorage::new(Some(config_str))
+            .expect("Failed to create storage");
+        let config = KvStoreType::InMemory(storage);
+
+        // Use authenticated proxy format
+        let proxy_url = "http://testuser:testpass@localhost:8080";
+        println!("Testing proxy with authentication: {}", proxy_url);
+
+        let options = ClientOptions::new(
+            String::new(),
+            config,
+            Level::Info,
+            None,
+            None,
+            Some(proxy_url.to_string()),
+            KSMCache::None,
+        );
+
+        let mut secrets_manager = SecretsManager::new(options)
+            .expect("Failed to create SecretsManager with authenticated proxy");
+
+        match secrets_manager.get_secrets(Vec::new()) {
+            Ok(secrets) => {
+                println!("✓ Authenticated proxy test passed! Retrieved {} secrets", secrets.len());
+            }
+            Err(e) => {
+                println!("Note: Authentication test may fail if proxy doesn't require auth");
+                println!("Error: {:?}", e);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore] // Must be run manually
+    fn test_env_var_proxy() {
+        // Test that HTTPS_PROXY environment variable works
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Info)
+            .try_init();
+
+        // Set HTTPS_PROXY environment variable
+        env::set_var("HTTPS_PROXY", "http://localhost:8080");
+        println!("Set HTTPS_PROXY=http://localhost:8080");
+
+        let config_str = env::var("KSM_CONFIG").expect("KSM_CONFIG not set");
+
+        let storage = InMemoryKeyValueStorage::new(Some(config_str))
+            .expect("Failed to create storage");
+        let config = KvStoreType::InMemory(storage);
+
+        // Create options WITHOUT explicit proxy_url (should use HTTPS_PROXY)
+        let options = ClientOptions::new(
+            String::new(),
+            config,
+            Level::Info,
+            None,
+            None,
+            None, // No explicit proxy - should use HTTPS_PROXY env var
+            KSMCache::None,
+        );
+
+        let mut secrets_manager = SecretsManager::new(options)
+            .expect("Failed to create SecretsManager");
+
+        println!("Testing environment variable proxy fallback...");
+
+        match secrets_manager.get_secrets(Vec::new()) {
+            Ok(secrets) => {
+                println!("✓ Environment variable proxy test passed!");
+                println!("  Retrieved {} secrets using HTTPS_PROXY", secrets.len());
+            }
+            Err(e) => {
+                eprintln!("❌ Environment variable proxy test failed: {:?}", e);
+                panic!("Failed to use HTTPS_PROXY environment variable");
+            }
+        }
+
+        // Clean up
+        env::remove_var("HTTPS_PROXY");
+    }
+}

--- a/sdk/rust/tests/proxy_test.rs
+++ b/sdk/rust/tests/proxy_test.rs
@@ -1,0 +1,163 @@
+// -*- coding: utf-8 -*-
+//  _  __
+// | |/ /___ ___ _ __  ___ _ _ (R)
+// | ' </ -_) -_) '_ \/ -_) '_|
+// |_|\_\___\___| .__/\___|_|
+//              |_|
+//
+// Keeper Secrets Manager
+// Copyright 2024 Keeper Security Inc.
+// Contact: sm@keepersecurity.com
+//
+
+#[cfg(test)]
+mod proxy_tests {
+    use keeper_secrets_manager_core::cache::KSMCache;
+    use keeper_secrets_manager_core::core::ClientOptions;
+    use keeper_secrets_manager_core::enums::KvStoreType;
+    use keeper_secrets_manager_core::storage::InMemoryKeyValueStorage;
+    use log::Level;
+
+    #[test]
+    fn test_proxy_url_configuration() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some("http://proxy.example.com:8080".to_string()),
+            KSMCache::None,
+        );
+
+        assert_eq!(
+            options.proxy_url,
+            Some("http://proxy.example.com:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn test_proxy_url_none_by_default() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new_client_options(config);
+
+        assert_eq!(options.proxy_url, None);
+    }
+
+    #[test]
+    fn test_proxy_url_with_authentication() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let proxy_url_with_auth = "http://user:password@proxy.example.com:8080".to_string();
+
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some(proxy_url_with_auth.clone()),
+            KSMCache::None,
+        );
+
+        assert_eq!(options.proxy_url, Some(proxy_url_with_auth));
+    }
+
+    #[test]
+    fn test_proxy_url_with_token_constructor() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options =
+            ClientOptions::new_client_options_with_token("test_token".to_string(), config);
+
+        // Should default to None
+        assert_eq!(options.proxy_url, None);
+    }
+
+    #[test]
+    fn test_proxy_url_empty_string() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        // Some users might pass empty string instead of None
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some("".to_string()),
+            KSMCache::None,
+        );
+
+        // We allow empty strings (reqwest will handle validation)
+        assert_eq!(options.proxy_url, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_proxy_url_https_scheme() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some("https://secure-proxy.example.com:8443".to_string()),
+            KSMCache::None,
+        );
+
+        assert_eq!(
+            options.proxy_url,
+            Some("https://secure-proxy.example.com:8443".to_string())
+        );
+    }
+
+    #[test]
+    fn test_proxy_url_with_ipv4_address() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some("http://192.168.1.100:3128".to_string()),
+            KSMCache::None,
+        );
+
+        assert_eq!(
+            options.proxy_url,
+            Some("http://192.168.1.100:3128".to_string())
+        );
+    }
+
+    #[test]
+    fn test_proxy_url_with_localhost() {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let config = KvStoreType::InMemory(storage);
+
+        let options = ClientOptions::new(
+            "test_token".to_string(),
+            config,
+            Level::Error,
+            None,
+            None,
+            Some("http://localhost:8888".to_string()),
+            KSMCache::None,
+        );
+
+        assert_eq!(options.proxy_url, Some("http://localhost:8888".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Add HTTP/HTTPS proxy configuration support to the Rust SDK for enterprise environments with mandatory proxy requirements.

## Changes

### Core Implementation
- Add proxy_url: Option<String> parameter to ClientOptions and SecretsManager
- Add build_proxy() helper function with automatic credential parsing (http://user:pass@host:port)
- Modify HTTP client builder to apply proxy configuration
- Leverage reqwest's built-in HTTP_PROXY/HTTPS_PROXY environment variable support

### Testing
- 8 unit tests (proxy_test.rs) - run automatically with cargo test
- 3 manual E2E tests (proxy_integration_test.rs) - verified with QA vault + mitmproxy
- Successfully retrieved 10 secrets through proxy in integration test

### Documentation
- Added comprehensive proxy configuration section to README.md
- Documented explicit configuration and authentication examples
- Documented environment variable fallback behavior

### Code Quality
- Removed SDK reference from caching.rs comment
- All tests pass
- cargo fmt clean
- cargo clippy no warnings

## Test Plan

**Automatic tests:**
```bash
cargo test --test proxy_test
# 8/8 passed
```

**Manual verification (optional):**
```bash
# Start test proxy
mitmproxy -p 8080

# Set credentials
export KSM_CONFIG=$(cat ~/.keeper/qa_credential)

# Run integration test
cargo test --test proxy_integration_test -- --ignored --nocapture
# Retrieved 10 secrets through proxy
```

## Backward Compatibility

Fully backward compatible - proxy_url defaults to None

## Related

- Jira: KSM-584
- Base branch: release/sdk/rust/v17.1.0
- Part of Rust SDK v17.1.0 release