### PR TITLE
KSM-804: warn on stderr when keyring empty and legacy keeper.ini found

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -18,6 +18,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Security**: KSM-761 - Fixed CVE-2026-23949 (jaraco.context path traversal vulnerability)
 - **Fix**: Updated prompt-toolkit from ~=2.0 to >=3.0 (fixes dependency resolution conflicts)
 - **Fix**: Pinned boto3>=1.20.0 to ensure IMDSFetcher support for AWS integrations
+- **Fix**: KSM-804 - Warn on stderr when keyring is active but empty and a keeper.ini file exists at CWD or standard locations, including hint to use `--ini-file`
 
 ## 1.2.0
 - KSM-649 Added AWS KMS JSON support for sync command

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -99,6 +99,18 @@ class Profile:
                 except Exception as e:
                     self.logger.debug("Unexpected keyring error: %s", e, exc_info=True)
                     print(Fore.YELLOW + "Warning: Keyring access failed (see debug logs)" + Style.RESET_ALL, file=sys.stderr)
+                # Upgrade-path warning: keyring is empty but a legacy keeper.ini exists
+                if len(self._config.profile_list()) == 0:
+                    found_ini_file = self._find_ini_file()
+                    if found_ini_file is not None:
+                        print(Fore.YELLOW + "Warning: Keyring has no profiles, but a keeper.ini file was "
+                              "found at: " + found_ini_file + Style.RESET_ALL, file=sys.stderr)
+                        print(Fore.YELLOW + "  To use it: ksm --ini-file \"" + found_ini_file
+                              + "\" profile list" + Style.RESET_ALL, file=sys.stderr)
+                        self.logger.warning(
+                            "Keyring active but empty; existing keeper.ini at %s will not be used",
+                            found_ini_file
+                        )
             else:
                 found_ini_file = self._find_ini_file()
                 if found_ini_file is not None:


### PR DESCRIPTION
## Summary

On macOS (and any system with `keyring` installed), upgrading to v1.3.0 silently ignores an existing `keeper.ini` because the new keyring-priority path never falls through to `_find_ini_file()`. Users get no indication their profiles are missing or how to recover.

## Changes

- **`profile.py`** — After the `elif KeyringConfigStorage.is_available()` try/except block, check whether the keyring loaded zero profiles. If so, call `_find_ini_file()` and emit a yellow stderr warning with the exact path and a copy-pasteable `--ini-file` hint. No change to priority logic.
- **`tests/keyring_test.py`** — Two new tests in `KeyringStoragePriorityTest`:
  - `test_warn_when_keyring_empty_and_cwd_ini_exists` — asserts warning fires and `use_keyring` stays `True`
  - `test_no_warn_when_keyring_has_profiles_and_ini_exists` — asserts no false-positive warning when keyring is populated
- **`README.md`** — Changelog bullet under `## 1.3.0`

## Test plan

```bash
# Unit tests (all pass)
cd integration/keeper_secrets_manager_cli
python -m pytest tests/keyring_test.py -v

# Integration test (live vault, run locally)
# Test 1: warning fires — real keeper.ini + mock empty keyring
# Test 2: --ini-file connectivity — real keeper.ini + live vault profile list
# Both passed against production vault
```

## Example output (upgrade scenario)

```
$ ksm profile list
Warning: Keyring has no profiles, but a keeper.ini file was found at: /Users/you/project/keeper.ini
  To use it: ksm --ini-file "/Users/you/project/keeper.ini" profile list
```

## Related

Closes KSM-804