### PR TITLE
KSM-805: add SHA-256 cross-session integrity verification for keyring config

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -19,6 +19,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Fix**: Updated prompt-toolkit from ~=2.0 to >=3.0 (fixes dependency resolution conflicts)
 - **Fix**: Pinned boto3>=1.20.0 to ensure IMDSFetcher support for AWS integrations
 - **Fix**: KSM-804 - Warn on stderr when keyring is active but empty and a keeper.ini file exists at CWD or standard locations, including hint to use `--ini-file`
+- **Fix**: KSM-805 - SHA-256 integrity hash now persisted as a separate Keychain entry and verified on every load; tampered entries raise a `KsmCliIntegrityException` with a clear recovery hint
 
 ## 1.2.0
 - KSM-649 Added AWS KMS JSON support for sync command

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exception.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/exception.py
@@ -31,5 +31,15 @@ class KsmCliException(click.ClickException):
         return self.colorize()
 
 
+class KsmCliIntegrityException(KsmCliException):
+    """Raised when a Keychain/keyring entry fails SHA-256 integrity verification.
+
+    This indicates the stored config was modified outside of the CLI
+    (e.g., via Keychain Access.app or the ``security`` CLI).  The caller
+    should surface a recovery hint directing the user to
+    ``ksm profile delete`` and re-initialize.
+    """
+
+
 class KsmRecordSyntaxException:
     pass


### PR DESCRIPTION
## Summary

- Persists a SHA-256 integrity hash as a separate Keychain entry alongside the config on every save
- Verifies the hash on every load; tampered entries raise `KsmCliIntegrityException` with a clear recovery hint
- Deletion bypasses the integrity check so compromised profiles can always be removed via `ksm profile delete`

## Changes

**`exception.py`**
- Add `KsmCliIntegrityException(KsmCliException)` — distinguishes integrity failures from generic CLI errors so they propagate through exception-swallowing layers

**`keyring_config.py`**
- `KeyringUtilityStorage.__init__`: add `skip_integrity_check` parameter (used by deletion path)
- `__load_config`: after loading, compare stored integrity hash; set mismatch flag outside `try/except` so it cannot be swallowed, then raise `KsmCliIntegrityException`
- `__save_config`: write `secret_name + "-integrity"` hash in same `try` block as the config write
- `delete_all`: also delete the integrity entry
- `_get_storage`: add `skip_integrity_check` passthrough; re-raise `KsmCliIntegrityException` before generic catch
- `delete_profile` / `delete_common_config`: pass `skip_integrity_check=True` so tampered entries are always deletable
- `load_profile` / `load_common_config`: re-raise `KsmCliIntegrityException` before the `except KsmCliException: return None` swallow

**`tests/keyring_test.py`**
- Add `KeyringIntegrityTest` with 5 tests (MockKeyring pattern, same as existing tests)

**`README.md`**
- Add KSM-805 bullet under `## 1.3.0`

## Backward Compatibility

Existing installations have no integrity key. `if stored_hash and ...` guard means no check fires on first load. The key is written automatically on the next save — silent bootstrapping, no migration needed.

## Test Plan

```bash
cd integration/keeper_secrets_manager_cli
pip install -e ".[keyring]"
python -m pytest tests/keyring_test.py -v
# → 21 passed
```

Live integration test (macOS Keychain) verified:
- Step 1: Save fresh profile → config + integrity key both written to Keychain ✓
- Step 2: Reload unmodified → passes silently ✓
- Step 3: Tamper config entry directly in Keychain ✓
- Step 4: Reload after tamper → `KsmCliIntegrityException` raised with recovery hint ✓
- Step 5: `delete_profile()` on tampered entry → both entries deleted, no exception ✓

Closes KSM-805