### PR TITLE
KSM-831: fix boto3 import error for non-AWS --ini-file profiles

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -28,6 +28,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Fix**: KSM-820 - `ksm secret get --json` now outputs custom fields under `"custom"` key (was `"custom_fields"`), matching the canonical V3 record format used by Commander and the Keeper Vault
 - **Fix**: KSM-828 - Unit tests no longer write mock data to the real system keyring; added `KeyringConfigStorage.is_available` mock to all tests that call `Profile.init()` as scaffolding (`secret_test.py`, `exec_test.py`, `secret_inflate_test.py`)
 - **Fix**: KSM-829 - Profile name validation before OTT redemption now uses the same strict pattern as keyring storage (`[a-zA-Z0-9_-]{1,64}`); previously the early check allowed path-traversal characters and special characters through, consuming the one-time token before the stricter validator fired
+- **Fix**: KSM-831 - `--ini-file` no longer fails with `Missing import dependencies: boto3` for non-AWS profiles; `AwsConfigProvider` import is now deferred to the `aws` storage branch in `_load_config`, so users without the `[aws]` extra are unaffected
 ## 1.2.0
 - KSM-649 Added AWS KMS JSON support for sync command
 - KSM-465 Implemented ksm interpolate command for shell built-in compatibility

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/config.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/config.py
@@ -158,8 +158,6 @@ class Config:
             raise PermissionError("Cannot find configuration file {}.".format(self.ini_file))
 
     def _load_config(self, section: configparser.SectionProxy):
-        from keeper_secrets_manager_storage.storage_aws_secret import AwsConfigProvider
-
         storage = section.get("storage", "")
         if storage in ("", "internal"):
             return ConfigProfile(
@@ -170,6 +168,7 @@ class Config:
                     app_owner_public_key=section.get("appownerpublickey"),
                     server_public_key_id=section.get("serverpublickeyid"))
         elif storage == "aws":
+            from keeper_secrets_manager_storage.storage_aws_secret import AwsConfigProvider
             cfg = ConfigProfile(storage=storage)
             cfg.storage_config = {x: section.get(x) for x in section.keys() if x != "storage"}
 

--- a/integration/keeper_secrets_manager_cli/tests/profile_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/profile_test.py
@@ -942,5 +942,66 @@ color = True
                              "'profile import' created default keeper.ini instead of using --ini-file")
 
 
+    def test_ini_file_with_internal_storage_does_not_require_boto3(self):
+        """Regression test: --ini-file with internal storage must not require boto3.
+
+        _load_config() must not import AwsConfigProvider unconditionally at the top of
+        the function — doing so triggers a top-level 'import boto3' in storage_aws_secret.py
+        even for profiles with storage=internal, causing a hard failure when boto3 is not
+        installed (e.g., pip install keeper-secrets-manager-cli[keyring] without [aws]).
+
+        The import must be deferred to inside the 'elif storage == "aws":' branch so that
+        non-AWS profiles load without requiring boto3.
+        """
+        import sys
+
+        custom_profile_name = "boto3-regression-profile"
+        ini_content = (
+            "[{profile}]\n"
+            "clientid = DUMMY_CLIENT_ID\n"
+            "privatekey = DUMMY_PRIVATE_KEY\n"
+            "appkey = DUMMY_APP_KEY\n"
+            "hostname = keepersecurity.com\n"
+            "\n"
+            "[_config]\n"
+            "active_profile = {profile}\n"
+        ).format(profile=custom_profile_name)
+
+        ini_path = os.path.join(self.temp_dir.name, "custom_boto3_regression.ini")
+        with open(ini_path, "w") as fh:
+            fh.write(ini_content)
+        os.chmod(ini_path, 0o600)
+
+        mock_config = MockConfig.make_config()
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(mock_config))
+
+        # Simulate boto3 not being installed by removing storage_aws_secret from sys.modules
+        # and making boto3 unimportable. The bug causes _load_config() to import the module
+        # unconditionally, which triggers import boto3, which fails.
+        aws_mod_key = "keeper_secrets_manager_storage.storage_aws_secret"
+        saved = sys.modules.pop(aws_mod_key, None)
+        try:
+            with patch.dict(sys.modules, {"boto3": None}):
+                with patch("keeper_secrets_manager_cli.KeeperCli.get_client") as mock_client:
+                    mock_client.return_value = secrets_manager
+                    runner = CliRunner()
+                    result = runner.invoke(
+                        cli,
+                        ["--ini-file", ini_path, "profile", "list", "--json"],
+                        catch_exceptions=False,
+                    )
+        finally:
+            if saved is not None:
+                sys.modules[aws_mod_key] = saved
+
+        self.assertEqual(0, result.exit_code,
+                         "--ini-file with internal storage failed without boto3: "
+                         + result.output)
+        profiles = json.loads(result.output)
+        profile_names = [p["name"] for p in profiles]
+        self.assertIn(custom_profile_name, profile_names,
+                      "expected profile not found in --ini-file output")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

`ksm --ini-file` failed with `Missing import dependencies: boto3` for standard (non-AWS) profiles. `_load_config()` unconditionally imported `AwsConfigProvider` at the top of the function, which triggered a module-level `import boto3` in `storage_aws_secret.py` even for `storage=internal` profiles — breaking users who installed without the `[aws]` extra (e.g., `pip install keeper-secrets-manager-cli[keyring]`).

## Changes

### Fixed
- `--ini-file` with non-AWS profiles no longer requires boto3; `AwsConfigProvider` import deferred to inside the `elif storage == "aws":` branch in `_load_config` (KSM-831)

## Testing

```bash
cd integration/keeper_secrets_manager_cli
pytest tests/profile_test.py -v
```

Regression test: `test_ini_file_with_internal_storage_does_not_require_boto3` — patches boto3 out of `sys.modules` and asserts `ksm --ini-file <path> profile list` succeeds.

Live test (no boto3 installed):
```bash
pip install -e .  # no [aws]
ksm --ini-file /path/to/keeper.ini profile list
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-831