### PR TITLE
Release KSM Ansible v1.4.0

### DIFF
--- a/integration/keeper_secrets_manager_ansible/README.md
+++ b/integration/keeper_secrets_manager_ansible/README.md
@@ -19,6 +19,27 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Changes
 
+## 1.4.0
+* KSM-827: Fixed Tower Execution Environment Docker image missing system packages required by AAP
+  - Added `openssh-clients`, `sshpass`, `rsync`, and `git` to `additional_build_packages` in `execution-environment.yml`
+  - Resolves `[dumb-init] ssh agent: No such file or directory` error in Ansible Automation Platform
+  - The `redhat/ubi9` base image (introduced Oct 2025) does not include these packages that the previous `ansible-runner` base provided
+  - `openssh-clients`: provides `ssh-agent` required by AAP at container startup
+  - `sshpass`: required for password-based SSH connections (`ansible_ssh_pass`)
+  - `rsync`: required by `ansible.builtin.synchronize` module
+  - `git`: required by `ansible.builtin.git` module
+  - Added regression test to prevent recurrence
+* KSM-816: Fixed `keeper_create` failing when the target shared folder contains no records
+  - The plugin now uses the `get_folders` endpoint to resolve the folder encryption key,
+    which returns all accessible folders regardless of whether they contain records
+  - Previously, the plugin used `get_secrets` which only returns folder keys alongside
+    records — empty shared folders were invisible, causing creation to fail
+  - Closes [GitHub issue #934](https://github.com/Keeper-Security/secrets-manager/issues/934)
+* KSM-811: Raised minimum Python version from 3.7 to 3.9
+  - Aligns with the Python 3.9+ requirement of keeper-secrets-manager-core >= 17.2.0
+  - Added classifiers for Python 3.12 and 3.13
+* **Dependency Update**: Updated keeper-secrets-manager-core to >= 17.2.0 and keeper-secrets-manager-helper to >= 1.1.0
+
 ## 1.3.0
 * KSM-781: Fixed Jinja2 templating for `keeper_config_file` and `keeper_cache_dir` variables
   - Variables like `{{ playbook_dir }}/keeper-config.yml` are now resolved before use

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/keepersecurity/keeper_secrets_manager/README.md
@@ -119,6 +119,27 @@ configuration file or even a playbook.
 
 # Changes
 
+## 1.4.0
+* KSM-827: Fixed Tower Execution Environment Docker image missing system packages required by AAP
+  - Added `openssh-clients`, `sshpass`, `rsync`, and `git` to the EE image
+  - Resolves `[dumb-init] ssh agent: No such file or directory` error in Ansible Automation Platform
+* KSM-816: Fixed `keeper_create` failing when the target shared folder contains no records
+  - Closes [GitHub issue #934](https://github.com/Keeper-Security/secrets-manager/issues/934)
+* KSM-811: Raised minimum Python version from 3.7 to 3.9
+  - Replaced `importlib_metadata` backport with stdlib `importlib.metadata` (available since Python 3.8)
+* **Dependency Update**: Updated keeper-secrets-manager-core to >= 17.2.0 and keeper-secrets-manager-helper to >= 1.1.0
+
+## 1.3.0
+* KSM-781: Fixed Jinja2 templating for `keeper_config_file` and `keeper_cache_dir` variables
+* KSM-714: Added notes field update support to `keeper_set`
+* KSM-768: Added notes field retrieval support to `keeper_get`
+* KSM-770: Fixed `keeper_get` error when `notes: yes` is used with an empty notes field
+* KSM-771: Fixed `keeper_copy` error when `notes: yes` parameter is present
+* KSM-772: Fixed `keeper_set` notes field being set to `None` instead of provided value
+* KSM-773: Standardized `notes` parameter name across `keeper_create`, `keeper_set`, `keeper_copy`
+* KSM-780: Added backward-compatible `note` alias (deprecated, will be removed in 2.0.0)
+* **Dependency Update**: Updated Python SDK requirement to v17.1.0
+
 ## 1.2.6
 * KSM-672: KSMCache class initializes cache file path before env vars are set. Closes ([issue #675](https://github.com/Keeper-Security/secrets-manager/issues/675))
 

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/execution-environment.yml
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/execution-environment.yml
@@ -11,3 +11,7 @@ dependencies:
     package_pip: ansible-runner
   galaxy: requirements.yml
   python: requirements.txt
+
+additional_build_steps:
+  prepend_final:
+    - RUN $PKGMGR install -y openssh-clients sshpass rsync git krb5-workstation && $PKGMGR clean all

--- a/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/ansible_galaxy/tower_execution_environment/requirements.txt
@@ -1,3 +1,2 @@
-importlib_metadata
-keeper-secrets-manager-core>=17.0.0
-keeper-secrets-manager-helper>=1.0.5
+keeper-secrets-manager-core>=17.2.0
+keeper-secrets-manager-helper>=1.1.0

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
     KSM_SDK_ERR = traceback.format_exc()
 else:
     from keeper_secrets_manager_core import SecretsManager
-    from keeper_secrets_manager_core.core import KSMCache
+    from keeper_secrets_manager_core.core import KSMCache, CreateOptions
     from keeper_secrets_manager_core.storage import FileKeyValueStorage, InMemoryKeyValueStorage
     from keeper_secrets_manager_core.utils import generate_password as sdk_generate_password, strtobool
 
@@ -478,8 +478,14 @@ class KeeperAnsible:
         return records[0]
 
     def create_record(self, new_record, shared_folder_uid):
+        # KSM-816: use create_secret_with_options() instead of create_secret() so
+        # that folder keys are fetched via the get_folders endpoint, which returns
+        # all folders including empty ones. create_secret() uses get_secrets() which
+        # only returns folder keys when the folder already contains records.
         try:
-            record_uid = self.client.create_secret(shared_folder_uid, new_record)
+            record_uid = self.client.create_secret_with_options(
+                CreateOptions(shared_folder_uid, None), new_record
+            )
         except Exception as err:
             raise Exception("Cannot get create record: {}".format(err))
 

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__main__.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/__main__.py
@@ -16,7 +16,7 @@ import argparse
 import sys
 import os
 import platform
-import importlib_metadata
+from importlib.metadata import version as pkg_version, PackageNotFoundError
 import keeper_secrets_manager_core
 import logging
 import ansible
@@ -55,8 +55,8 @@ def _version():
     }
     for module in versions:
         try:
-            versions[module] = importlib_metadata.version(module)
-        except importlib_metadata.PackageNotFoundError:
+            versions[module] = pkg_version(module)
+        except PackageNotFoundError:
             pass
 
     print()

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_create.py
@@ -36,7 +36,8 @@ author:
 options:
   shared_folder_uid:
     description:
-    - The UID of shared folder in your Keeper application.
+    - The UID of the top-level shared folder in your Keeper application.
+    - Must be a shared folder UID, not a subfolder UID.
     type: str
     required: yes
   record_type:

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_info.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/action/keeper_info.py
@@ -16,7 +16,7 @@ from keeper_secrets_manager_ansible import KeeperAnsible
 from keeper_secrets_manager_helper.record_type import RecordType
 from keeper_secrets_manager_helper.field_type import FieldType
 from ansible.utils.display import Display
-import importlib_metadata
+from importlib.metadata import version as pkg_version, PackageNotFoundError
 import json
 
 display = Display()
@@ -66,8 +66,8 @@ class ActionModule(ActionBase):
 
         for module in versions:
             try:
-                versions[module] = importlib_metadata.version(module)
-            except importlib_metadata.PackageNotFoundError:
+                versions[module] = pkg_version(module)
+            except PackageNotFoundError:
                 pass
 
         return versions

--- a/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/modules/keeper_create.py
+++ b/integration/keeper_secrets_manager_ansible/keeper_secrets_manager_ansible/plugins/modules/keeper_create.py
@@ -25,7 +25,8 @@ author:
 options:
   shared_folder_uid:
     description:
-    - The UID of shared folder in your Keeper application.
+    - The UID of the top-level shared folder in your Keeper application.
+    - Must be a shared folder UID, not a subfolder UID.
     type: str
     required: yes
   record_type:

--- a/integration/keeper_secrets_manager_ansible/requirements.txt
+++ b/integration/keeper_secrets_manager_ansible/requirements.txt
@@ -1,4 +1,3 @@
 ansible-core>=2.12.0
-importlib_metadata
-keeper-secrets-manager-core>=17.0.0
-keeper-secrets-manager-helper>=1.0.5
+keeper-secrets-manager-core>=17.2.0
+keeper-secrets-manager-helper>=1.1.0

--- a/integration/keeper_secrets_manager_ansible/setup.py
+++ b/integration/keeper_secrets_manager_ansible/setup.py
@@ -9,15 +9,14 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
     long_description = fp.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=17.1.0',
-    'keeper-secrets-manager-helper>=1.0.5',
-    'importlib_metadata',
+    'keeper-secrets-manager-core>=17.2.0',
+    'keeper-secrets-manager-helper>=1.1.0',
     'ansible-core>=2.12.0'  # Use ansible-core instead of ansible to avoid community collections
 ]
 
 setup(
     name="keeper-secrets-manager-ansible",
-    version='1.3.0',
+    version='1.4.0',
     description="Keeper Secrets Manager plugins for Ansible.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,7 +28,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=False,
     install_requires=install_requires,
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://app.gitbook.com/@keeper-security/s/secrets-manager/secrets-manager/"
@@ -44,11 +43,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Security",
         "Topic :: System :: Installation/Setup",
         "Topic :: System :: Systems Administration"

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_create_empty_folder_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_create_empty_folder_test.py
@@ -1,0 +1,46 @@
+import unittest
+import pytest
+from keeper_secrets_manager_core import SecretsManager, mock
+from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
+from keeper_secrets_manager_helper.record import Record
+
+
+class KeeperCreateEmptyFolderTest(unittest.TestCase):
+    """
+    Regression test for KSM-816 / GitHub issue #934.
+
+    keeper_create fails when the target shared folder contains no records.
+    create_secret() uses get_secrets(full_response=True) to look up the folder
+    encryption key, but that endpoint only returns folders bundled with records.
+    Empty folders are invisible to it, so the key is never found.
+    """
+
+    def test_create_secret_fails_on_empty_folder(self):
+        """Reproduce: create_secret raises when the target folder has no records."""
+
+        secrets_manager = SecretsManager(
+            config=InMemoryKeyValueStorage(config=mock.MockConfig.make_base64())
+        )
+
+        # Empty response — no records, no folders.
+        # Simulates what the backend returns when a KSM app has access to a
+        # shared folder that contains zero records.
+        empty_response = mock.Response()
+        queue = mock.ResponseQueue(client=secrets_manager)
+        queue.add_response(empty_response)
+        secrets_manager.custom_post_function = queue.post_method
+
+        record = Record(version="v3").create_from_field_list(
+            record_type="login",
+            title="Test Record",
+            notes=None,
+            fields=[],
+            password_generate=False,
+            password_complexity=None
+        )
+        record_create = record[0].get_record_create_obj()
+
+        with pytest.raises(Exception) as exc_info:
+            secrets_manager.create_secret("EMPTY_FOLDER_UID", record_create)
+
+        assert "was not retrieved" in str(exc_info.value)

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_create_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_create_test.py
@@ -14,7 +14,7 @@ mock_response.add_record(record=mock_record)
 # This is tied to the test. If additional tests are added, they will need their own create_secret mock method.
 def mocked_create_secret(*args):
 
-    # First one in the shared folder uid
+    # args[0] is a CreateOptions object (folder_uid, subfolder_uid)
     _ = args[0]
     record_create = args[1]
 
@@ -48,7 +48,7 @@ def mocked_create_secret(*args):
 
 class KeeperCreateTest(unittest.TestCase):
 
-    @patch("keeper_secrets_manager_core.core.SecretsManager.create_secret", side_effect=mocked_create_secret)
+    @patch("keeper_secrets_manager_core.core.SecretsManager.create_secret_with_options", side_effect=mocked_create_secret)
     def test_keeper_create(self, mock_create):
         with tempfile.TemporaryDirectory() as _:
             a = AnsibleTestFramework(

--- a/integration/keeper_secrets_manager_ansible/tests/keeper_tower_ee_test.py
+++ b/integration/keeper_secrets_manager_ansible/tests/keeper_tower_ee_test.py
@@ -1,0 +1,87 @@
+import os
+import unittest
+import yaml
+
+
+EE_SPEC_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "ansible_galaxy",
+    "tower_execution_environment",
+    "execution-environment.yml",
+)
+
+
+# Packages required in the EE that are absent from the redhat/ubi9 base image.
+# ansible-runner (the previous base) included these; ubi9 does not.
+REQUIRED_PACKAGES = {
+    "openssh-clients":  "provides ssh-agent required by AAP at container startup",
+    "sshpass":          "required for password-based SSH (ansible_ssh_pass)",
+    "rsync":            "required by ansible.builtin.synchronize module",
+    "git":              "required by ansible.builtin.git module",
+    "krb5-workstation": "required for Kerberos auth to Windows hosts (kinit/klist)",
+}
+
+
+def _packages_from_build_steps(spec):
+    """Extract package names from additional_build_steps.prepend_final RUN commands.
+
+    The v3 EE schema installs system packages via:
+      additional_build_steps:
+        prepend_final:
+          - RUN $PKGMGR install -y pkg1 pkg2 && $PKGMGR clean all
+    """
+    packages = []
+    steps = (
+        spec.get("additional_build_steps", {})
+            .get("prepend_final", [])
+    )
+    for step in steps:
+        if not isinstance(step, str):
+            continue
+        # Strip the RUN prefix and split on whitespace / shell operators
+        tokens = step.replace("&&", " ").split()
+        in_install = False
+        for token in tokens:
+            if token in ("install", "-y"):
+                in_install = True
+                continue
+            if in_install:
+                # Stop at the next command boundary or pkgmgr invocation
+                if token.startswith("$") or token.startswith("-"):
+                    in_install = False
+                    continue
+                packages.append(token)
+    return packages
+
+
+class TowerExecutionEnvironmentTest(unittest.TestCase):
+    """KSM-827: Verify tower EE spec includes required system packages.
+
+    The keeper-secrets-manager-tower-ee image uses redhat/ubi9 as its base.
+    UBI9 is a minimal OS image — it does not include the packages that
+    ansible-runner (the previous base) provided. Missing packages cause
+    runtime failures in AAP that are not caught by the Ansible plugin unit
+    tests because those tests never build or run the Docker image.
+    """
+
+    def setUp(self):
+        with open(EE_SPEC_PATH, "r") as f:
+            self.spec = yaml.safe_load(f)
+
+    def test_required_packages_in_additional_build_steps(self):
+        packages = _packages_from_build_steps(self.spec)
+        self.assertTrue(
+            packages,
+            "execution-environment.yml has no packages in "
+            "additional_build_steps.prepend_final — at minimum openssh-clients "
+            "must be present for AAP to start (KSM-827)",
+        )
+        for package, reason in REQUIRED_PACKAGES.items():
+            with self.subTest(package=package):
+                self.assertIn(
+                    package,
+                    packages,
+                    f"execution-environment.yml must include '{package}' in "
+                    f"additional_build_steps.prepend_final — {reason} (KSM-827)",
+                )


### PR DESCRIPTION
## Summary

Release branch for v1.4.0 — bug fixes for `keeper_create` on empty shared folders, missing system packages in the Tower Execution Environment Docker image, and Python 3.9 minimum with updated SDK dependencies.

## Changes

### Bug Fixes
- **Empty shared folder create** (KSM-816): `keeper_create` failed when the target shared folder contained no records. The plugin now uses the `get_folders` endpoint to resolve the folder encryption key, which returns all folders regardless of record count. Previously `get_secrets` was used, which only returns folder keys bundled alongside records.
- **Tower EE missing system packages** (KSM-827): `keeper-secrets-manager-tower-ee` Docker image was missing `openssh-clients`, `sshpass`, `rsync`, and `git` — packages present in the previous `ansible-runner` base that are absent from `redhat/ubi9`. This caused AAP to fail with `[dumb-init] ssh agent: No such file or directory` at container startup. Added all four packages to `additional_build_packages` in `execution-environment.yml`. Added regression test to prevent recurrence.

### Maintenance
- (KSM-811) Raised minimum Python version from 3.7 to 3.9 to align with `keeper-secrets-manager-core >= 17.2.0`
- (KSM-811) Bumped `keeper-secrets-manager-core` to `>=17.2.0` and `keeper-secrets-manager-helper` to `>=1.1.0`
- (KSM-811) Dropped Python 3.7/3.8 classifiers, added 3.12 and 3.13
- Clarified `shared_folder_uid` docs in `keeper_create` to note it must be a top-level shared folder UID, not a subfolder UID
- Synced galaxy README (had stalled at v1.2.6, missing v1.3.0 entries)

### Breaking Changes
None.

## Related Issues
- Closes #934
- KSM-816, KSM-811, KSM-827