### PR TITLE
KSM-843: fix ObjectDisposedException in LocalConfigStorage.SaveToFile()

### DIFF
--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Keeper Secrets Manager .NET SDK will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.1.2] - 2026-03-23
+
+### Fixed
+
+- KSM-843 - Fixed `ObjectDisposedException` in `LocalConfigStorage.SaveToFile()` when writing config to file
+  - `stream.Close()` was called before `writer.Dispose()`, causing the writer's flush-on-dispose to fail
+  - Switched to explicit `using` blocks so the writer flushes and disposes before the stream closes
+  - Regression introduced in v17.1.0 (KSM-698 file permissions fix); resolves GitHub issue #966
+
 ## [17.1.1] - 2026-02-03
 
 ### Fixed

--- a/sdk/dotNet/SecretsManager.Test.Core/LocalConfigStorageBugRepro.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/LocalConfigStorageBugRepro.Test.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace SecretsManager.Test
+{
+    /// <summary>
+    /// Regression test for GitHub issue #966:
+    /// LocalConfigStorage.SaveToFile() throws ObjectDisposedException in v17.1.0
+    /// because stream.Close() is called before writer.Dispose().
+    /// </summary>
+    [TestFixture]
+    public class LocalConfigStorageBugReproTests
+    {
+        private string _tempFile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempFile = Path.Combine(Path.GetTempPath(), $"ksm-test-{Guid.NewGuid()}.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_tempFile))
+                File.Delete(_tempFile);
+        }
+
+        [Test]
+        public void SaveString_WithFilePath_DoesNotThrowObjectDisposedException()
+        {
+            // Arrange: LocalConfigStorage backed by a real file (triggers SaveToFile)
+            var storage = new LocalConfigStorage(_tempFile);
+
+            // Act & Assert: SaveString -> SaveToFile -> should NOT throw
+            Assert.DoesNotThrow(() => storage.SaveString("hostname", "fake.keepersecurity.com"));
+        }
+
+        [Test]
+        public void InitializeStorage_WithLocalConfigStorage_DoesNotThrowObjectDisposedException()
+        {
+            // This reproduces the exact call stack from the issue report:
+            // SecretsManagerClient.InitializeStorage -> storage.SaveString -> SaveToFile
+            var storage = new LocalConfigStorage(_tempFile);
+
+            Assert.DoesNotThrow(() =>
+                SecretsManagerClient.InitializeStorage(storage, "US:FAKE_ONE_TIME_TOKEN", "fake.keepersecurity.com")
+            );
+        }
+
+        [Test]
+        public void SaveString_WithFilePath_WritesValidJson()
+        {
+            var storage = new LocalConfigStorage(_tempFile);
+            storage.SaveString("hostname", "fake.keepersecurity.com");
+
+            var written = File.ReadAllText(_tempFile);
+            Assert.That(written, Does.Contain("hostname"));
+            Assert.That(written, Does.Contain("fake.keepersecurity.com"));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager/LocalConfigStorage.cs
+++ b/sdk/dotNet/SecretsManager/LocalConfigStorage.cs
@@ -141,23 +141,22 @@ namespace SecretsManager
                 return;
             }
 
-            using var stream = File.Create(fileName);
-            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+            using (var stream = File.Create(fileName))
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Indented = true,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-            });
-            writer.WriteStartObject();
-            foreach (var kv in storage.Strings)
+            }))
             {
-                writer.WriteString(kv.Key, kv.Value);
-            }
+                writer.WriteStartObject();
+                foreach (var kv in storage.Strings)
+                {
+                    writer.WriteString(kv.Key, kv.Value);
+                }
+                writer.WriteEndObject();
+            } // writer disposed first (flushes), then stream disposed (closes)
 
-            writer.WriteEndObject();
-            writer.Flush();
-            stream.Close();
-
-            // Set secure permissions after file creation
+            // Set secure permissions after file is fully written and closed
             SetSecurePermissions(fileName);
         }
 

--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -5,9 +5,9 @@
         <LangVersion>9</LangVersion>
         <Company>Keeper Security Inc.</Company>
         <Product>SecretsManager .Net SDK</Product>
-        <AssemblyVersion>17.1.1</AssemblyVersion>
-        <FileVersion>17.1.1</FileVersion>
-        <PackageVersion>17.1.1</PackageVersion>
+        <AssemblyVersion>17.1.2</AssemblyVersion>
+        <FileVersion>17.1.2</FileVersion>
+        <PackageVersion>17.1.2</PackageVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Keeper.SecretsManager</PackageId>
         <Authors>Sergey Aldoukhov</Authors>


### PR DESCRIPTION
## Summary
`LocalConfigStorage.SaveToFile()` in v17.1.0 throws `ObjectDisposedException` because `stream.Close()` is called before the `using var writer` block exits. When the method returns, `writer.Dispose()` tries to flush to the already-closed stream and throws. This was introduced by the KSM-698 file-permissions fix.

## Changes

### Fixed
- **ObjectDisposedException in SaveToFile** (KSM-843): Replaced `using var` declarations with explicit `using` blocks so disposal order is deterministic — writer flushes and disposes first, then the stream closes. Removed the explicit `stream.Close()` call. `SetSecurePermissions` now runs after the file is fully written and closed.

## Testing
```bash
cd sdk/dotNet
dotnet test SecretsManager.Test.Core/SecretsManager.Test.Core.csproj --filter "FullyQualifiedName~LocalConfigStorageBugRepro"
```
3 regression tests: `SaveString_WithFilePath_DoesNotThrowObjectDisposedException`, `InitializeStorage_WithLocalConfigStorage_DoesNotThrowObjectDisposedException`, `SaveString_WithFilePath_WritesValidJson` — all failed before fix, all pass after.

## Breaking Changes
None.

## Related Issues
- Closes #966
- KSM-843