### PR TITLE
KSM-818: pin click-repl<0.3.0 to fix shell crash with click>=8.2

### DIFF
--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -18,7 +18,9 @@ install_requires = [
     'importlib_metadata',
     'click',
     'click_help_colors',
-    'click-repl',
+    # KSM-818: click-repl 0.3.0 crashes with click>=8.2 (protected_args became read-only).
+    # Pin to <0.3.0 until click-repl releases Click 8.2+ support (see click-repl PR #132).
+    'click-repl>=0.2.0,<0.3.0',
     'pyyaml',
     'update-checker',
     'psutil>=5.0.0',

--- a/integration/keeper_secrets_manager_cli/tests/shell_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/shell_test.py
@@ -1,0 +1,37 @@
+import unittest
+import importlib.metadata
+
+
+class ShellTest(unittest.TestCase):
+
+    def test_click_repl_compatible_with_installed_click(self):
+        """KSM-818 regression: click-repl must be compatible with the installed click version.
+
+        click-repl 0.3.0 crashes with click>=8.2 because Context.protected_args
+        was made read-only in that release. click-repl 0.3.0 assigns to it at
+        _repl.py:134 during REPL command dispatch, raising AttributeError.
+
+        setup.py pins click-repl>=0.2.0,<0.3.0 to prevent pip from resolving the
+        incompatible combination. This test verifies that invariant holds in the
+        installed environment.
+
+        See: https://keeper.atlassian.net/browse/KSM-818
+        """
+        click_version_str = importlib.metadata.version('click')
+        repl_version_str = importlib.metadata.version('click-repl')
+
+        click_major, click_minor = (int(x) for x in click_version_str.split('.')[:2])
+        repl_major, repl_minor = (int(x) for x in repl_version_str.split('.')[:2])
+
+        if (click_major, click_minor) >= (8, 2):
+            self.assertLess(
+                (repl_major, repl_minor),
+                (0, 3),
+                f"KSM-818: click-repl {repl_version_str} is incompatible with "
+                f"click {click_version_str} (>= 8.2 makes protected_args read-only). "
+                f"Pin click-repl<0.3.0 in setup.py until click-repl PR #132 is released."
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `ksm shell` crashes immediately on any command when `click-repl==0.3.0` is installed with `click>=8.2`
- Click 8.2 made `Context.protected_args` a read-only property; click-repl 0.3.0 assigns to it at `_repl.py:134`, raising `AttributeError`
- Pin `click-repl>=0.2.0,<0.3.0` — version 0.2.0 does not touch `protected_args` and is confirmed compatible with click 8.3.x

## Changes

- **`setup.py`**: pin `click-repl>=0.2.0,<0.3.0` with explanatory comment referencing click-repl PR #132
- **`tests/shell_test.py`**: regression test — asserts that if click>=8.2 is installed, click-repl must be <0.3.0

## Reproduction

Windows QA (Python 3.13): `click==8.3.1` + `click-repl==0.3.0` → crash on first shell command:
```
ksm had a problem: property 'protected_args' of 'Context' object has no setter
```

macOS QA (Python 3.14): `click-repl==0.2.0` → works (no constraint in setup.py, pip resolved 0.2.0 by luck)

## Testing

Regression test passes:
```bash
cd integration/keeper_secrets_manager_cli
pytest tests/shell_test.py -v   # 1 passed
pytest tests/ -v                # 120 passed
```

Manual verification: `ksm shell` → typed `secret list` → dispatched successfully (got expected network error, not `AttributeError`).

## Notes

- When click-repl releases a version compatible with Click 8.2+ (upstream PR #132), update the pin
- The `click_help_colors` deprecation warning (`MultiCommand` → `Group`) is an unrelated upstream issue in click-help-colors 0.9.4 (latest)

Closes KSM-818