### PR TITLE
Release .NET SDK v17.1.2

### DIFF
--- a/.github/workflows/publish.nuget.yml
+++ b/.github/workflows/publish.nuget.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       sdk-version: ${{ steps.extract-sdk-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Extract SDK version
         id: extract-sdk-version
@@ -66,7 +66,7 @@ jobs:
 
   # Generate and upload SBOM for SDK
   generate-sdk-sbom:
-    needs: check-version
+    needs: [check-version, get-version]
     runs-on: ubuntu-latest
 
     defaults:
@@ -74,10 +74,10 @@ jobs:
         working-directory: ./sdk/dotNet
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 6.0.x
 
@@ -92,6 +92,12 @@ jobs:
         env:
           MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
           SYFT_PACKAGE_CATALOGER_DOTNET_ENABLED: "true"
+          # Syft reads SYFT_SOURCE_NAME / SYFT_SOURCE_VERSION from the environment when
+          # invoked by manifest-cli, injecting them into the root package versionInfo field.
+          # This fixes the pseudo-version (v0.0.0-YYYYMMDDHHMMSS) that Syft generates when
+          # scanning a directory without a Go module or other recognizable version source.
+          SYFT_SOURCE_NAME: keeper-secrets-manager-dotnet
+          SYFT_SOURCE_VERSION: ${{ needs.get-version.outputs.sdk-version }}
         run: |
           # Install tools
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.18.1
@@ -121,11 +127,11 @@ jobs:
           mv sbom.json "${{ github.workspace }}/sdk/dotNet/"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: sbom-keeper-secrets-manager-dotnet-${{ needs.get-version.outputs.sdk-version }}
           path: ./sdk/dotNet/sbom.json
-          retention-days: 90
+          retention-days: 10
   
   build-nuget:
     needs: generate-sdk-sbom
@@ -137,10 +143,10 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 6.0.x
 
@@ -151,7 +157,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: nuget-packages-${{ github.run_number }}
           path: |
@@ -165,21 +171,21 @@ jobs:
 
     steps:
       - name: Download NuGet packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: nuget-packages-${{ github.run_number }}
           path: ./packages
 
       - name: Retrieve secrets from KSM
         id: ksmsecrets
-        uses: Keeper-Security/ksm-action@master
+        uses: Keeper-Security/ksm-action@37abbada28637b6478ba845e73d3f8b9676572fe
         with:
           keeper-secret-config: ${{ secrets.KSM_KSM_CONFIG }}
           secrets: |
             Sq4nnb5HXXNp1l6KryXynw/field/password > NUGET_AUTH_TOKEN
 
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 6.0.x
 
@@ -196,10 +202,10 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 6.0.x
 
@@ -216,7 +222,7 @@ jobs:
           ./build.ps1 -Package
 
       - name: Upload PowerShell module
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: powershell-module-${{ github.run_number }}
           path: |
@@ -230,14 +236,14 @@ jobs:
 
     steps:
       - name: Download PowerShell module
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: powershell-module-${{ github.run_number }}
           path: ./out
 
       - name: Retrieve secrets from KSM
         id: ksmsecrets
-        uses: Keeper-Security/ksm-action@master
+        uses: Keeper-Security/ksm-action@37abbada28637b6478ba845e73d3f8b9676572fe
         with:
           keeper-secret-config: ${{ secrets.KSM_KSM_CONFIG }}
           secrets: |

--- a/.github/workflows/reusable.sbom.workflow.yml
+++ b/.github/workflows/reusable.sbom.workflow.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup .NET
         if: inputs.project-type == 'dotnet'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: '6.0.x'
 
@@ -641,7 +641,7 @@ jobs:
           cp *.json "${{ github.workspace }}/"
 
       - name: Archive SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: sbom-${{ inputs.project-name }}-${{ env.PROJECT_VERSION }}
           path: |

--- a/.github/workflows/test.dotnet.powershell.yml
+++ b/.github/workflows/test.dotnet.powershell.yml
@@ -23,10 +23,10 @@ jobs:
         working-directory: ./sdk/dotNet
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: "8.0.x"
 

--- a/.github/workflows/test.dotnet.yml
+++ b/.github/workflows/test.dotnet.yml
@@ -3,6 +3,9 @@ name: Test-DotNet
 on:
   pull_request:
     branches: [ master ]
+    paths:
+      - 'sdk/dotNet/**'
+      - '.github/workflows/test.dotnet.yml'
 
 jobs:
   test-dotnet:
@@ -15,10 +18,10 @@ jobs:
       run:
         working-directory: ./sdk/dotNet
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
         

--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to the Keeper Secrets Manager .NET SDK will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.1.2]
+
+### Fixed
+
+- KSM-822 - Ensure `"custom": []` is always included in RecordCreate V3 API payload even when no custom fields are set
+  - Changed `KeeperRecordData.custom` default from `null` to empty array so the serializer always includes the field
+  - Aligns .NET SDK record creation with Commander and Vault behavior
+- KSM-843 - Fixed `ObjectDisposedException` in `LocalConfigStorage.SaveToFile()` when writing config to file
+  - `stream.Close()` was called before `writer.Dispose()`, causing the writer's flush-on-dispose to fail
+  - Switched to explicit `using` blocks so the writer flushes and disposes before the stream closes
+  - Regression introduced in v17.1.0 (KSM-698 file permissions fix); resolves GitHub issue #966
+- KSM-865 - Fixed `DownloadThumbnail` returning full file content instead of thumbnail
+  - Was passing `file.Url` to the internal download call instead of `file.ThumbnailUrl` (copy-paste bug)
+- KSM-864 - Fixed `GetSecrets` silently dropping records when boolean fields contain integer values
+  - `required`, `privacyScreen`, and `enforceGeneration` were declared as non-nullable `bool`
+  - Records created by older clients or Commander send `0`/`1` integers or quoted strings for these fields
+  - Changed to `bool?` with `FlexibleBoolConverter` to accept JSON booleans, integers, and quoted strings
+- KSM-873 - Fixed `Get-SecretInfo` / `Get-Secret` round-trip silently returning null (PowerShell)
+  - `GetSecretsInfo()` was returning names in the format `"UID title"` which `GetSecret()` could not resolve
+  - Now returns the record title as the name (falls back to UID when title is null or empty)
+- KSM-863 - Removed bundled `System.Management.Automation.dll` from PowerShell module package
+  - This DLL conflicts with PowerShell's own copy, causing `Import-Module` to fail on some environments
+  - Removed from the file list in `build.ps1`; PowerShell already provides this assembly at runtime
+- KSM-874 - Removed `Set-KeeperVault` ghost export from PowerShell module manifest
+  - Function was listed in `FunctionsToExport` in `SecretManagement.Keeper.Extension.psd1` but never implemented
+  - Any call to `Set-KeeperVault` produced a hard terminating error
+- KSM-875 - Fixed `FieldValue()` throwing `NullReferenceException` or `IndexOutOfRangeException` on records with null or empty value arrays
+  - Added null/length guard before accessing `value[0]`; returns `null` when the value array is absent
+  - Callers can now safely iterate all fields on any record type, including PAM and gateway records
+
 ## [17.1.1] - 2026-02-03
 
 ### Fixed

--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.Extension/SecretManagement.Keeper.Extension.psd1
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.Extension/SecretManagement.Keeper.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '17.1.1'
+    ModuleVersion = '17.1.2'
     RootModule = 'SecretManagement.Keeper.Extension.psm1'
     RequiredAssemblies = '../SecretManagement.Keeper.dll'    
     CompatiblePSEditions = @('Core')
@@ -7,7 +7,7 @@
     Author = 'Sergey Aldoukhov'
     CompanyName = 'Keeper Security'
     Copyright = '(c) 2024 Keeper Security, Inc.'
-    FunctionsToExport = 'Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault', 'Set-KeeperVault', 'Get-Notation'
+    FunctionsToExport = 'Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault', 'Get-Notation'
     CmdletsToExport = @()    
     VariablesToExport = @()
     AliasesToExport = @()

--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>SecretManagement.Keeper</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <AssemblyVersion>17.1.1</AssemblyVersion>
-        <FileVersion>17.1.1</FileVersion>
+        <AssemblyVersion>17.1.2</AssemblyVersion>
+        <FileVersion>17.1.2</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.psd1
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '17.1.1'
+    ModuleVersion = '17.1.2'
     CompatiblePSEditions = @('Core')
     GUID = '20ab89cb-f0dd-4e8e-b276-f3a7708c1eb2'
     Author = 'Sergey Aldoukhov'

--- a/sdk/dotNet/SecretManagement.Keeper/build.ps1
+++ b/sdk/dotNet/SecretManagement.Keeper/build.ps1
@@ -34,7 +34,6 @@ if ($Package) {
         './bin/Release/netstandard2.0/BouncyCastle.Cryptography.dll'
         './bin/Release/netstandard2.0/Microsoft.Bcl.AsyncInterfaces.dll'
         './bin/Release/netstandard2.0/System.Buffers.dll'
-        './bin/Release/netstandard2.0/System.Management.Automation.dll'
         './bin/Release/netstandard2.0/System.Memory.dll'
         './bin/Release/netstandard2.0/System.Numerics.Vectors.dll'
         './bin/Release/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll'

--- a/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
+++ b/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
@@ -148,12 +148,12 @@ namespace SecretManagement.Keeper
                 }
 
                 var field = found.Data.fields
-                    .Concat(found.Data.custom ?? new KeeperRecordField[] { })
+                    .Concat(found.Data.custom)
                     .FirstOrDefault(x => (x.label ?? x.type).Equals(parts[1], StringComparison.OrdinalIgnoreCase));
                 return field?.value[0].ToString();
             }
 
-            foreach (var field in found.Data.fields.Concat(found.Data.custom ?? new KeeperRecordField[] { }))
+            foreach (var field in found.Data.fields.Concat(found.Data.custom))
             {
                 if (field.type == "fileRef" || field.value.Length == 0)
                 {
@@ -197,7 +197,7 @@ namespace SecretManagement.Keeper
             return records
                 .Where(x => x.RecordUid == filter || filterPattern.IsMatch(x.Data.title))
                 .Distinct(new RecordComparer())
-                .Select(x => $"{x.RecordUid} {x.Data.title}").ToArray();
+                .Select(x => string.IsNullOrEmpty(x.Data.title) ? x.RecordUid : x.Data.title).ToArray();
         }
 
         public static async Task<KeeperResult> SetSecret(string name, object secret, Hashtable config)

--- a/sdk/dotNet/SecretsManager.Test.Core/JsonUtils.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/JsonUtils.Test.cs
@@ -30,9 +30,96 @@ namespace SecretsManager.Test
             Assert.That(recordData.fields[1].value[0].ToString(), Is.EqualTo(rec.fields[1].value[0]));
         }
         [Test]
+        public void DefaultCustomField_ShouldSerializeAsEmptyArray()
+        {
+            // KSM-822: RecordCreate with no custom fields must include "custom":[] in JSON payload
+            var recordData = new KeeperRecordData
+            {
+                title = "Test Record",
+                type = "login",
+                fields = new KeeperRecordField[]
+                {
+                    new KeeperRecordField { type = "login", value = new object[] { "user@example.com" } }
+                }
+                // custom is intentionally NOT set â€” this is the bug scenario
+            };
+
+            var json = CryptoUtils.BytesToString(JsonUtils.SerializeJson(recordData));
+
+            Assert.That(json, Does.Contain("\"custom\":[]"),
+                "KSM-822: Serialized payload must include 'custom':[] even when custom is not explicitly set");
+        }
+
+        [Test]
+        public void DefaultCustomField_ShouldNotBeNull()
+        {
+            // KSM-822: custom must default to empty array, not null
+            var recordData = new KeeperRecordData();
+            Assert.That(recordData.custom, Is.Not.Null);
+            Assert.That(recordData.custom, Is.Empty);
+        }
+
+        [Test]
+        public void DefaultCustomField_RoundTrip_ShouldPreserveEmptyArray()
+        {
+            // KSM-822: Round-trip serialization must preserve empty custom array
+            var recordData = new KeeperRecordData
+            {
+                title = "Round Trip Test",
+                type = "login",
+                fields = new KeeperRecordField[] { }
+            };
+
+            var jsonBytes = JsonUtils.SerializeJson(recordData);
+            var deserialized = JsonUtils.ParseJson<KeeperRecordData>(jsonBytes);
+
+            Assert.That(deserialized.custom, Is.Not.Null);
+            Assert.That(deserialized.custom, Is.Empty);
+        }
+
+        [Test]
+        public void KSM864_IntegerBoolFields_ShouldDeserializeWithoutThrowing()
+        {
+            // Server sends integer 0/1 instead of JSON boolean for records created by
+            // older clients or Commander â€” must not throw JsonException
+            const string json = "{\"title\":\"Test\",\"type\":\"login\",\"fields\":[" +
+                "{\"type\":\"login\",\"label\":\"Login\",\"value\":[\"user@example.com\"]," +
+                "\"required\":1,\"privacyScreen\":0,\"enforceGeneration\":1}]," +
+                "\"custom\":[]}";
+
+            KeeperRecordData result = null;
+            Assert.DoesNotThrow(() =>
+                result = JsonUtils.ParseJson<KeeperRecordData>(CryptoUtils.StringToBytes(json)));
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.fields[0].required, Is.EqualTo(true));
+            Assert.That(result.fields[0].privacyScreen, Is.EqualTo(false));
+            Assert.That(result.fields[0].enforceGeneration, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void KSM864_StringBoolFields_ShouldDeserializeWithoutThrowing()
+        {
+            // Older clients/Commander send bool fields as quoted strings (e.g. "required":"1")
+            const string json = "{\"title\":\"Test\",\"type\":\"login\",\"fields\":[" +
+                "{\"type\":\"login\",\"label\":\"Login\",\"value\":[\"user@example.com\"]," +
+                "\"required\":\"1\",\"privacyScreen\":\"false\",\"enforceGeneration\":\"true\"}]," +
+                "\"custom\":[]}";
+
+            KeeperRecordData result = null;
+            Assert.DoesNotThrow(() =>
+                result = JsonUtils.ParseJson<KeeperRecordData>(CryptoUtils.StringToBytes(json)));
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.fields[0].required, Is.EqualTo(true));
+            Assert.That(result.fields[0].privacyScreen, Is.EqualTo(false));
+            Assert.That(result.fields[0].enforceGeneration, Is.EqualTo(true));
+        }
+
+        [Test]
         public void ParseAndSerializeShouldPreserveDiacritics()
         {
-            string recordTitle = "MySpéciàlHomèL°gin";
+            string recordTitle = "MySpï¿½ciï¿½lHomï¿½Lï¿½gin";
             var krdin = new KeeperRecordData { title = recordTitle, type = "login" };
             var krdout = JsonUtils.ParseJson<KeeperRecordData>(JsonUtils.SerializeJson(krdin));
             Assert.That(krdin.title, Is.EqualTo(krdout.title));

--- a/sdk/dotNet/SecretsManager.Test.Core/KSM873BugProof.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/KSM873BugProof.Test.cs
@@ -1,0 +1,97 @@
+using NUnit.Framework;
+using System.Linq;
+
+namespace SecretsManager.Test
+{
+    /// <summary>
+    /// Proof-of-concept test demonstrating KSM-873 bug
+    ///
+    /// GetSecretsInfo() returns names in the format "UID title" (e.g. "YGGHvDMb0qw7QacqqLqCAg My Login").
+    /// GetSecret() looks up records by matching x.RecordUid or x.Data.title individually.
+    /// The combined "UID title" string matches neither branch, so Get-Secret silently returns null.
+    /// </summary>
+    [TestFixture]
+    public class KSM873BugProofTests
+    {
+        private static KeeperRecord MakeRecord(string uid, string title)
+        {
+            var data = new KeeperRecordData
+            {
+                title = title,
+                type = "login",
+                fields = new KeeperRecordField[0],
+                custom = new KeeperRecordField[0]
+            };
+            return new KeeperRecord(
+                recordKey: new byte[32],
+                recordUid: uid,
+                folderUid: null,
+                folderKey: null,
+                innerFolderUid: null,
+                data: data,
+                revision: 1,
+                files: null,
+                links: null
+            );
+        }
+
+        [Test]
+        public void BugProof_CombinedUidTitleName_DoesNotMatchGetSecretLookup()
+        {
+            // Arrange: a record as it would exist in the vault
+            const string uid = "YGGHvDMb0qw7QacqqLqCAg";
+            const string title = "My Login";
+            var records = new[] { MakeRecord(uid, title) };
+
+            // Simulate the BROKEN GetSecretsInfo() select (line 200, before fix)
+            var brokenName = $"{uid} {title}"; // "YGGHvDMb0qw7QacqqLqCAg My Login"
+
+            // Simulate GetSecret() lookup (line 125)
+            var foundByBrokenName = records.FirstOrDefault(
+                x => x.RecordUid == brokenName || x.Data.title == brokenName);
+
+            // BUG: the combined string matches neither UID nor title — returns null
+            Assert.That(foundByBrokenName, Is.Null,
+                "Bug proof: combined 'UID title' name should NOT match GetSecret lookup");
+        }
+
+        [Test]
+        public void FixProof_TitleName_MatchesGetSecretLookup()
+        {
+            // Arrange
+            const string uid = "YGGHvDMb0qw7QacqqLqCAg";
+            const string title = "My Login";
+            var records = new[] { MakeRecord(uid, title) };
+
+            // Simulate the FIXED GetSecretsInfo() select: title only
+            var fixedName = string.IsNullOrEmpty(title) ? uid : title; // "My Login"
+
+            // Simulate GetSecret() lookup (line 125)
+            var foundByFixedName = records.FirstOrDefault(
+                x => x.RecordUid == fixedName || x.Data.title == fixedName);
+
+            // FIX: title matches x.Data.title branch — round-trip works
+            Assert.That(foundByFixedName, Is.Not.Null,
+                "Fix proof: title name should match GetSecret lookup");
+            Assert.That(foundByFixedName.RecordUid, Is.EqualTo(uid));
+        }
+
+        [Test]
+        public void FixProof_NullTitle_FallsBackToUid()
+        {
+            // Arrange: record with no title
+            const string uid = "YGGHvDMb0qw7QacqqLqCAg";
+            var records = new[] { MakeRecord(uid, title: null) };
+
+            // Simulate the FIXED select: falls back to UID when title is null/empty
+            var fixedName = string.IsNullOrEmpty(null) ? uid : null; // uid
+
+            var found = records.FirstOrDefault(
+                x => x.RecordUid == fixedName || x.Data.title == fixedName);
+
+            Assert.That(found, Is.Not.Null,
+                "Fix proof: UID fallback should match when title is null");
+            Assert.That(found.RecordUid, Is.EqualTo(uid));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager.Test.Core/KSM874BugProof.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/KSM874BugProof.Test.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SecretsManager.Test
+{
+    /// <summary>
+    /// Proof-of-concept test demonstrating KSM-874 bug
+    ///
+    /// SecretManagement.Keeper.Extension.psd1 declared Set-KeeperVault in FunctionsToExport
+    /// but no such function existed in SecretManagement.Keeper.Extension.psm1.
+    /// Any call to Set-KeeperVault produced a hard terminating error.
+    ///
+    /// After the fix: every name in FunctionsToExport has a matching function definition in the psm1.
+    /// </summary>
+    [TestFixture]
+    public class KSM874BugProofTests
+    {
+        private static readonly string PsmPath = Path.GetFullPath(
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "../../../../../../sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.Extension/SecretManagement.Keeper.Extension.psm1"));
+
+        private static readonly string PsdPath = Path.GetFullPath(
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "../../../../../../sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.Extension/SecretManagement.Keeper.Extension.psd1"));
+
+        private static string[] GetExportedFunctions()
+        {
+            var psd = File.ReadAllText(PsdPath);
+            var match = Regex.Match(psd, @"FunctionsToExport\s*=\s*(.+)");
+            if (!match.Success) return new string[0];
+            return Regex.Matches(match.Groups[1].Value, @"'(\w[\w-]*)'")
+                .Cast<Match>()
+                .Select(m => m.Groups[1].Value)
+                .ToArray();
+        }
+
+        private static string[] GetDefinedFunctions()
+        {
+            var psm = File.ReadAllText(PsmPath);
+            return Regex.Matches(psm, @"^function\s+([\w-]+)", RegexOptions.Multiline)
+                .Cast<Match>()
+                .Select(m => m.Groups[1].Value)
+                .ToArray();
+        }
+
+        [Test]
+        public void AllExportedFunctions_HaveImplementations()
+        {
+            var exported = GetExportedFunctions();
+            var defined = GetDefinedFunctions();
+
+            var missing = exported.Except(defined).ToArray();
+
+            Assert.That(missing, Is.Empty,
+                $"FunctionsToExport lists functions with no implementation in psm1: {string.Join(", ", missing)}");
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager.Test.Core/LocalConfigStorageBugRepro.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/LocalConfigStorageBugRepro.Test.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace SecretsManager.Test
+{
+    /// <summary>
+    /// Regression test for GitHub issue #966:
+    /// LocalConfigStorage.SaveToFile() throws ObjectDisposedException in v17.1.0
+    /// because stream.Close() is called before writer.Dispose().
+    /// </summary>
+    [TestFixture]
+    public class LocalConfigStorageBugReproTests
+    {
+        private string _tempFile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempFile = Path.Combine(Path.GetTempPath(), $"ksm-test-{Guid.NewGuid()}.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_tempFile))
+                File.Delete(_tempFile);
+        }
+
+        [Test]
+        public void SaveString_WithFilePath_DoesNotThrowObjectDisposedException()
+        {
+            // Arrange: LocalConfigStorage backed by a real file (triggers SaveToFile)
+            var storage = new LocalConfigStorage(_tempFile);
+
+            // Act & Assert: SaveString -> SaveToFile -> should NOT throw
+            Assert.DoesNotThrow(() => storage.SaveString("hostname", "fake.keepersecurity.com"));
+        }
+
+        [Test]
+        public void InitializeStorage_WithLocalConfigStorage_DoesNotThrowObjectDisposedException()
+        {
+            // This reproduces the exact call stack from the issue report:
+            // SecretsManagerClient.InitializeStorage -> storage.SaveString -> SaveToFile
+            var storage = new LocalConfigStorage(_tempFile);
+
+            Assert.DoesNotThrow(() =>
+                SecretsManagerClient.InitializeStorage(storage, "US:FAKE_ONE_TIME_TOKEN", "fake.keepersecurity.com")
+            );
+        }
+
+        [Test]
+        public void SaveString_WithFilePath_WritesValidJson()
+        {
+            var storage = new LocalConfigStorage(_tempFile);
+            storage.SaveString("hostname", "fake.keepersecurity.com");
+
+            var written = File.ReadAllText(_tempFile);
+            Assert.That(written, Does.Contain("hostname"));
+            Assert.That(written, Does.Contain("fake.keepersecurity.com"));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace SecretsManager.Test
 {
@@ -89,6 +90,42 @@ namespace SecretsManager.Test
 
             var storage = new InMemoryStorage(fakeBase64Config);
             Assert.That("fake.keepersecurity.com", Is.EqualTo(storage.GetString("hostname")));
+        }
+    }
+
+    public class FieldValueTests
+    {
+        [Test]
+        public void FieldValue_ReturnsNull_WhenValueArrayIsNull()
+        {
+            var record = MakeRecord(new KeeperRecordField { type = "login", value = null });
+            Assert.That(record.FieldValue("login"), Is.Null);
+        }
+
+        [Test]
+        public void FieldValue_ReturnsNull_WhenValueArrayIsEmpty()
+        {
+            var record = MakeRecord(new KeeperRecordField { type = "login", value = Array.Empty<object>() });
+            Assert.That(record.FieldValue("login"), Is.Null);
+        }
+
+        [Test]
+        public void FieldValue_ReturnsValue_WhenPresent()
+        {
+            var record = MakeRecord(new KeeperRecordField { type = "login", value = new object[] { "alice" } });
+            Assert.That(record.FieldValue("login"), Is.EqualTo("alice"));
+        }
+
+        private static KeeperRecord MakeRecord(KeeperRecordField field)
+        {
+            var data = new KeeperRecordData
+            {
+                title = "Test",
+                type = "login",
+                fields = new[] { field },
+                custom = Array.Empty<KeeperRecordField>()
+            };
+            return new KeeperRecord(null, "test-uid", null, null, null, data, 0, Array.Empty<KeeperFile>(), null);
         }
     }
 }

--- a/sdk/dotNet/SecretsManager/LocalConfigStorage.cs
+++ b/sdk/dotNet/SecretsManager/LocalConfigStorage.cs
@@ -141,23 +141,22 @@ namespace SecretsManager
                 return;
             }
 
-            using var stream = File.Create(fileName);
-            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+            using (var stream = File.Create(fileName))
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Indented = true,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-            });
-            writer.WriteStartObject();
-            foreach (var kv in storage.Strings)
+            }))
             {
-                writer.WriteString(kv.Key, kv.Value);
-            }
+                writer.WriteStartObject();
+                foreach (var kv in storage.Strings)
+                {
+                    writer.WriteString(kv.Key, kv.Value);
+                }
+                writer.WriteEndObject();
+            } // writer disposed first (flushes), then stream disposed (closes)
 
-            writer.WriteEndObject();
-            writer.Flush();
-            stream.Close();
-
-            // Set secure permissions after file creation
+            // Set secure permissions after file is fully written and closed
             SetSecurePermissions(fileName);
         }
 

--- a/sdk/dotNet/SecretsManager/RecordData.cs
+++ b/sdk/dotNet/SecretsManager/RecordData.cs
@@ -10,7 +10,7 @@ namespace SecretsManager
         public string title { get; set; }
         public string type { get; set; }
         public KeeperRecordField[] fields { get; set; }
-        public KeeperRecordField[] custom { get; set; }
+        public KeeperRecordField[] custom { get; set; } = Array.Empty<KeeperRecordField>();
         public string notes { get; set; }
     }
 
@@ -19,10 +19,42 @@ namespace SecretsManager
         public string type { get; set; }
         public string label { get; set; }
         public object[] value { get; set; }
-        public bool required { get; set; }
-        public bool privacyScreen { get; set; }
-        public bool enforceGeneration { get; set; }
+        [JsonConverter(typeof(FlexibleBoolConverter))]
+        public bool? required { get; set; }
+        [JsonConverter(typeof(FlexibleBoolConverter))]
+        public bool? privacyScreen { get; set; }
+        [JsonConverter(typeof(FlexibleBoolConverter))]
+        public bool? enforceGeneration { get; set; }
         public object complexity { get; set; }
+    }
+
+    public class FlexibleBoolConverter : JsonConverter<bool?>
+    {
+        public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.True => true,
+                JsonTokenType.False => false,
+                JsonTokenType.Number => reader.GetInt32() != 0,
+                JsonTokenType.String => reader.GetString()?.ToLowerInvariant() switch
+                {
+                    "1" or "true" => true,
+                    "0" or "false" => false,
+                    _ => throw new JsonException("Unable to convert to bool.")
+                },
+                JsonTokenType.Null => null,
+                _ => throw new JsonException("Unable to convert to bool.")
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+        {
+            if (value.HasValue)
+                writer.WriteBooleanValue(value.Value);
+            else
+                writer.WriteNullValue();
+        }
     }
 
     public class FlexibleLongConverter : JsonConverter<long>

--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -5,9 +5,9 @@
         <LangVersion>9</LangVersion>
         <Company>Keeper Security Inc.</Company>
         <Product>SecretsManager .Net SDK</Product>
-        <AssemblyVersion>17.1.1</AssemblyVersion>
-        <FileVersion>17.1.1</FileVersion>
-        <PackageVersion>17.1.1</PackageVersion>
+        <AssemblyVersion>17.1.2</AssemblyVersion>
+        <FileVersion>17.1.2</FileVersion>
+        <PackageVersion>17.1.2</PackageVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Keeper.SecretsManager</PackageId>
         <Authors>Sergey Aldoukhov</Authors>
@@ -17,7 +17,7 @@
         <RepositoryType>GitHub</RepositoryType>
         <PackageTags>keeper secrets manager passwords</PackageTags>
         <Copyright>© 2024 Keeper Security, Inc.</Copyright>
-        <License>https://raw.githubusercontent.com/Keeper-Security/secrets-manager/master/LICENSE?token=AACNMRVMD5L3PYT3C5MTNF3BEAFZY</License>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -414,18 +414,21 @@ namespace SecretsManager
 
         public object FieldValue(string fieldType)
         {
-            return Data.fields.Concat(Data.custom ?? new KeeperRecordField[] { }).FirstOrDefault(x => x.type == fieldType)?.value[0];
+            var field = Data.fields.Concat(Data.custom).FirstOrDefault(x => x.type == fieldType);
+            if (field?.value == null || field.value.Length == 0)
+                return null;
+            return field.value[0];
         }
 
         public void UpdateFieldValue(string fieldType, object value)
         {
-            var field = Data.fields.Concat(Data.custom ?? new KeeperRecordField[] { }).FirstOrDefault(x => x.type == fieldType);
+            var field = Data.fields.Concat(Data.custom).FirstOrDefault(x => x.type == fieldType);
             if (field == null)
-            {
                 return;
-            }
-
-            field.value[0] = value;
+            if (field.value == null || field.value.Length == 0)
+                field.value = new object[] { value };
+            else
+                field.value[0] = value;
         }
 
         public bool AddCustomField(object field)
@@ -436,8 +439,6 @@ namespace SecretsManager
                 Console.Error.WriteLine($"AddCustomField: Field '{field.GetType().Name}' is of unknown field class - skipped.");
                 return false;
             }
-
-            Data.custom = Data.custom ?? new KeeperRecordField[] { };
 
             var json = JsonUtils.SerializeJson(field);
             var krf = JsonUtils.ParseJson<KeeperRecordField>(json);
@@ -851,7 +852,7 @@ namespace SecretsManager
             await UpdateSecretWithOptions(options, record, new UpdateOptions(transactionType, null));
         }
 
-        public static async Task UpdateSecretWithOptions(SecretsManagerOptions options, KeeperRecord record, UpdateOptions? updateOptions = null)
+        public static async Task UpdateSecretWithOptions(SecretsManagerOptions options, KeeperRecord record, UpdateOptions updateOptions = null)
         {
             var payload = PrepareUpdatePayload(options.Storage, record, updateOptions);
             await PostQuery(options, "update_secret", payload);
@@ -956,7 +957,7 @@ namespace SecretsManager
                 throw new Exception($"Thumbnail does not exist for the file {file.FileUid}");
             }
 
-            return DownloadFile(file, file.Url);
+            return DownloadFile(file, file.ThumbnailUrl);
         }
 
         private static byte[] DownloadFile(KeeperFile file, string url)


### PR DESCRIPTION
## Summary
Release branch for v17.1.2 — seven patch fixes for the .NET SDK and PowerShell SecretManagement extension.

## Changes

### Bug Fixes
- **RecordCreate missing \`custom\` field** (KSM-822): \`KeeperRecordData.custom\` defaulted to \`null\`, causing the serializer to omit \`"custom"\` from the V3 API payload. Commander and Vault always include \`"custom": []\`. Changed the default to an empty array and removed redundant null guards across \`SecretsManagerClient\`, \`Notation\`, and \`SecretManagement\`.
- **ObjectDisposedException in SaveToFile** (KSM-843): \`stream.Close()\` was called before \`writer.Dispose()\`, causing the writer's flush-on-dispose to fail. Switched to explicit \`using\` blocks so the writer disposes (and flushes) before the stream closes.
- **DownloadThumbnail returns full file instead of thumbnail** (KSM-865): \`DownloadThumbnail\` null-checked \`file.ThumbnailUrl\` but passed \`file.Url\` to the internal download call — copy-paste bug from \`DownloadFile\`. Changed to use \`file.ThumbnailUrl\`.
- **Integer bool fields crash deserialization** (KSM-864): \`KeeperRecordField.required\`, \`privacyScreen\`, and \`enforceGeneration\` were declared as non-nullable \`bool\`, causing \`System.Text.Json\` to throw \`JsonException\` when the server sent \`0\`/\`1\` integers (records created by older clients or Commander). The exception was swallowed, silently dropping those records from \`GetSecrets\` results. Changed to \`bool?\` and added \`FlexibleBoolConverter\` to accept JSON booleans, integer values, and quoted strings.
- **Get-SecretInfo / Get-Secret round-trip broken** (KSM-873): \`GetSecretsInfo()\` returned names in the format \`"UID title"\` which \`GetSecret()\` could not resolve — lookup silently returned null. Now returns the record title as the name (falls back to UID when title is null or empty).
- **Set-KeeperVault ghost export** (KSM-874): \`Set-KeeperVault\` was listed in \`FunctionsToExport\` in \`SecretManagement.Keeper.Extension.psd1\` but never implemented — any call produced a hard terminating error. Removed from the manifest.
- **FieldValue() crashes on null or empty value arrays** (KSM-875): \`FieldValue()\` accessed \`field.value[0]\` without guarding against a null or zero-length array. Records with partially populated fields — common in PAM and gateway record types — threw \`NullReferenceException\` (null array) or \`IndexOutOfRangeException\` (empty array). Added a null/length guard; returns \`null\` safely when the value array is absent.

### Breaking Changes
None.

## Related Issues
- Closes #966
- KSM-822
- KSM-843
- KSM-864
- KSM-865
- KSM-873
- KSM-874
- KSM-875