### PR TITLE
KSM-855: Fix resource leaks in LocalConfigStorage and SecretsManager

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,9 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
+- KSM-855 - Fix file descriptor and HTTP connection leaks in `LocalConfigStorage` and `SecretsManager`
+  - `LocalConfigStorage`: init block, `saveToFile()`, `saveCachedValue()`, and `getCachedValue()` now use Kotlin `.use {}` blocks to guarantee stream closure
+  - `SecretsManager`: `postFunction()`, `downloadFile()`, and `uploadFile()` now use try/finally with `disconnect()` to guarantee HTTP connection closure
 - KSM-854 - Fix `KeeperFileData` crash when `lastModified` field is absent from file metadata
   - Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit `lastModified`
   - Previously threw `MissingFieldException` and silently skipped the file attachment

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -14,9 +14,7 @@ import kotlin.collections.HashMap
 
 fun saveCachedValue(data: ByteArray) {
     val file = File("cache.dat")
-    val fos = FileOutputStream(file)
-    fos.write(data)
-    fos.close()
+    FileOutputStream(file).use { it.write(data) }
 
     // Set file permissions to 0600 (owner read/write only)
     try {
@@ -34,10 +32,7 @@ fun saveCachedValue(data: ByteArray) {
 
 fun getCachedValue(): ByteArray {
     try {
-        val fis = FileInputStream("cache.dat")
-        val bytes = fis.readBytes()
-        fis.close()
-        return bytes
+        return FileInputStream("cache.dat").use { it.readBytes() }
     } catch (e: Exception) {
         throw Exception("Cached value does not exist")
     }
@@ -117,8 +112,8 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private val file = configName?.let { File(it) }
     private var storage: InMemoryStorage = if (file != null && file.exists()) {
-        val inputStream = BufferedReader(FileReader(file))
-        InMemoryStorage(inputStream.readText())
+        val content = BufferedReader(FileReader(file)).use { it.readText() }
+        InMemoryStorage(content)
     } else {
         InMemoryStorage()
     }
@@ -136,9 +131,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
         config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBIC_KEY_ID)
         val json = prettyJson.encodeToString(config)
-        val outputStream = BufferedWriter(FileWriter(file))
-        outputStream.write(json)
-        outputStream.close()
+        BufferedWriter(FileWriter(file)).use { it.write(json) }
 
         // Set file permissions to 0600 (owner read/write only)
         try {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1062,17 +1062,17 @@ fun downloadThumbnail(file: KeeperFile): ByteArray {
 }
 
 private fun downloadFile(file: KeeperFile, url: String): ByteArray {
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "GET"
-        val statusCode = responseCode
-        val data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
-        }
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
+    try {
+        connection.requestMethod = "GET"
+        val statusCode = connection.responseCode
+        val data = (connection.errorStream ?: connection.inputStream).use { it.readBytes() }
         if (statusCode != HTTP_OK) {
             throw Exception(String(data))
         }
         return decrypt(data, file.fileKey)
+    } finally {
+        connection.disconnect()
     }
 }
 
@@ -1082,28 +1082,28 @@ private fun uploadFile(url: String, parameters: String, fileData: ByteArray): Ke
     val boundary = String.format("----------%x", Instant.now().epochSecond)
     val boundaryBytes: ByteArray = stringToBytes("\r\n--$boundary")
     val paramJson = Json.parseToJsonElement(parameters) as JsonObject
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "POST"
-        useCaches = false
-        doInput = true
-        doOutput = true
-        setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
-        with(outputStream) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
+    try {
+        connection.requestMethod = "POST"
+        connection.useCaches = false
+        connection.doInput = true
+        connection.doOutput = true
+        connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+        connection.outputStream.use { os ->
             for (param in paramJson.entries) {
-                write(boundaryBytes)
-                write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
+                os.write(boundaryBytes)
+                os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
             }
-            write(boundaryBytes)
-            write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
-            write(fileData)
-            write(boundaryBytes)
-            write(stringToBytes("--\r\n"))
+            os.write(boundaryBytes)
+            os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
+            os.write(fileData)
+            os.write(boundaryBytes)
+            os.write(stringToBytes("--\r\n"))
         }
-        statusCode = responseCode
-        data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
-        }
+        statusCode = connection.responseCode
+        data = (connection.errorStream ?: connection.inputStream).use { it.readBytes() }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }
@@ -1541,22 +1541,24 @@ fun postFunction(
 ): KeeperHttpResponse {
     var statusCode: Int
     var data: ByteArray
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
+    try {
         if (allowUnverifiedCertificate) {
-            sslSocketFactory = trustAllSocketFactory()
+            connection.sslSocketFactory = trustAllSocketFactory()
         }
-        requestMethod = "POST"
-        doOutput = true
-        setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
-        setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
-        setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
-        outputStream.write(payload.payload)
-        outputStream.flush()
-        statusCode = responseCode
-        data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+        connection.requestMethod = "POST"
+        connection.doOutput = true
+        connection.setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
+        connection.setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
+        connection.setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
+        connection.outputStream.use { os ->
+            os.write(payload.payload)
+            os.flush()
         }
+        statusCode = connection.responseCode
+        data = (connection.errorStream ?: connection.inputStream).use { it.readBytes() }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -168,8 +168,7 @@ internal class SecretsManagerTest {
 //            updateSecret(options, record)
         }
 
-        val fis = FileInputStream("config-dev.json")
-        val bytes = fis.readBytes()
+        val bytes = FileInputStream("config-dev.json").use { it.readBytes() }
         uploadFile(options, record, KeeperFileUpload("config-dev.json", "Sample File", "application/json", bytes))
 
 //        if (record.folderUid != null) {


### PR DESCRIPTION
## Summary

- Replace manual open/close patterns with Kotlin `.use {}` blocks and `try/finally + disconnect()` to guarantee resource closure on exceptions
- Fixes file descriptor leaks in `LocalConfigStorage` (4 sites) and HTTP connection leaks in `SecretsManager` (3 sites)

## Changes

**`LocalConfigStorage.kt`**
- `init` block: `BufferedReader` now closed via `.use {}` — previously leaked on every instantiation, no close call existed
- `saveToFile()`: `BufferedWriter` wrapped in `.use {}` — previously leaked if `write()` threw
- `saveCachedValue()`: `FileOutputStream` wrapped in `.use {}` — previously leaked if `write()` threw
- `getCachedValue()`: `FileInputStream` wrapped in `.use {}` — previously leaked if `readBytes()` threw

**`SecretsManager.kt`**
- `postFunction()`: replace `with()` block with `try/finally + connection.disconnect()` — most critical, used for every KSM API call
- `downloadFile()`: same pattern; response stream read via `.use {}`
- `uploadFile()`: same pattern; `outputStream` and response stream via `.use {}`

**`SecretsManagerTest.kt`**
- `FileInputStream` in upload test wrapped in `.use {}`

**`README.md`**
- Changelog entry added under v17.2.1

## Testing

```bash
# Unit tests
cd sdk/java/core && ./gradlew test
# BUILD SUCCESSFUL

# Live vault test (postFunction HTTP round-trip + LocalConfigStorage init block)
# Both verified manually against production vault
```

## Related

- Closes [KSM-855](https://keeper.atlassian.net/browse/KSM-855)
- Root cause: commit cf8cba1 (KSM-698 secure file permissions) introduced manual stream management without `.use {}` wrappers; init block leak predates KSM-698
- GCP storage module leaks deferred to [KSM-856](https://keeper.atlassian.net/browse/KSM-856) (separate Maven artifact)

[KSM-855]: https://keeper.atlassian.net/browse/KSM-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ