### PR TITLE
KSM-702: ensure custom: [] is included in record create payload

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -20,6 +20,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Fix**: Pinned boto3>=1.20.0 to ensure IMDSFetcher support for AWS integrations
 - **Fix**: KSM-804 - Warn on stderr when keyring is active but empty and a keeper.ini file exists at CWD or standard locations, including hint to use `--ini-file`
 - **Fix**: KSM-805 - SHA-256 integrity hash now persisted as a separate Keychain entry and verified on every load; tampered entries raise a `KsmCliIntegrityException` with a clear recovery hint
+- **Fix**: KSM-702 - Record create payload now always includes `custom: []`; previously the key was silently omitted when no custom fields were set
 
 ## 1.2.0
 - KSM-649 Added AWS KMS JSON support for sync command

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/secret.py
@@ -855,6 +855,8 @@ class Secret:
             record_uids = []
             for record in records:
                 record_create_obj = record.get_record_create_obj()
+                if record_create_obj.custom is None:   # KSM-702: ensure custom: [] is always present
+                    record_create_obj.custom = []
                 folder_options, folders = self.build_folder_options(folder_uid, folders)
                 record_uid = self.cli.client.create_secret_with_options(folder_options, record_create_obj, folders)
                 record_uids.append(record_uid)
@@ -881,6 +883,8 @@ class Secret:
             )
             record = records[0]
             record_create_obj = record.get_record_create_obj()
+            if record_create_obj.custom is None:   # KSM-702
+                record_create_obj.custom = []
 
             folder_options, folders = self.build_folder_options(folder_uid)
             record_uid = self.cli.client.create_secret_with_options(folder_options, record_create_obj, folders)
@@ -915,6 +919,8 @@ class Secret:
                     records = RecordV3.create_from_data(record_data)
                     record = records[0]
                     record_create_obj = record.get_record_create_obj()
+                    if record_create_obj.custom is None:   # KSM-702
+                        record_create_obj.custom = []
                     record_uid = self.cli.client.create_secret_with_options(folder_options, record_create_obj)
                 else:
                     print(f"Unable to find the parent shared folder for record {uid} - individually shared records cannot be cloned.", file=sys.stderr)


### PR DESCRIPTION
## Summary

When creating a record with no custom fields, the CLI was omitting the \`custom\` key entirely from the payload. Vault and Commander always include \`\"custom\": []\`. Added a null guard at all three CLI create callsites to enforce consistent schema.

## Changes

### Bug Fixes
- Record create payload now always includes \`custom: []\` when no custom fields are set (KSM-702)

## Testing

```bash
cd integration/keeper_secrets_manager_cli && python -m pytest tests/ -v
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-702