### PR TITLE
KSM-840: fix delete() skipping keys with falsy values in GCP storage

### DIFF
--- a/sdk/javascript/packages/gcp/src/GCPKeyValueStore.ts
+++ b/sdk/javascript/packages/gcp/src/GCPKeyValueStore.ts
@@ -60,7 +60,7 @@ export class GCPKeyValueStorage implements KeyValueStorage {
   public async delete(key: string): Promise<void> {
     const config = await this.readStorage();
 
-    if (config[key]) {
+    if (key in config) {
       this.logger.debug(`Deleting key ${key} from ${this.configFileLocation}`);
       delete config[key];
     } else {

--- a/sdk/javascript/packages/gcp/test/GCPKeyValueStorage.test.ts
+++ b/sdk/javascript/packages/gcp/test/GCPKeyValueStorage.test.ts
@@ -287,4 +287,49 @@ describe('GCPKeyValueStorage', () => {
             expect(result).toBe(false);
         });
     });
+
+    // KSM-840: Regression tests for delete() — truthy check skips falsy values
+    describe('delete() — KSM-840 regression', () => {
+        let storage: GCPKeyValueStorage;
+
+        beforeEach(() => {
+            const gcpKeyConfig = new GCPKeyConfig(
+                'projects/test-project/locations/us-central1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1'
+            );
+            storage = new GCPKeyValueStorage(null, gcpKeyConfig, mockSessionConfig);
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('delete() should remove a key whose value is an empty string', async () => {
+            const mockConfig: Record<string, string> = { emptyKey: '' };
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            await storage.delete('emptyKey');
+
+            expect(mockConfig).not.toHaveProperty('emptyKey');
+        });
+
+        it('delete() should remove a key whose value is falsy (0)', async () => {
+            const mockConfig: Record<string, any> = { zeroKey: 0 };
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            await storage.delete('zeroKey');
+
+            expect(mockConfig).not.toHaveProperty('zeroKey');
+        });
+
+        it('delete() should log "not found" for a truly missing key', async () => {
+            const mockConfig: Record<string, string> = {};
+            jest.spyOn(storage, 'readStorage').mockResolvedValue(mockConfig);
+            jest.spyOn(storage, 'saveStorage').mockResolvedValue(undefined);
+
+            // Should not throw; saveStorage still called
+            await expect(storage.delete('missing')).resolves.toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Fix `GCPKeyValueStore.delete()` silently skipping deletion when a key holds a falsy value (`""`, `0`, `false`).

## Root Cause

`delete()` used `if (config[key])` (truthy check) instead of `if (key in config)` (existence check). Keys with falsy values routed into the `else` branch — the key was never removed and the logger incorrectly reported "Key not found".

**Same bug** was fixed in Azure (KSM-835) and AWS (KSM-839). `contains()` was already corrected for GCP in KSM-837.

## Changes

- `sdk/javascript/packages/gcp/src/GCPKeyValueStore.ts`: Replace `if (config[key])` → `if (key in config)` (line 63)
- `sdk/javascript/packages/gcp/test/GCPKeyValueStorage.test.ts`: Add `describe('delete() — KSM-840 regression')` with 3 tests (empty string, zero, truly missing key)

## Test Plan

```bash
cd sdk/javascript/packages/gcp
npm test
# Expected: 52 tests pass (3 new KSM-840 regression tests + 49 existing)
```

Regression tests confirmed **failing** before fix, **passing** after fix.

Closes https://keeper.atlassian.net/browse/KSM-840