### PR TITLE
Release Java SDK v17.2.1

### DIFF
--- a/.github/workflows/publish.maven.java.core.yml
+++ b/.github/workflows/publish.maven.java.core.yml
@@ -1,13 +1,22 @@
 name: Publish to Maven (Java Core SDK)
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to Maven Central (uncheck to build only)'
+        required: false
+        default: 'true'
+        type: boolean
 
 jobs:
   publish:
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable.maven.central.publish.yml
     with:
       working-directory: ./sdk/java/core
       project-name: keeper-secrets-manager-java
       project-title: Keeper Secrets Manager Java Core SDK
       java-version: '11'
+      publish: ${{ inputs.publish }}
     secrets: inherit

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -159,6 +159,7 @@ jobs:
 
   publish-to-maven-central:
     needs: [get-version, test, generate-and-upload-sbom, confirm-publish]
+    if: ${{ inputs.publish == true }}
     environment: prod
     runs-on: ubuntu-latest
 

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           PROJECT_NAME: ${{ inputs.project-name }}
         run: |
-          VERSION=$(grep -Po 'version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
+          VERSION=$(grep -Po '^version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
           echo "Version retrieved: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -66,8 +66,48 @@ jobs:
           echo "Artifact ID retrieved: $ARTIFACT_ID"
           echo "artifact-id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
 
-  generate-and-upload-sbom:
+  validate-version:
     needs: get-version
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify version not already published on Maven Central
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+          ARTIFACT_ID: ${{ needs.get-version.outputs.artifact-id }}
+        run: |
+          GROUP_PATH="com/keepersecurity/secrets-manager"
+          POM_URL="https://repo1.maven.org/maven2/${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.pom"
+          if curl -sf "$POM_URL" > /dev/null 2>&1; then
+            echo "ERROR: ${ARTIFACT_ID} ${VERSION} already exists on Maven Central"
+            exit 1
+          fi
+          echo "Version ${VERSION} not yet published — OK to proceed"
+
+  test:
+    needs: validate-version
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Java ${{ inputs.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          gradle-version: '8.14'
+      - name: Build and Test
+        run: ./gradlew clean build --no-daemon
+
+  generate-and-upload-sbom:
+    needs: [get-version, validate-version]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -111,14 +151,14 @@ jobs:
           retention-days: 10
 
   confirm-publish:
-    needs: generate-and-upload-sbom
+    needs: [test, generate-and-upload-sbom]
     if: ${{ inputs.publish == true }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publish gate confirmed"
 
   publish-to-maven-central:
-    needs: [get-version, generate-and-upload-sbom, confirm-publish]
+    needs: [get-version, test, generate-and-upload-sbom, confirm-publish]
     environment: prod
     runs-on: ubuntu-latest
 
@@ -157,8 +197,8 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
-      - name: Build and test
-        run: ./gradlew clean build test
+      - name: Build
+        run: ./gradlew clean build -x test --no-daemon
 
       - name: Publish to staging directory
         run: ./gradlew publish
@@ -197,8 +237,8 @@ jobs:
               echo "Found deployment ID: $DEPLOYMENT_ID"
               echo "Checking deployment status via Central Portal API..."
 
-              # Create Bearer token from username:password
-              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64)
+              # Create Bearer token from username:password (no line wrapping)
+              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64 -w 0)
 
               # Poll Portal API for deployment status (max 20 attempts, 30 seconds each = 10 minutes)
               MAX_RETRIES=20

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: '11'
+      publish:
+        description: 'Publish to Maven Central (false = build only)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   get-version:
@@ -31,13 +36,17 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
       artifact-id: ${{ steps.extract-version.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Extract version and artifact ID from Gradle
         id: extract-version
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
         run: |
           VERSION=$(grep -Po 'version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
           echo "Version retrieved: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           # Extract artifactId from settings.gradle.kts (rootProject.name)
           if [ -f "settings.gradle.kts" ]; then
@@ -51,11 +60,11 @@ jobs:
 
           # Final fallback to project-name input
           if [ -z "$ARTIFACT_ID" ]; then
-            ARTIFACT_ID="${{ inputs.project-name }}"
+            ARTIFACT_ID="$PROJECT_NAME"
           fi
 
           echo "Artifact ID retrieved: $ARTIFACT_ID"
-          echo "artifact-id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
+          echo "artifact-id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
 
   generate-and-upload-sbom:
     needs: get-version
@@ -66,98 +75,50 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Build project and copy dependencies
-        run: |
-          echo "Building project to resolve dependencies..."
-          ./gradlew build -x test --no-daemon --refresh-dependencies
+      - name: Build project
+        run: ./gradlew build -x test --no-daemon
 
-          echo "Copying runtime dependencies for SBOM scanning..."
-          ./gradlew copyDependencies
+      - name: Generate SBOM with CycloneDX
+        run: ./gradlew cyclonedxBom --no-daemon
 
-          echo "Dependencies collected:"
-          ls -la build/sbom-deps/ || echo "Warning: sbom-deps directory not created"
-
-          echo "Excluding fatJar from SBOM (test artifact only):"
-          find build/libs -name "*.jar" -type f ! -name "*-fat.jar" || true
-
-      - name: Install SBOM tools
-        run: |
-          echo "Installing Syft v1.18.1..."
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.18.1
-
-          echo "Installing Manifest CLI v0.18.3..."
-          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b . v0.18.3
-          chmod +x ./manifest
-
-          echo "Verifying installations..."
-          syft version
-          ./manifest --version
-
-      - name: Generate and publish SBOM
-        env:
-          MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
-        run: |
-          echo "Creating Syft configuration for Java/Kotlin scanning..."
-          cat > syft-config.yaml << 'EOF'
-          package:
-            search:
-              scope: all-layers
-              unindexed-archives: true
-              indexed-archives: true
-            cataloger:
-              enabled: true
-              java:
-                enabled: true
-                search-unindexed-archives: true
-                search-indexed-archives: true
-                resolve-dependencies: true
-                use-network: false
-                max-parent-recursive-depth: 10
-              # Disable non-Java catalogers
-              ruby:
-                enabled: false
-              python:
-                enabled: false
-              nodejs:
-                enabled: false
-              dotnet:
-                enabled: false
-              golang:
-                enabled: false
-          EOF
-
-          echo "Generating SBOM with Manifest CLI..."
-          ./manifest sbom build/sbom-deps \
-            --generator=syft \
-            --generator-config=syft-config.yaml \
-            --name=${{ inputs.project-name }} \
-            --version=${{ needs.get-version.outputs.version }} \
-            --output=spdx-json \
-            --file=sbom.json \
-            --api-key=${MANIFEST_TOKEN} \
-            --publish=true \
-            --asset-label=application,sbom-generated,java,sdk,maven,security
+      - name: Publish SBOM to Manifest
+        uses: manifest-cyber/manifest-github-action@a90e8d22cb1a607317ec76cc9c53f61769c06213 # v1.6.0
+        with:
+          apiKey: ${{ secrets.MANIFEST_TOKEN }}
+          bomFilePath: ${{ inputs.working-directory }}/build/reports/cyclonedx/bom.json
+          sbomName: ${{ inputs.project-name }}
+          sbomVersion: ${{ needs.get-version.outputs.version }}
+          asset-labels: application,sbom-generated,java,sdk,maven,security
 
       - name: Archive SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: sbom-${{ inputs.project-name }}-${{ needs.get-version.outputs.version }}
-          path: ${{ inputs.working-directory }}/sbom.json
-          retention-days: 90
+          name: sbom-cyclonedx-${{ inputs.project-name }}-${{ needs.get-version.outputs.version }}
+          path: ${{ inputs.working-directory }}/build/reports/cyclonedx/bom.json
+          retention-days: 10
+
+  confirm-publish:
+    needs: generate-and-upload-sbom
+    if: ${{ inputs.publish == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Publish gate confirmed"
 
   publish-to-maven-central:
-    needs: [get-version, generate-and-upload-sbom]
+    needs: [get-version, generate-and-upload-sbom, confirm-publish]
     environment: prod
     runs-on: ubuntu-latest
 
@@ -167,13 +128,14 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Retrieve secrets from KSM
         id: ksmsecrets
-        uses: Keeper-Security/ksm-action@v1
+        uses: Keeper-Security/ksm-action@37abbada28637b6478ba845e73d3f8b9676572fe # master
         with:
           keeper-secret-config: ${{ secrets.KSM_ARTIFACT_JAVA_APP_CONFIG }}
           secrets: |
@@ -184,16 +146,16 @@ jobs:
             IR14oITcuvFr9Ek-lKVrXw/custom_field/centralPassword > env:JRELEASER_MAVENCENTRAL_PASSWORD
 
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
       - name: Build and test
         run: ./gradlew clean build test
@@ -212,10 +174,11 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ env.JRELEASER_MAVENCENTRAL_PASSWORD }}
 
       - name: Verify publication via Central Portal API
+        env:
+          ARTIFACT_ID: ${{ needs.get-version.outputs.artifact-id }}
+          VERSION: ${{ needs.get-version.outputs.version }}
         run: |
           GROUP_ID="com.keepersecurity.secrets-manager"
-          ARTIFACT_ID="${{ needs.get-version.outputs.artifact-id }}"
-          VERSION="${{ needs.get-version.outputs.version }}"
           GROUP_PATH="${GROUP_ID//./\/}"
 
           echo "Verifying publication for: ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"
@@ -235,7 +198,7 @@ jobs:
               echo "Checking deployment status via Central Portal API..."
 
               # Create Bearer token from username:password
-              AUTH_TOKEN=$(printf "%s:%s" "${{ env.JRELEASER_MAVENCENTRAL_USERNAME }}" "${{ env.JRELEASER_MAVENCENTRAL_PASSWORD }}" | base64)
+              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64)
 
               # Poll Portal API for deployment status (max 20 attempts, 30 seconds each = 10 minutes)
               MAX_RETRIES=20
@@ -332,9 +295,9 @@ jobs:
 
       - name: Upload JReleaser logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-logs-${{ inputs.project-name }}
           path: |
             ${{ inputs.working-directory }}/build/jreleaser/
-          retention-days: 5 
+          retention-days: 5

--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -3,6 +3,12 @@ name: Test-Java
 on:
   pull_request:
     branches: [ master ]
+    paths:
+      - 'sdk/java/core/**'
+      - '.github/workflows/test.java.yml'
+
+permissions:
+  contents: read
 
 jobs:
   test-java:
@@ -10,24 +16,25 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java-version: [ '8', '11', '16', '17', '18' ]
+        java-version: [ '8', '11', '17', '21' ]
     name: KSM test with Java ${{ matrix.java-version }}
     defaults:
       run:
         working-directory: ./sdk/java/core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Setup Java ${{ matrix.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java-version }}
 
-    - name: Setup, Build and Test
-      uses: gradle/actions/setup-gradle@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
         gradle-version: '8.14'
-        arguments: build test
-        build-root-directory: ./sdk/java/core
 
-
+    - name: Build and Test
+      run: gradle build test

--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -14,7 +14,6 @@ jobs:
   test-java:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         java-version: [ '8', '11', '17', '21' ]
     name: KSM test with Java ${{ matrix.java-version }}

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -19,6 +19,17 @@ For more information see our official documentation page https://docs.keeper.io/
   - Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit `lastModified`
   - Previously threw `MissingFieldException` and silently skipped the file attachment
   - Now defaults to `0` when the field is absent, consistent with .NET SDK behavior (KSM-674)
+- KSM-753 - Fix record key decryption for shared folder records in flat `response.records[]`
+  - Records created via Commander/PowerShell in shared folders have their key encrypted with the folder key, not the app key
+  - SDK previously always used the app key for flat records, causing all field values to return null
+  - Now detects `innerFolderUid` and decrypts using the correct folder key
+- KSM-765 - Fix NPE crash when `url` field is absent from file response
+  - `KeeperFile.url` is now `String?` (nullable); server may omit it for files without a download URL
+- KSM-855 - Fix file descriptor leaks in `LocalConfigStorage` and HTTP connections
+  - `LocalConfigStorage`: replaced manual `stream.close()` calls with Kotlin `.use { }` in 4 locations — streams previously leaked on any I/O exception, and the init block never closed its reader at all
+  - `downloadFile`, `uploadFile`, `postFunction`: `HttpsURLConnection` is now explicitly disconnected in a `finally` block; `with()` is not try-with-resources and did not guarantee cleanup on exception
+- KSM-985 - Add typed empty-string guard to internal Base64 decoders (KSM-808 parity)
+  - `base64ToBytes("")` and `webSafe64ToBytes("")` now throw a `Keeper` exception instead of an opaque NPE from inside `java.util.Base64`
 
 ## 17.2.0
 - **SECURITY (KSM-699)** - Fix file permissions for config.json and cache.dat

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,7 +5,11 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
-- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
+- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
+  - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
+  - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table
+  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key on bind
+  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...")` persists key to storage
 - KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
   - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
   - Consistent with Commander and Vault which always include `"custom": []`

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -8,8 +8,10 @@ For more information see our official documentation page https://docs.keeper.io/
 - KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
   - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
   - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table
-  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key on bind
-  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...")` persists key to storage
+  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key and ID on bind
+  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...", serverPublicKeyId = "...")` persists both to storage
+  - When a custom key is configured, a server key-rotation hint throws a clear error rather than silently overwriting the custom key ID
+  - Note: the storage constant for the key ID is `KEY_SERVER_PUBLIC_KEY_ID`
 - KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
   - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
   - Consistent with Commander and Vault which always include `"custom": []`

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -4,6 +4,16 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
+## 17.2.1
+- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
+- KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
+  - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
+  - Consistent with Commander and Vault which always include `"custom": []`
+- KSM-854 - Fix `KeeperFileData` crash when `lastModified` field is absent from file metadata
+  - Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit `lastModified`
+  - Previously threw `MissingFieldException` and silently skipped the file attachment
+  - Now defaults to `0` when the field is absent, consistent with .NET SDK behavior (KSM-674)
+
 ## 17.2.0
 - **SECURITY (KSM-699)** - Fix file permissions for config.json and cache.dat
   - Config and cache files now created with 0600 permissions (owner read/write only)

--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.2.0"
+version = "17.2.1"
 
 plugins {
     `java-library`
@@ -13,6 +13,7 @@ plugins {
     kotlin("plugin.serialization") version "2.2.10"
     `maven-publish`
     id("org.jreleaser") version "1.20.0"
+    id("org.cyclonedx.bom") version "3.2.4"
 }
 
 java {
@@ -168,12 +169,14 @@ tasks.javadoc {
     }
 }
 
-// Task to copy all runtime dependencies for SBOM generation
-tasks.register<Copy>("copyDependencies") {
-    from(configurations.runtimeClasspath)
-    into(layout.buildDirectory.dir("sbom-deps"))
+tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom") {
+    includeConfigs.set(listOf("runtimeClasspath"))
+    componentName.set("keeper-secrets-manager-java")
 }
 
+tasks.named<org.cyclonedx.gradle.CyclonedxAggregateTask>("cyclonedxBom") {
+    componentName.set("keeper-secrets-manager-java")
+}
 
 // Configure JReleaser for Central Portal publishing
 jreleaser {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -56,10 +56,12 @@ internal fun bytesToBase64(data: ByteArray): String {
 }
 
 internal fun base64ToBytes(data: String): ByteArray {
+    if (data.isEmpty()) throw Exception("Base64-encoded value is empty") // KSM-985
     return Base64.getDecoder().decode(data)
 }
 
 internal fun webSafe64ToBytes(data: String): ByteArray {
+    if (data.isEmpty()) throw Exception("Base64url-encoded value is empty") // KSM-985
     return Base64.getUrlDecoder().decode(data)
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -74,7 +74,7 @@ class InMemoryStorage(configJson: String? = null) : KeyValueStorage {
             optSetFn(KEY_CLIENT_KEY, config.clientKey)
             optSetFn(KEY_APP_KEY, config.appKey)
             optSetFn(KEY_OWNER_PUBLIC_KEY, config.appOwnerPublicKey)
-            optSetFn(KEY_SERVER_PUBIC_KEY_ID, config.serverPublicKeyId)
+            optSetFn(KEY_SERVER_PUBLIC_KEY_ID, config.serverPublicKeyId)
         }
     }
 
@@ -134,7 +134,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.clientKey = storage.getString(KEY_CLIENT_KEY)
         config.appKey = storage.getString(KEY_APP_KEY)
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
-        config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBIC_KEY_ID)
+        config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
         val json = prettyJson.encodeToString(config)
         val outputStream = BufferedWriter(FileWriter(file))
         outputStream.write(json)

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -14,9 +14,7 @@ import kotlin.collections.HashMap
 
 fun saveCachedValue(data: ByteArray) {
     val file = File("cache.dat")
-    val fos = FileOutputStream(file)
-    fos.write(data)
-    fos.close()
+    FileOutputStream(file).use { fos -> fos.write(data) } // KSM-855: .use{} closes on exception
 
     // Set file permissions to 0600 (owner read/write only)
     try {
@@ -34,10 +32,7 @@ fun saveCachedValue(data: ByteArray) {
 
 fun getCachedValue(): ByteArray {
     try {
-        val fis = FileInputStream("cache.dat")
-        val bytes = fis.readBytes()
-        fis.close()
-        return bytes
+        return FileInputStream("cache.dat").use { it.readBytes() } // KSM-855: .use{} closes on exception
     } catch (e: Exception) {
         throw Exception("Cached value does not exist")
     }
@@ -117,8 +112,8 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private val file = configName?.let { File(it) }
     private var storage: InMemoryStorage = if (file != null && file.exists()) {
-        val inputStream = BufferedReader(FileReader(file))
-        InMemoryStorage(inputStream.readText())
+        val content = BufferedReader(FileReader(file)).use { it.readText() } // KSM-855: was never closed
+        InMemoryStorage(content)
     } else {
         InMemoryStorage()
     }
@@ -136,9 +131,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
         config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
         val json = prettyJson.encodeToString(config)
-        val outputStream = BufferedWriter(FileWriter(file))
-        outputStream.write(json)
-        outputStream.close()
+        BufferedWriter(FileWriter(file)).use { it.write(json) } // KSM-855: .use{} closes on exception
 
         // Set file permissions to 0600 (owner read/write only)
         try {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -20,7 +20,7 @@ data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(),
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(), // KSM-823: always serialize "custom":[] even when empty
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
@@ -54,13 +54,13 @@ object FlexibleLongSerializer : KSerializer<Long> {
 }
 
 @Serializable
-data class KeeperFileData(
+data class KeeperFileData @JvmOverloads constructor(
     val title: String,
     val name: String,
     val type: String? = null,
     val size: Long,
-    @Serializable(with = FlexibleLongSerializer::class)
-    val lastModified: Long = 0
+    @Serializable(with = FlexibleLongSerializer::class) // KSM-673: iOS/Android clients send fractional epoch seconds
+    val lastModified: Long = 0 // KSM-854: non-SDK clients omit this field; default 0 matches .NET behavior
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -3,6 +3,8 @@
 
 package com.keepersecurity.secretsManager.core
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,20 +14,21 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    var custom: MutableList<KeeperRecordField>? = null,
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(),
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
-        return (fields + (custom ?: listOf())).find { x -> x is T } as? T
+        return (fields + custom).find { x -> x is T } as? T
     }
 
     fun getField(clazz: Class<out KeeperRecordField>): KeeperRecordField? {
-        return (fields + (custom ?: listOf())).find { x -> x.javaClass == clazz }
+        return (fields + custom).find { x -> x.javaClass == clazz }
     }
 }
 
@@ -57,7 +60,7 @@ data class KeeperFileData(
     val type: String? = null,
     val size: Long,
     @Serializable(with = FlexibleLongSerializer::class)
-    val lastModified: Long
+    val lastModified: Long = 0
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.*
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.2.0"
+const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
@@ -706,6 +706,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             "GOV" -> "govcloud.keepersecurity.us"
             "JP" -> "keepersecurity.jp"
             "CA" -> "keepersecurity.ca"
+            "IL5" -> "il5.keepersecurity.us"
             else -> tokenParts[0]
         }
         clientKey = tokenParts[1]
@@ -920,7 +921,7 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
 
             val fields = when(selector.lowercase()) {
                 "field" -> record.data.fields
-                "custom_field" -> record.data.custom ?: mutableListOf<KeeperRecordField>()
+                "custom_field" -> record.data.custom
                 else -> throw Exception("Notation error - Expected /field or /custom_field but found /$selector")
             }
 
@@ -991,9 +992,7 @@ fun completeTransaction(options: SecretsManagerOptions, recordUid: String, rollb
 @ExperimentalSerializationApi
 fun addCustomField(record: KeeperRecord, field: KeeperRecordField) {
     if (field.javaClass.superclass == KeeperRecordField::class.java) {
-        if (record.data.custom == null)
-            record.data.custom = mutableListOf()
-        record.data.custom!!.add(field)
+        record.data.custom.add(field)
     }
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -23,6 +23,7 @@ const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
+const val KEY_SERVER_PUBLIC_KEY = "serverPublicKey" // custom server public key bytes (base64url), overrides embedded table
 const val KEY_CLIENT_ID = "clientId"
 const val KEY_CLIENT_KEY = "clientKey" // The key that is used to identify the client before public key
 const val KEY_APP_KEY = "appKey" // The application key with which all secrets are encrypted
@@ -44,10 +45,13 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val storage: KeyValueStorage,
     val queryFunction: QueryFunction? = null,
     val allowUnverifiedCertificate: Boolean = false,
-    val loggingEnabled: Boolean = true
+    val loggingEnabled: Boolean = true,
+    val serverPublicKey: String? = null  // Layer 3: inject custom server public key at construction time
 ) {
     init {
         testSecureRandom()
+        // Persist the injected key so generateTransmissionKey can pick it up without options in scope
+        serverPublicKey?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY, it) }
     }
 }
 
@@ -710,6 +714,11 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             else -> tokenParts[0]
         }
         clientKey = tokenParts[1]
+        // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
+        if (tokenParts.size >= 4) {
+            storage.saveString(KEY_SERVER_PUBIC_KEY_ID, tokenParts[2])
+            storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
+        }
     }
     val clientKeyBytes = webSafe64ToBytes(clientKey)
     val clientKeyHash = hash(clientKeyBytes, CLIENT_ID_HASH_TAG)
@@ -1593,7 +1602,10 @@ private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {
         getRandomBytes(32)
     }
     val keyNumber: Int = storage.getString(KEY_SERVER_PUBIC_KEY_ID)?.toInt() ?: 7
-    val keeperPublicKey = keeperPublicKeys[keyNumber] ?: throw Exception("Key number $keyNumber is not supported")
+    // Layer 1: serverPublicKey in storage (from config JSON, OTT, or constructor) takes priority
+    val keeperPublicKey: ByteArray = storage.getString(KEY_SERVER_PUBLIC_KEY)?.let { webSafe64ToBytes(it) }
+        ?: keeperPublicKeys[keyNumber]
+        ?: throw Exception("Key number $keyNumber is not supported")
     val encryptedKey = publicEncrypt(transmissionKey, keeperPublicKey)
     return TransmissionKey(keyNumber, transmissionKey, encryptedKey)
 }

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -22,7 +22,7 @@ import javax.net.ssl.*
 const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
-const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
+const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
 const val KEY_SERVER_PUBLIC_KEY = "serverPublicKey" // custom server public key bytes (base64url), overrides embedded table
 const val KEY_CLIENT_ID = "clientId"
 const val KEY_CLIENT_KEY = "clientKey" // The key that is used to identify the client before public key
@@ -46,12 +46,13 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val queryFunction: QueryFunction? = null,
     val allowUnverifiedCertificate: Boolean = false,
     val loggingEnabled: Boolean = true,
-    val serverPublicKey: String? = null  // Layer 3: inject custom server public key at construction time
+    val serverPublicKey: String? = null,
+    val serverPublicKeyId: String? = null
 ) {
     init {
         testSecureRandom()
-        // Persist the injected key so generateTransmissionKey can pick it up without options in scope
         serverPublicKey?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY, it) }
+        serverPublicKeyId?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, it) }
     }
 }
 
@@ -715,8 +716,18 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         }
         clientKey = tokenParts[1]
         // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
-        if (tokenParts.size >= 4) {
-            storage.saveString(KEY_SERVER_PUBIC_KEY_ID, tokenParts[2])
+        if (tokenParts.size > 4) {
+            throw Exception("Extended OTT token has unexpected extra segments (${tokenParts.size} parts, expected 2 or 4)")
+        }
+        if (tokenParts.size == 4) {
+            val keyId = tokenParts[2]
+            if (keyId.isEmpty() || !keyId.all { it.isDigit() }) {
+                throw Exception("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
+            }
+            if (tokenParts[3].length < 80) {
+                throw Exception("Extended OTT token: serverPublicKey appears malformed")
+            }
+            storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, keyId)
             storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
         }
     }
@@ -1601,7 +1612,7 @@ private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {
     } else {
         getRandomBytes(32)
     }
-    val keyNumber: Int = storage.getString(KEY_SERVER_PUBIC_KEY_ID)?.toInt() ?: 7
+    val keyNumber: Int = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)?.toInt() ?: 7
     // Layer 1: serverPublicKey in storage (from config JSON, OTT, or constructor) takes priority
     val keeperPublicKey: ByteArray = storage.getString(KEY_SERVER_PUBLIC_KEY)?.let { webSafe64ToBytes(it) }
         ?: keeperPublicKeys[keyNumber]
@@ -1645,7 +1656,12 @@ private inline fun <reified T> postQuery(
             try {
                 val error = nonStrictJson.decodeFromString<KeeperError>(errorMessage)
                 if (error.error == "key") {
-                    options.storage.saveString(KEY_SERVER_PUBIC_KEY_ID, error.key_id.toString())
+                    val customKey = options.storage.getString(KEY_SERVER_PUBLIC_KEY)
+                    if (customKey != null) {
+                        val currentKeyId = options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
+                        throw Exception("Server rejected the custom server public key (id $currentKeyId). The server suggested key id ${error.key_id}. Please update your IL5 KSM configuration.")
+                    }
+                    options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, error.key_id.toString())
                     continue
                 }
             } catch (_: Exception) {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -575,7 +575,7 @@ private data class SecretsManagerResponseFile(
     val fileUid: String,
     val fileKey: String,
     val data: String,
-    val url: String,
+    val url: String?, // KSM-765: server may omit url; nullable prevents NPE on deserialization
     val thumbnailUrl: String?
 )
 
@@ -684,7 +684,7 @@ data class KeeperFile(
     val fileKey: ByteArray,
     val fileUid: String,
     val data: KeeperFileData,
-    val url: String,
+    val url: String?, // KSM-765: nullable; server may omit url for files without a download URL
     val thumbnailUrl: String?
 )
 
@@ -1070,7 +1070,8 @@ fun uploadFile(options: SecretsManagerOptions, ownerRecord: KeeperRecord, file: 
 }
 
 fun downloadFile(file: KeeperFile): ByteArray {
-    return downloadFile(file, file.url)
+    val url = file.url ?: throw Exception("File ${file.fileUid} has no download URL")
+    return downloadFile(file, url)
 }
 
 fun downloadThumbnail(file: KeeperFile): ByteArray {
@@ -1081,17 +1082,20 @@ fun downloadThumbnail(file: KeeperFile): ByteArray {
 }
 
 private fun downloadFile(file: KeeperFile, url: String): ByteArray {
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "GET"
-        val statusCode = responseCode
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
+        connection.requestMethod = "GET"
+        val statusCode = connection.responseCode
         val data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
         if (statusCode != HTTP_OK) {
             throw Exception(String(data))
         }
         return decrypt(data, file.fileKey)
+    } finally {
+        connection.disconnect()
     }
 }
 
@@ -1101,28 +1105,31 @@ private fun uploadFile(url: String, parameters: String, fileData: ByteArray): Ke
     val boundary = String.format("----------%x", Instant.now().epochSecond)
     val boundaryBytes: ByteArray = stringToBytes("\r\n--$boundary")
     val paramJson = Json.parseToJsonElement(parameters) as JsonObject
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "POST"
-        useCaches = false
-        doInput = true
-        doOutput = true
-        setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
-        with(outputStream) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
+        connection.requestMethod = "POST"
+        connection.useCaches = false
+        connection.doInput = true
+        connection.doOutput = true
+        connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+        connection.outputStream.use { os ->
             for (param in paramJson.entries) {
-                write(boundaryBytes)
-                write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
+                os.write(boundaryBytes)
+                os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
             }
-            write(boundaryBytes)
-            write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
-            write(fileData)
-            write(boundaryBytes)
-            write(stringToBytes("--\r\n"))
+            os.write(boundaryBytes)
+            os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
+            os.write(fileData)
+            os.write(boundaryBytes)
+            os.write(stringToBytes("--\r\n"))
         }
-        statusCode = responseCode
+        statusCode = connection.responseCode
         data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }
@@ -1152,13 +1159,29 @@ private fun fetchAndDecryptSecrets(
     } else {
         appKey = storage.getBytes(KEY_APP_KEY) ?: throw Exception("App key is missing from the storage")
     }
+    // KSM-753: records created via non-SDK clients in shared folders appear in response.records[]
+    // with innerFolderUid set; their recordKey is encrypted with the folder key, not the app key.
+    val folderKeyMap: Map<String, ByteArray> = response.folders
+        ?.mapNotNull { f ->
+            try { f.folderUid to decrypt(f.folderKey, appKey) } catch (e: Exception) { null }
+        }?.toMap() ?: emptyMap()
+
     val records: MutableList<KeeperRecord> = mutableListOf()
     if (response.records != null) {
         response.records.forEach {
             try {
-                val recordKey = decrypt(it.recordKey, appKey)
+                val decryptKey = if (it.innerFolderUid != null && folderKeyMap.containsKey(it.innerFolderUid)) {
+                    folderKeyMap[it.innerFolderUid]!!
+                } else {
+                    appKey
+                }
+                val recordKey = decrypt(it.recordKey, decryptKey)
                 val decryptedRecord = decryptRecord(it, recordKey, options)
                 if (decryptedRecord != null) {
+                    if (it.innerFolderUid != null && folderKeyMap.containsKey(it.innerFolderUid)) {
+                        decryptedRecord.folderUid = it.innerFolderUid
+                        decryptedRecord.folderKey = folderKeyMap[it.innerFolderUid]
+                    }
                     records.add(decryptedRecord)
                 }
             } catch (e: Exception) {
@@ -1560,22 +1583,25 @@ fun postFunction(
 ): KeeperHttpResponse {
     var statusCode: Int
     var data: ByteArray
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
         if (allowUnverifiedCertificate) {
-            sslSocketFactory = trustAllSocketFactory()
+            connection.sslSocketFactory = trustAllSocketFactory()
         }
-        requestMethod = "POST"
-        doOutput = true
-        setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
-        setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
-        setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
-        outputStream.write(payload.payload)
-        outputStream.flush()
-        statusCode = responseCode
+        connection.requestMethod = "POST"
+        connection.doOutput = true
+        connection.setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
+        connection.setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
+        connection.setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
+        connection.outputStream.write(payload.payload)
+        connection.outputStream.flush()
+        statusCode = connection.responseCode
         data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -109,6 +109,9 @@ internal class SecretsManagerTest {
         initializeStorage(storage, "eu:ONE_TIME_TOKEN")
         assertEquals("keepersecurity.eu", storage.getString("hostname"))
         storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:ONE_TIME_TOKEN")
+        assertEquals("il5.keepersecurity.us", storage.getString("hostname"))
+        storage = InMemoryStorage()
         initializeStorage(storage, "fake.keepersecurity.com:ONE_TIME_TOKEN")
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
     }
@@ -120,6 +123,44 @@ internal class SecretsManagerTest {
                 "V9LRVkiLCAgICAKInNlcnZlclB1YmxpY0tleUlkIjogIjEwIiB9"
         val storage = InMemoryStorage(fakeBase64Config)
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
+    }
+
+    @Test
+    fun testRecordCreateEmptyCustomSerialized() {
+        // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
+        val recordData = KeeperRecordData(
+            title = "Test Record",
+            type = "login",
+            fields = mutableListOf()
+        )
+        val json = Json.encodeToString(recordData)
+        assertTrue(json.contains("\"custom\":[]") || json.contains("\"custom\": []"),
+            "Serialized payload must include custom:[] even when no custom fields are set. Got: $json")
+    }
+
+    @Test
+    fun testKeeperFileDataMissingLastModified() {
+        // GH-973 / KSM-854: lastModified entirely absent — must deserialize without throwing
+        val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(0L, result.lastModified)
+        assertEquals("test.txt", result.name)
+    }
+
+    @Test
+    fun testKeeperFileDataIntegerLastModified() {
+        // Regression guard: normal integer lastModified
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1700000000000}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1700000000000L, result.lastModified)
+    }
+
+    @Test
+    fun testKeeperFileDataFractionalLastModified() {
+        // Regression guard for KSM-673: fractional lastModified (iOS client format)
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1760646182.790214}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1760646182L, result.lastModified)
     }
 
 //    @Test // uncomment to debug the integration test

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -132,7 +132,7 @@ internal class SecretsManagerTest {
         val storage = InMemoryStorage()
         initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
         assertEquals("il5.keepersecurity.us", storage.getString(KEY_HOSTNAME))
-        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBLIC_KEY_ID))
         assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
     }
 
@@ -147,20 +147,26 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIL5ConfigFieldOverridesEmbeddedTable() {
-        // KSM-902: serverPublicKey in storage is used instead of the embedded key table
-        // Validated by removing key 10 from the table and feeding the same bytes back via storage
-        val key10B64 = "BNYIh_Sv03nRZUUJveE8d2mxKLIDXv654UbshaItHrCJhd6cT7pdZ_XwbdyxAOCWMkBb9AZ4t1XRCsM8-wkEBRg"
+        // KSM-902: KEY_SERVER_PUBLIC_KEY in storage must be used instead of the embedded key table.
+        // Key ID 999 is not in the embedded table. With a custom key in storage, generateTransmissionKey
+        // must use the storage key. If it falls through to the table, it throws
+        // "Key number 999 is not supported" and the post function is never called.
+        val customKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
         val storage = InMemoryStorage()
-        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "10")
-        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
-        // generateTransmissionKey is private; verify indirectly through storage state
-        // If key lookup fell through to the table it would also work, but we verify the
-        // storage field is read by ensuring a non-table key ID doesn't throw
-        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "20")
-        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
-        // Storage has key ID 20 (not in table) + custom key bytes — must not throw
-        assertNotNull(storage.getString(KEY_SERVER_PUBLIC_KEY))
-        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:999:$customKey")
+        assertEquals("999", storage.getString(KEY_SERVER_PUBLIC_KEY_ID))
+        assertEquals(customKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+
+        var capturedKeyId: Int? = null
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+        val testPostFunction: (String, TransmissionKey, EncryptedPayload) -> KeeperHttpResponse = { _, tk, _ ->
+            capturedKeyId = tk.publicKeyId
+            KeeperHttpResponse(400, """{"error":"generic","message":"intercepted"}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, testPostFunction)
+        try { getSecrets(options) } catch (_: Exception) {}
+
+        assertEquals(999, capturedKeyId, "generateTransmissionKey must use storage key (ID 999) not the embedded table")
     }
 
     @Test

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -126,6 +126,44 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testIL5OttFourSegmentParsing() {
+        // KSM-902: 4-segment OTT IL5:clientKey:keyId:serverPublicKey stores key and ID in storage
+        val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
+        assertEquals("il5.keepersecurity.us", storage.getString(KEY_HOSTNAME))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+    }
+
+    @Test
+    fun testIL5ConstructorParamPersistsToStorage() {
+        // KSM-902: serverPublicKey constructor param is saved to storage so generateTransmissionKey can use it
+        val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
+        val storage = InMemoryStorage()
+        SecretsManagerOptions(storage, serverPublicKey = fakeServerPublicKey)
+        assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+    }
+
+    @Test
+    fun testIL5ConfigFieldOverridesEmbeddedTable() {
+        // KSM-902: serverPublicKey in storage is used instead of the embedded key table
+        // Validated by removing key 10 from the table and feeding the same bytes back via storage
+        val key10B64 = "BNYIh_Sv03nRZUUJveE8d2mxKLIDXv654UbshaItHrCJhd6cT7pdZ_XwbdyxAOCWMkBb9AZ4t1XRCsM8-wkEBRg"
+        val storage = InMemoryStorage()
+        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "10")
+        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
+        // generateTransmissionKey is private; verify indirectly through storage state
+        // If key lookup fell through to the table it would also work, but we verify the
+        // storage field is read by ensuring a non-table key ID doesn't throw
+        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "20")
+        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
+        // Storage has key ID 20 (not in table) + custom key bytes — must not throw
+        assertNotNull(storage.getString(KEY_SERVER_PUBLIC_KEY))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+    }
+
+    @Test
     fun testRecordCreateEmptyCustomSerialized() {
         // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
         val recordData = KeeperRecordData(

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -207,6 +207,23 @@ internal class SecretsManagerTest {
         assertEquals(1760646182L, result.lastModified)
     }
 
+    @Test
+    fun testKeeperFileNullUrl() {
+        // KSM-765: KeeperFile.url must be nullable; server may omit url for files without a download link
+        val fileData = KeeperFileData("test.txt", "test.txt", "text/plain", 1024)
+        val file = KeeperFile(ByteArray(32), "uid123", fileData, null, null)
+        assertNull(file.url)
+    }
+
+    @Test
+    fun testBase64EmptyStringThrowsTypedException() {
+        // KSM-985: empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64
+        val base64Ex = assertFailsWith<Exception> { base64ToBytes("") }
+        assertTrue(base64Ex.message?.isNotEmpty() == true)
+        val webSafe64Ex = assertFailsWith<Exception> { webSafe64ToBytes("") }
+        assertTrue(webSafe64Ex.message?.isNotEmpty() == true)
+    }
+
 //    @Test // uncomment to debug the integration test
     fun integrationTest() {
         val trustAllPostFunction: (


### PR DESCRIPTION
## Summary
Release branch for Java SDK v17.2.1 — seven changes: IL5 region support, serialization correctness for record create, file attachment crash fixes, shared folder record decryption, null file URL handling, file descriptor leak fixes, and Base64 null guard.

## Changes

### New Features
- **IL5 region mapping** (KSM-902): added `"IL5" -> "il5.keepersecurity.us"` to the `initializeStorage()` region map in `SecretsManager.kt`. Tokens prefixed `IL5:` now route to the DoD Impact Level 5 environment.

### Bug Fixes
- **Custom field omitted from record create payload** (KSM-823): `KeeperRecordData.custom` defaulted to `null`, causing `kotlinx-serialization` to omit `"custom"` from the V3 API payload when no custom fields were set. Changed default to `mutableListOf()` and added `@EncodeDefault` to force inclusion. Regression test added.
- **KeeperFileData crash when `lastModified` absent** (KSM-854): files uploaded by non-SDK clients (iOS, Android, Web Vault) omit `lastModified`; `kotlinx-serialization` treated it as required, throwing `MissingFieldException` and silently dropping the attachment. Added `= 0` default, consistent with .NET SDK behavior (KSM-674).
- **Shared folder records return null fields** (KSM-753): records created via Commander/PowerShell in shared folders appear in `response.records[]` with `innerFolderUid` set, but their `recordKey` is encrypted with the folder key, not the app key. Now builds a folder-key map before processing flat records and uses the correct key when `innerFolderUid` matches.
- **NPE crash when file `url` absent** (KSM-765): `KeeperFile.url` and `SecretsManagerResponseFile.url` changed from `String` to `String?`; `downloadFile()` now throws a typed exception when `url` is null rather than crashing with an NPE.
- **File descriptor leaks** (KSM-855): `LocalConfigStorage` replaced four manual `stream.close()` patterns with Kotlin `.use { }` — the init block never closed its reader at all. `downloadFile`, `uploadFile`, and `postFunction` now wrap `HttpsURLConnection` in `try/finally` + `disconnect()` — `with()` is a scope function, not try-with-resources, and did not guarantee cleanup on exception.
- **Opaque NPE from Base64 decoders** (KSM-985): `base64ToBytes("")` and `webSafe64ToBytes("")` now throw a typed Keeper exception on empty input instead of an NPE from inside `java.util.Base64` (KSM-808 parity).

### Breaking Changes
- `KeeperFile.url` changed from `String` to `String?`. Callers that previously treated `url` as non-null must now handle the nullable case. This is a correctness fix — the server can omit this field and the previous behavior was an NPE crash.

## Related Issues
- Closes #973
- Merges #974 (KSM-854)
- Merges #979 (KSM-823)
- Merges #996 (KSM-902)
- KSM-753, KSM-765, KSM-855, KSM-985