### PR TITLE
KSM-823: Always include custom:[] in record create payload

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,9 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
+- KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
+  - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
+  - Consistent with Commander and Vault which always include `"custom": []`
 - KSM-855 - Fix file descriptor and HTTP connection leaks in `LocalConfigStorage` and `SecretsManager`
   - `LocalConfigStorage`: init block, `saveToFile()`, `saveCachedValue()`, and `getCachedValue()` now use Kotlin `.use {}` blocks to guarantee stream closure
   - `SecretsManager`: `postFunction()`, `downloadFile()`, and `uploadFile()` now use try/finally with `disconnect()` to guarantee HTTP connection closure

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -3,6 +3,8 @@
 
 package com.keepersecurity.secretsManager.core
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,20 +14,21 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    var custom: MutableList<KeeperRecordField>? = null,
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(),
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
-        return (fields + (custom ?: listOf())).find { x -> x is T } as? T
+        return (fields + custom).find { x -> x is T } as? T
     }
 
     fun getField(clazz: Class<out KeeperRecordField>): KeeperRecordField? {
-        return (fields + (custom ?: listOf())).find { x -> x.javaClass == clazz }
+        return (fields + custom).find { x -> x.javaClass == clazz }
     }
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -920,7 +920,7 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
 
             val fields = when(selector.lowercase()) {
                 "field" -> record.data.fields
-                "custom_field" -> record.data.custom ?: mutableListOf<KeeperRecordField>()
+                "custom_field" -> record.data.custom
                 else -> throw Exception("Notation error - Expected /field or /custom_field but found /$selector")
             }
 
@@ -991,9 +991,7 @@ fun completeTransaction(options: SecretsManagerOptions, recordUid: String, rollb
 @ExperimentalSerializationApi
 fun addCustomField(record: KeeperRecord, field: KeeperRecordField) {
     if (field.javaClass.superclass == KeeperRecordField::class.java) {
-        if (record.data.custom == null)
-            record.data.custom = mutableListOf()
-        record.data.custom!!.add(field)
+        record.data.custom.add(field)
     }
 }
 

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -123,6 +123,19 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testRecordCreateEmptyCustomSerialized() {
+        // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
+        val recordData = KeeperRecordData(
+            title = "Test Record",
+            type = "login",
+            fields = mutableListOf()
+        )
+        val json = Json.encodeToString(recordData)
+        assertTrue(json.contains("\"custom\":[]") || json.contains("\"custom\": []"),
+            "Serialized payload must include custom:[] even when no custom fields are set. Got: $json")
+    }
+
+    @Test
     fun testKeeperFileDataMissingLastModified() {
         // GH-973 / KSM-854: lastModified entirely absent — must deserialize without throwing
         val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""


### PR DESCRIPTION
## Summary

Records created via the Java SDK were missing `"custom": []` from the V3 API payload when no custom fields were set. Commander and Vault always include it — this inconsistency could cause record creation failures or unexpected server behavior.

## Root Cause

`KeeperRecordData.custom` defaulted to `null`. `kotlinx-serialization` omits null fields by default, so the field was silently absent from the payload. Changing the default to `mutableListOf()` alone wasn't sufficient — `encodeDefaults = false` (the library default) also skips fields whose value matches the default. Required `@EncodeDefault` to force inclusion.

## Changes

**`RecordData.kt`**
- `custom` default changed from `null` → `mutableListOf()`
- `@EncodeDefault` added to force serialization when list is empty
- `@OptIn(ExperimentalSerializationApi::class)` added (consistent with existing usage in codebase)
- `?: listOf()` null-safety guards in `getField()` removed (now redundant)

**`SecretsManager.kt`**
- `addCustomField()`: null guard + `!!` operator removed (now redundant)
- Notation resolver: `?: mutableListOf()` fallback removed (now redundant)

**`SecretsManagerTest.kt`**
- Regression test added: `testRecordCreateEmptyCustomSerialized` — asserts `"custom":[]` is present in serialized payload when no custom fields are set

## Testing

```bash
cd sdk/java/core && ./gradlew test
# 25 tests completed, BUILD SUCCESSFUL
```

## Related

- Closes [KSM-823](https://keeper.atlassian.net/browse/KSM-823)
- Epic: [KSM-821](https://keeper.atlassian.net/browse/KSM-821) (cross-SDK fix, same root cause in Python/Ruby/Rust/Go/.NET)

[KSM-823]: https://keeper.atlassian.net/browse/KSM-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ