### PR TITLE
KSM-854: fix KeeperFileData crash when lastModified is absent

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.2.0"
+version = "17.2.1"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -57,7 +57,7 @@ data class KeeperFileData(
     val type: String? = null,
     val size: Long,
     @Serializable(with = FlexibleLongSerializer::class)
-    val lastModified: Long
+    val lastModified: Long = 0
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.*
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.2.0"
+const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -122,6 +122,31 @@ internal class SecretsManagerTest {
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
     }
 
+    @Test
+    fun testKeeperFileDataMissingLastModified() {
+        // GH-973 / KSM-854: lastModified entirely absent — must deserialize without throwing
+        val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(0L, result.lastModified)
+        assertEquals("test.txt", result.name)
+    }
+
+    @Test
+    fun testKeeperFileDataIntegerLastModified() {
+        // Regression guard: normal integer lastModified
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1700000000000}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1700000000000L, result.lastModified)
+    }
+
+    @Test
+    fun testKeeperFileDataFractionalLastModified() {
+        // Regression guard for KSM-673: fractional lastModified (iOS client format)
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1760646182.790214}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1760646182L, result.lastModified)
+    }
+
 //    @Test // uncomment to debug the integration test
     fun integrationTest() {
         val trustAllPostFunction: (


### PR DESCRIPTION
## Summary

Fixes a `MissingFieldException` that caused the Java/Kotlin SDK to silently skip file attachments when the decrypted file metadata omits the `lastModified` field. Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit this field.

## Changes

### Bug Fixes
- **KeeperFileData missing lastModified** (KSM-854): add `= 0` default to `KeeperFileData.lastModified` in `RecordData.kt` so kotlinx-serialization uses the default instead of throwing `MissingFieldException` when the field is absent. Matches the behavior of the .NET SDK (KSM-674).
- Bumps version to `17.2.1` (`mj17.2.1`)

## Testing

```bash
cd sdk/java/core
./gradlew test --tests "SecretsManagerTest.testKeeperFileDataMissingLastModified"  # regression test (was failing before fix)
./gradlew test  # full suite
```

## Breaking Changes
None.

## Related Issues
- Closes #973
- Jira: KSM-854
- Related: KSM-673 (fractional lastModified, fixed 17.1.2), KSM-674 (.NET equivalent)