### PR TITLE
Python SDK Release v17.2.0 - Python 3.9+ upgrade + CVE fixes

### DIFF
--- a/.github/workflows/publish.pypi.sdk.yml
+++ b/.github/workflows/publish.pypi.sdk.yml
@@ -11,7 +11,7 @@ jobs:
       helper-version: ${{ steps.extract-helper-version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Extract SDK version
         id: extract-sdk-version
         working-directory: ./sdk/python/core
@@ -19,7 +19,7 @@ jobs:
           VERSION=$(python3 setup.py --version 2>/dev/null || grep -Po 'version\s*=\s*["\x27]\K[^\x27"]*' setup.py)
           echo "SDK Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      
+
       - name: Extract Helper version
         id: extract-helper-version
         working-directory: ./sdk/python/helper
@@ -28,110 +28,173 @@ jobs:
           echo "Helper Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-  # Generate and upload SBOM for SDK
-  generate-sdk-sbom:
+  # Fail fast if either version is already on PyPI - before SBOM generation
+  # and before the release manager is asked to approve anything.
+  validate-versions:
+    name: Validate versions not yet published
     needs: get-versions
-    uses: ./.github/workflows/reusable.sbom.workflow.yml
-    with:
-      working-directory: ./sdk/python/core
-      project-name: keeper-secrets-manager-python
-      project-type: python
-      project-version: ${{ needs.get-versions.outputs.sdk-version }}
-      sbom-format: spdx-json
-      additional-labels: ksm,sdk,python,security
-    secrets:
-      MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
-
-  # Generate and upload SBOM for Helper
-  generate-helper-sbom:
-    needs: get-versions
-    uses: ./.github/workflows/reusable.sbom.workflow.yml
-    with:
-      working-directory: ./sdk/python/helper
-      project-name: keeper-secrets-manager-helper
-      project-type: python
-      project-version: ${{ needs.get-versions.outputs.helper-version }}
-      sbom-format: spdx-json
-      additional-labels: ksm,helper,python,security
-    secrets:
-      MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
-
-  # Publish SDK to PyPI
-  publish-sdk:
-    name: Publish KSM Python SDK to PyPI
-    needs: [generate-sdk-sbom, get-versions]
-    environment: prod
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    defaults:
-      run:
-        working-directory: ./sdk/python/core
-
     steps:
-      - name: Get the source code
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Check if SDK version exists on PyPI
-        id: check-sdk-version
+      - name: Check SDK version not on PyPI
         run: |
           VERSION="${{ needs.get-versions.outputs.sdk-version }}"
-          echo "Checking if keeper-secrets-manager-core version $VERSION exists on PyPI..."
+          echo "Checking keeper-secrets-manager-core $VERSION..."
           if pip index versions keeper-secrets-manager-core 2>/dev/null | grep -qE "\b$VERSION\b"; then
-            echo "Version $VERSION already exists on PyPI"
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version $VERSION does not exist on PyPI"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "::error::keeper-secrets-manager-core $VERSION is already on PyPI. Aborting."
+            exit 1
           fi
+          echo "keeper-secrets-manager-core $VERSION not yet on PyPI - ok to proceed"
 
-      - name: Retrieve secrets from KSM
-        if: steps.check-sdk-version.outputs.exists == 'false'
-        id: ksmsecrets
-        uses: Keeper-Security/ksm-action@master
+      - name: Check Helper version not on PyPI
+        run: |
+          VERSION="${{ needs.get-versions.outputs.helper-version }}"
+          echo "Checking keeper-secrets-manager-helper $VERSION..."
+          if pip index versions keeper-secrets-manager-helper 2>/dev/null | grep -qE "\b$VERSION\b"; then
+            echo "::error::keeper-secrets-manager-helper $VERSION is already on PyPI. Aborting."
+            exit 1
+          fi
+          echo "keeper-secrets-manager-helper $VERSION not yet on PyPI - ok to proceed"
+
+  # Generate and publish SBOM for SDK.
+  # Uses pip --target to install only runtime deps into an isolated directory.
+  # This excludes pip, wheel, setuptools and their internal dep trees from the
+  # SBOM so that installer-tool CVEs don't appear as SDK vulnerabilities.
+  generate-sdk-sbom:
+    name: Generate and publish SDK SBOM
+    needs: [get-versions, validate-versions]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          keeper-secret-config: ${{ secrets.KSM_PYPI_PUBLISHER_PYPI_SDK_CONFIG }}
-          secrets: |
-            -aBWi3-yU_qvatNh0Eaqew/field/password > PYPI_API_TOKEN
+          python-version: '3.11'
 
-      - name: Install dependencies
-        if: steps.check-sdk-version.outputs.exists == 'false'
+      - name: Install SDK from source into scan target
         run: |
-          python3 -m pip install --upgrade setuptools pip twine
-          python3 -m pip install 'wheel>=0.46.3'  # CVE-2026-24049: ensure patched version
-          python3 -m pip install -r requirements.txt
+          mkdir -p /tmp/sdk-scan-target
+          pip3 install --quiet --target /tmp/sdk-scan-target ./sdk/python/core
 
-      - name: Build and Publish SDK
-        if: steps.check-sdk-version.outputs.exists == 'false'
+      - name: Install Syft and Manifest CLI
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.32.0
+          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b /usr/local/bin v0.30.0
+
+      - name: Generate and publish SDK SBOM
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ steps.ksmsecrets.outputs.PYPI_API_TOKEN }}
+          MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
         run: |
-          python3 setup.py build
-          python3 setup.py sdist
-          python3 -m twine upload --verbose dist/*
+          SCAN_TARGET=/tmp/sdk-scan-target
+          VERSION="${{ needs.get-versions.outputs.sdk-version }}"
 
-      - name: Skip SDK publishing (already exists)
-        if: steps.check-sdk-version.outputs.exists == 'true'
+          echo "Scanning: $SCAN_TARGET"
+          echo "Packages installed:"
+          pip3 list --path "$SCAN_TARGET"
+
+          manifest sbom "$SCAN_TARGET" \
+            --generator=syft \
+            --name=keeper-secrets-manager-python \
+            --version="${VERSION}" \
+            --output=spdx-json \
+            --file=sdk-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --asset-label=ksm,sdk,python,security 2>&1 || \
+          manifest sbom "$SCAN_TARGET" \
+            --generator=syft \
+            --name=keeper-secrets-manager-python \
+            --version="${VERSION}" \
+            --output=spdx-json \
+            --file=sdk-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --label=ksm,sdk,python,security
+
+      - name: Archive SDK SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-sdk-${{ needs.get-versions.outputs.sdk-version }}
+          path: sdk-sbom.json
+          retention-days: 90
+
+  # Generate and publish SBOM for Helper.
+  # Installs core from source first so this job has no dependency on core
+  # being published to PyPI - both SBOM jobs run in parallel before the
+  # release manager is asked to approve anything.
+  # Uses pip --target to exclude installer-tool CVEs from the SBOM.
+  generate-helper-sbom:
+    name: Generate and publish Helper SBOM
+    needs: [get-versions, validate-versions]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install SDK and Helper from source into scan target
         run: |
-          echo "::notice::Skipping SDK publishing - version ${{ needs.get-versions.outputs.sdk-version }} already exists on PyPI"
+          mkdir -p /tmp/helper-scan-target
+          # Install both in one call so pip resolves core locally instead of
+          # hitting PyPI - core 17.2.0 isn't published yet at SBOM scan time.
+          pip3 install --quiet --target /tmp/helper-scan-target \
+            ./sdk/python/core ./sdk/python/helper
 
-  # Publish Helper to PyPI
-  publish-helper:
-    name: Publish KSM SDK Helper to PyPI
-    needs: [publish-sdk, generate-helper-sbom, get-versions]  # Depends on SDK being published first
+      - name: Install Syft and Manifest CLI
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.32.0
+          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b /usr/local/bin v0.30.0
+
+      - name: Generate and publish Helper SBOM
+        env:
+          MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
+        run: |
+          SCAN_TARGET=/tmp/helper-scan-target
+          VERSION="${{ needs.get-versions.outputs.helper-version }}"
+
+          echo "Scanning: $SCAN_TARGET"
+          echo "Packages installed:"
+          pip3 list --path "$SCAN_TARGET"
+
+          manifest sbom "$SCAN_TARGET" \
+            --generator=syft \
+            --name=keeper-secrets-manager-helper \
+            --version="${VERSION}" \
+            --output=spdx-json \
+            --file=helper-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --asset-label=ksm,helper,python,security 2>&1 || \
+          manifest sbom "$SCAN_TARGET" \
+            --generator=syft \
+            --name=keeper-secrets-manager-helper \
+            --version="${VERSION}" \
+            --output=spdx-json \
+            --file=helper-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --label=ksm,helper,python,security
+
+      - name: Archive Helper SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-helper-${{ needs.get-versions.outputs.helper-version }}
+          path: helper-sbom.json
+          retention-days: 90
+
+  # Single publish job - both SDK and Helper publish under one environment: prod
+  # gate so the release manager only presses the button once.
+  # Both SBOM jobs must complete (and be verified by Manifest Cyber) before
+  # this job runs.
+  publish:
+    name: Publish KSM Python SDK and Helper to PyPI
+    needs: [generate-sdk-sbom, generate-helper-sbom, get-versions]
     environment: prod
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    defaults:
-      run:
-        working-directory: ./sdk/python/helper
+    timeout-minutes: 15
 
     steps:
       - name: Get the source code
@@ -140,48 +203,47 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
-      - name: Check if Helper version exists on PyPI
-        id: check-helper-version
+      - name: Install build tools
         run: |
-          VERSION="${{ needs.get-versions.outputs.helper-version }}"
-          echo "Checking if keeper-secrets-manager-helper version $VERSION exists on PyPI..."
-          if pip index versions keeper-secrets-manager-helper 2>/dev/null | grep -qE "\b$VERSION\b"; then
-            echo "Version $VERSION already exists on PyPI"
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version $VERSION does not exist on PyPI"
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install build twine 'wheel>=0.46.3'  # wheel pin: CVE-2026-24049
 
-      - name: Retrieve secrets from KSM
-        if: steps.check-helper-version.outputs.exists == 'false'
-        id: ksmsecrets
+      # ── SDK ────────────────────────────────────────────────────────────────
+
+      - name: Retrieve PyPI token from KSM (SDK)
+        id: ksmsecrets-sdk
         uses: Keeper-Security/ksm-action@master
         with:
           keeper-secret-config: ${{ secrets.KSM_PYPI_PUBLISHER_PYPI_SDK_CONFIG }}
           secrets: |
             -aBWi3-yU_qvatNh0Eaqew/field/password > PYPI_API_TOKEN
 
-      - name: Install dependencies
-        if: steps.check-helper-version.outputs.exists == 'false'
-        run: |
-          python3 -m pip install --upgrade setuptools pip twine
-          python3 -m pip install 'wheel>=0.46.3'  # CVE-2026-24049: ensure patched version
-          python3 -m pip install -r requirements.txt
-
-      - name: Build and Publish Helper
-        if: steps.check-helper-version.outputs.exists == 'false'
+      - name: Build and publish SDK
+        working-directory: ./sdk/python/core
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ steps.ksmsecrets.outputs.PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ steps.ksmsecrets-sdk.outputs.PYPI_API_TOKEN }}
         run: |
-          python3 setup.py build
-          python3 setup.py sdist
+          python3 -m build --no-isolation
           python3 -m twine upload --verbose dist/*
 
-      - name: Skip Helper publishing (already exists)
-        if: steps.check-helper-version.outputs.exists == 'true'
+      # ── Helper ─────────────────────────────────────────────────────────────
+
+      - name: Retrieve PyPI token from KSM (Helper)
+        id: ksmsecrets-helper
+        uses: Keeper-Security/ksm-action@master
+        with:
+          keeper-secret-config: ${{ secrets.KSM_PYPI_PUBLISHER_PYPI_SDK_CONFIG }}
+          secrets: |
+            -aBWi3-yU_qvatNh0Eaqew/field/password > PYPI_API_TOKEN
+
+      - name: Build and publish Helper
+        working-directory: ./sdk/python/helper
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ steps.ksmsecrets-helper.outputs.PYPI_API_TOKEN }}
         run: |
-          echo "::notice::Skipping Helper publishing - version ${{ needs.get-versions.outputs.helper-version }} already exists on PyPI"
+          python3 -m build --no-isolation
+          python3 -m twine upload --verbose dist/*

--- a/.github/workflows/test.ansible.yml
+++ b/.github/workflows/test.ansible.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.cli.yml
+++ b/.github/workflows/test.cli.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.python.helper.yml
+++ b/.github/workflows/test.python.helper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.python.yml
+++ b/.github/workflows/test.python.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     defaults:
       run:

--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -2,9 +2,20 @@
 
 For more information see our official documentation page https://docs.keeper.io/secrets-manager/secrets-manager/developer-sdk-library/python-sdk
 
-**Python Requirements**: Python 3.6 or higher
+**Python Requirements**: Python 3.9 or higher
 
 # Change Log
+
+## 17.2.0
+* **Breaking**: Minimum Python version raised from 3.6 to 3.9
+  - Python 3.6-3.8 users: pip will automatically install v17.1.x (no action needed)
+  - Security/bug fixes backported to v17.1.x until August 2026 via `legacy/sdk/python/core/v17.1.x` branch
+* **Security**: KSM-777 - Raised dependency floors to resolve multiple CVEs
+  - `cryptography>=46.0.5` (was >=39.0.1, resolves CVE-2026-26007 elliptic curve vulnerability)
+  - `urllib3>=2.6.3` unconditionally (was split between urllib3 1.x/2.x, resolves CVE-2026-21441, CVE-2025-66471, CVE-2025-66418, CVE-2025-50181, CVE-2025-50182)
+  - `requests>=2.32.4` (resolves CVE-2024-47081 .netrc credentials leak)
+* Removed `importlib_metadata` dependency (stdlib `importlib.metadata` available since Python 3.8)
+* Added Python 3.13 support and CI testing
 
 ## 17.1.0
 * **Security**: KSM-760 - Fixed CVE-2026-23949 (jaraco.context path traversal) in SBOM generation workflow

--- a/sdk/python/core/keeper_secrets_manager_core/_version.py
+++ b/sdk/python/core/keeper_secrets_manager_core/_version.py
@@ -11,4 +11,4 @@
 
 # Single source of truth for package version
 # This file is imported by both setup.py and the package itself
-__version__ = "17.1.0"
+__version__ = "17.2.0"

--- a/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
+++ b/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
@@ -9,7 +9,7 @@
 # Copyright 2023 Keeper Security Inc.
 # Contact: sm@keepersecurity.com
 
-import importlib_metadata
+from importlib.metadata import version as _get_pkg_version, PackageNotFoundError
 import re
 
 logger_name = 'ksm'
@@ -19,7 +19,7 @@ def get_client_version(hardcode=False):
     """Get the version of the client
 
     Primary source: Package __version__ attribute from _version.py (single source of truth)
-    Fallback: importlib_metadata (for edge cases with broken installs)
+    Fallback: importlib.metadata (for edge cases with broken installs)
     Default: Hardcoded version for unit tests or when both fail
 
     The client version uses the major.minor.revision format (e.g., 17.1.0).
@@ -31,7 +31,7 @@ def get_client_version(hardcode=False):
     """
     # Default version for hardcode mode or when all detection methods fail
     version_major = "17"
-    version_minor_default = "1"
+    version_minor_default = "2"
     version_revision_default = "0"
     version = "{}.{}.{}".format(version_major, version_minor_default, version_revision_default)
 
@@ -50,14 +50,14 @@ def get_client_version(hardcode=False):
             # If __version__ isn't available, fall back to importlib_metadata
             pass
 
-        # Fallback: Try importlib_metadata (for edge cases with broken installs)
+        # Fallback: Try importlib.metadata (for edge cases with broken installs)
         try:
-            ksm_version = importlib_metadata.version("keeper-secrets-manager-core")
+            ksm_version = _get_pkg_version("keeper-secrets-manager-core")
             version_parts = ksm_version.split(".")
             version_minor = version_parts[1]
             version_revision = re.search(r'^\d+', version_parts[2]).group()
             version = "{}.{}.{}".format(version_major, version_minor, version_revision)
-        except importlib_metadata.PackageNotFoundError:
+        except PackageNotFoundError:
             # In a unit test or development run, not an installed version. Just use the default.
             pass
         except Exception as err:

--- a/sdk/python/core/requirements.txt
+++ b/sdk/python/core/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=39.0.1,!=44.0.0
-requests>=2.28.2
+cryptography>=46.0.5
+requests>=2.32.4
+urllib3>=2.6.3
 pytest>=7.2.1
-importlib_metadata>=6.0.0

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -16,11 +16,9 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
-    'requests',
-    'cryptography>=39.0.1,!=44.0.0',  # CVE-2026-23949: exclude vulnerable version (remove when dropping Python 3.6)
-    'importlib_metadata',
-    'urllib3>=2.6.0; python_version >= "3.10"',
-    'urllib3>=1.26.0,<1.27; python_version < "3.10"',
+    'requests>=2.32.4',
+    'cryptography>=46.0.5',
+    'urllib3>=2.6.3',
 ]
 
 setup(
@@ -37,7 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=False,
     install_requires=install_requires,
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://github.com/Keeper-Security/secrets-manager",
@@ -50,13 +48,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Security",
     ],
 )

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -189,20 +189,20 @@ class SmokeTest(unittest.TestCase):
         """Test client version detection with various scenarios
 
         KSM-749: Tests the fix for stale .dist-info metadata causing version mismatch.
-        The new implementation prioritizes __version__ from _version.py over importlib_metadata.
+        The new implementation prioritizes __version__ from _version.py over importlib.metadata.
         """
 
         # Test 1: Normal case - __version__ is available (primary path)
         client_version = get_client_version(hardcode=False)
-        self.assertEqual("17.1.0", client_version, "did not get correct version from __version__")
+        self.assertEqual("17.2.0", client_version, "did not get correct version from __version__")
 
         # Test 2: Hardcode mode still works
         client_version = get_client_version(hardcode=True)
-        self.assertEqual("17.1.0", client_version, "did not get the correct client version for hardcoded")
+        self.assertEqual("17.2.0", client_version, "did not get the correct client version for hardcoded")
 
-        # Test 3: Fallback to importlib_metadata when __version__ import fails
+        # Test 3: Fallback to importlib.metadata when __version__ import fails
         # Mock the import to fail, then check fallback works
-        with patch("keeper_secrets_manager_core.keeper_globals.importlib_metadata.version") as mock_meta:
+        with patch("keeper_secrets_manager_core.keeper_globals._get_pkg_version") as mock_meta:
             # Simulate __version__ not being available by patching the import
             with patch.dict('sys.modules', {'keeper_secrets_manager_core._version': None}):
                 mock_meta.return_value = "17.2.25"
@@ -224,13 +224,13 @@ class SmokeTest(unittest.TestCase):
         self.assertEqual(3, len(parts), "__version__ should have 3 parts (major.minor.patch)")
 
         # Test 5: Simulating stale metadata scenario (KSM-749 bug scenario)
-        # This simulates the case where importlib_metadata returns an old version
+        # This simulates the case where importlib.metadata returns an old version
         # but __version__ has the correct current version
-        with patch("keeper_secrets_manager_core.keeper_globals.importlib_metadata.version") as mock_meta:
+        with patch("keeper_secrets_manager_core.keeper_globals._get_pkg_version") as mock_meta:
             # Stale metadata says 16.6.5 (old version)
             mock_meta.return_value = "16.6.5"
             # But __version__ should take precedence with correct version
             client_version = get_client_version(hardcode=False)
             # Should get 17.1.0 from __version__, NOT 16.6.5 from stale metadata
-            self.assertEqual("17.1.0", client_version,
+            self.assertEqual("17.2.0", client_version,
                            "KSM-749: Should use __version__ (17.1.0) not stale metadata (16.6.5)")

--- a/sdk/python/helper/requirements.txt
+++ b/sdk/python/helper/requirements.txt
@@ -1,3 +1,3 @@
-keeper-secrets-manager-core>=17.1.0
+keeper-secrets-manager-core>=17.2.0
 pyyaml>=6.0.1
 iso8601

--- a/sdk/python/helper/setup.py
+++ b/sdk/python/helper/setup.py
@@ -8,14 +8,14 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=17.1.0',
+    'keeper-secrets-manager-core>=17.2.0',
     'pyyaml>=6.0.1',
     'iso8601'
 ]
 
 setup(
     name="keeper-secrets-manager-helper",
-    version="1.0.7",
+    version="1.1.0",
     description="Keeper Secrets Manager SDK helper for managing records.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,7 +29,7 @@ setup(
     package_data={},
     include_package_data=True,
     install_requires=install_requires,
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://app.gitbook.com/"
@@ -43,9 +43,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
Release branch for v17.2.0: raise the Python SDK minimum runtime to 3.9+, ship security dependency upgrades, and harden the PyPI publish workflow.

## Changes

### New Features
- **Python 3.13 support** (KSM-778): adds Python 3.13 to Core and Helper test/runtime support.
- **Wheel publishing for Python packages** (KSM-766): publish `sdist + wheel` for Core and Helper.

### Bug Fixes
- **Security remediation in Python dependencies** (KSM-778): upgrade `cryptography`, `urllib3`, and `requests` to address reported CVEs.
- **Publish pipeline race prevention** (KSM-766): run SBOM scanning from source and add fast-fail version checks before approval/publish.

### Maintenance
- Remove `importlib_metadata` from Core runtime requirements (stdlib on supported versions).
- Update Python CI matrices to 3.9-3.13 across Python SDK-related workflows.

### Breaking Changes
- Minimum supported Python version is now **3.9+** for:
  - `keeper-secrets-manager-core` `17.2.0+`
  - `keeper-secrets-manager-helper` `1.1.0+`
- Python 3.6-3.8 users remain on legacy lines (`core 17.1.x`, `helper 1.0.7`) via `python_requires` resolution.
- Legacy 3.6-3.8 branch receives security backports only (no new features)

## Related Issues
- Closes #926
- KSM-778, KSM-766, KSM-777
