### PR TITLE
KSM-839: fix AwsKeyValueStore.delete() skipping keys with falsy values

### DIFF
--- a/sdk/javascript/packages/aws/src/AwsKeyValueStore.ts
+++ b/sdk/javascript/packages/aws/src/AwsKeyValueStore.ts
@@ -462,7 +462,7 @@ export class AWSKeyValueStorage implements KeyValueStorage {
   public async delete(key: string): Promise<void> {
     const config = await this.readStorage();
 
-    if (config[key]) {
+    if (key in config) {
       this.logger.debug(`Deleting key ${key} from ${this.configFileLocation.toString()}`);
       delete config[key];
     } else {

--- a/sdk/javascript/packages/aws/test/AwsKeyValueStorage.test.ts
+++ b/sdk/javascript/packages/aws/test/AwsKeyValueStorage.test.ts
@@ -294,6 +294,50 @@ describe('AWSKeyValueStorage', () => {
         });
     });
 
+    // KSM-839: Regression tests for delete() — truthy check skips falsy values
+    describe('delete() — KSM-839 regression', () => {
+        let storage: AWSKeyValueStorage;
+
+        beforeEach(() => {
+            const keyId = 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012';
+            const awsSessionConfig = new AWSSessionConfig('AKIATEST', 'secret-key', 'us-east-1');
+            storage = new AWSKeyValueStorage(keyId, null, awsSessionConfig, null as any);
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('delete() should remove a key whose value is an empty string', async () => {
+            const mockConfig: Record<string, string> = { emptyKey: '' };
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            await storage.delete('emptyKey');
+
+            expect(mockConfig).not.toHaveProperty('emptyKey');
+        });
+
+        it('delete() should remove a key whose value is falsy (0)', async () => {
+            const mockConfig: Record<string, any> = { zeroKey: 0 };
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            await storage.delete('zeroKey');
+
+            expect(mockConfig).not.toHaveProperty('zeroKey');
+        });
+
+        it('delete() should log "not found" for a truly missing key', async () => {
+            const mockConfig: Record<string, string> = {};
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            // Should not throw; saveStorage still called
+            await expect(storage.delete('missing')).resolves.toBeUndefined();
+        });
+    });
+
     // KSM-836: Regression tests for contains() — incorrect `in` operator usage
     describe('contains() — KSM-836 regression', () => {
         let storage: AWSKeyValueStorage;


### PR DESCRIPTION
## Summary

`AwsKeyValueStore.delete()` used a truthy check (`if (config[key])`) to determine whether a key exists before deleting it. Any key holding a falsy value (`""`, `0`, `false`, `null`) silently survived the delete call — the key persisted in storage and the logger falsely reported "Key not found." Fix applies the same `key in config` pattern already used by `contains()` (fixed in KSM-836).

## Changes

### Bug Fixes
- **delete() falsy-value skip** (KSM-839): replace `if (config[key])` with `if (key in config)` so keys holding `""`, `0`, `false`, or `null` are correctly deleted

## Testing

```bash
cd sdk/javascript/packages/aws
npm test
```

All 50 tests pass, including 3 new regression tests covering empty-string values, numeric zero values, and truly missing keys.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-839