### PR TITLE
KSM-828: prevent unit tests from writing mock data to real system keyring

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -26,6 +26,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Fix**: KSM-815 - Profile name is now validated before redeeming the one-time token; invalid names (containing whitespace or exceeding 64 characters) are rejected immediately, preventing the token from being consumed on a failed init
 - **Fix**: KSM-818 - `ksm shell` no longer crashes on any command when click>=8.2 is installed; pinned click-repl to <0.3.0 (0.3.0 incompatible with click>=8.2)
 - **Fix**: KSM-820 - `ksm secret get --json` now outputs custom fields under `"custom"` key (was `"custom_fields"`), matching the canonical V3 record format used by Commander and the Keeper Vault
+- **Fix**: KSM-828 - Unit tests no longer write mock data to the real system keyring; added `KeyringConfigStorage.is_available` mock to all tests that call `Profile.init()` as scaffolding (`secret_test.py`, `exec_test.py`, `secret_inflate_test.py`)
 
 ## 1.2.0
 - KSM-649 Added AWS KMS JSON support for sync command

--- a/integration/keeper_secrets_manager_cli/tests/exec_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/exec_test.py
@@ -56,7 +56,9 @@ class ExecTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as \
-                mock_client:
+                mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -123,7 +125,9 @@ class ExecTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -191,7 +195,9 @@ class ExecTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') as \
-                mock_client:
+                mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')

--- a/integration/keeper_secrets_manager_cli/tests/secret_inflate_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/secret_inflate_test.py
@@ -71,7 +71,9 @@ class SecretInflateTest(unittest.TestCase):
         queue.add_response(address_res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')

--- a/integration/keeper_secrets_manager_cli/tests/secret_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/secret_test.py
@@ -80,7 +80,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -133,7 +135,9 @@ class SecretTest(unittest.TestCase):
             queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -229,7 +233,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -276,7 +282,9 @@ class SecretTest(unittest.TestCase):
             queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -330,7 +338,9 @@ class SecretTest(unittest.TestCase):
 
         with patch('requests.get', side_effect=mock_download_get) as mock_get:
             with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                    as mock_client:
+                    as mock_client, \
+                 patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                       return_value=False):
                 mock_client.return_value = secrets_manager
 
                 Profile.init(token='MY_TOKEN')
@@ -351,7 +361,9 @@ class SecretTest(unittest.TestCase):
 
         with patch('requests.get', side_effect=mock_download_get) as mock_get:
             with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                    as mock_client:
+                    as mock_client, \
+                 patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                       return_value=False):
                 mock_client.return_value = secrets_manager
 
                 Profile.init(token='MY_TOKEN')
@@ -387,7 +399,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -480,7 +494,9 @@ class SecretTest(unittest.TestCase):
 
         with patch('requests.get', side_effect=mock_download_get) as _:
             with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                    as mock_client:
+                    as mock_client, \
+                 patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                       return_value=False):
                 mock_client.return_value = secrets_manager
 
                 Profile.init(token='MY_TOKEN')
@@ -555,7 +571,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -647,7 +665,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -752,7 +772,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -805,7 +827,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(address_res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -848,7 +872,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(record_res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -889,7 +915,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(totp_res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -1042,7 +1070,9 @@ class SecretTest(unittest.TestCase):
         queue.add_response(profile_init_res)
 
         with patch('keeper_secrets_manager_cli.KeeperCli.get_client') \
-                as mock_client:
+                as mock_client, \
+             patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')
@@ -1093,7 +1123,9 @@ class SecretTest(unittest.TestCase):
         with _patch('keeper_secrets_manager_cli.KeeperCli.get_client') as mock_client, \
              _patch.object(secrets_manager, 'get_folders', return_value=[fake_folder]), \
              _patch.object(secrets_manager, 'create_secret_with_options',
-                           return_value='NEWUID0000000000000000') as mock_create:
+                           return_value='NEWUID0000000000000000') as mock_create, \
+             _patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                    return_value=False):
             mock_client.return_value = secrets_manager
 
             Profile.init(token='MY_TOKEN')


### PR DESCRIPTION
## Summary

- Add `KeyringConfigStorage.is_available` mock (returning `False`) to all 19 `Profile.init()` call sites in the CLI test suite that use it as scaffolding boilerplate
- Fixes silent corruption of the real system keyring (`_default` profile) when tests run on macOS, Windows, or Linux with a keyring backend available

## Root cause

KSM-800 changed `Profile.init()` to default to keyring storage when `keyring_available=True`. The affected tests predate that change and test *secret operations*, not keyring storage — they call `Profile.init(token='MY_TOKEN')` as setup boilerplate without preventing keyring writes.

## Changes

- `tests/secret_test.py` — 16 locations (including new `test_custom_fields_json_key` from upstream)
- `tests/exec_test.py` — 3 locations
- `tests/secret_inflate_test.py` — 1 location
- `README.md` — changelog entry for 1.3.0

## Test plan

- [x] All 130 tests pass locally (`python -m pytest tests/ -v`)
- [x] Keyring not corrupted: `hostname = US` before and after full test run (verified on macOS Keychain)

## Related

Closes KSM-828