### PR TITLE
fix(rust-sdk): KSM-886 reuse HTTP client for file downloads

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -195,12 +195,16 @@ pub struct SecretsManager {
     pub cache: KSMCache,
     pub proxy_url: Option<String>,
     custom_post_function: Option<CustomPostFunction>,
+    /// Pre-built HTTP client shared across all operations (API calls + file downloads).
+    /// Built once during init to avoid constructing reqwest::blocking::Client inside
+    /// tokio::spawn_blocking, which fails due to nested runtime conflicts.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    http_client: Option<reqwest::blocking::Client>,
 }
 
 impl Clone for SecretsManager {
     fn clone(&self) -> Self {
         SecretsManager {
-            // Clone each field of the struct
             token: self.token.clone(),
             hostname: self.hostname.clone(),
             verify_ssl_certs: self.verify_ssl_certs,
@@ -209,6 +213,7 @@ impl Clone for SecretsManager {
             cache: self.cache.clone(),
             proxy_url: self.proxy_url.clone(),
             custom_post_function: self.custom_post_function,
+            http_client: self.http_client.clone(),
         }
     }
 }
@@ -251,10 +256,11 @@ impl SecretsManager {
             hostname: String::new(),
             verify_ssl_certs: false,
             config: KvStoreType::None,
-            log_level: Level::Info, // Default to Info if not provided
-            cache: KSMCache::None,  // Default is no cache
+            log_level: Level::Info,
+            cache: KSMCache::None,
             proxy_url: client_options.proxy_url.clone(),
             custom_post_function: client_options.custom_post_function,
+            http_client: None, // built after SSL/proxy config is resolved
         };
 
         let mut config = client_options.config;
@@ -389,10 +395,22 @@ impl SecretsManager {
         }
         secrets_manager.config = config.clone();
 
-        match secrets_manager._init() {
-            Ok(secrets_manager) => Ok(secrets_manager),
-            Err(e) => Err(e),
+        let mut sm = secrets_manager._init()?;
+
+        // Build a shared HTTP client once, outside any async runtime.
+        // Reused for API calls and file downloads. Avoids constructing
+        // reqwest::blocking::Client inside tokio::spawn_blocking which fails
+        // due to nested runtime conflicts (reqwest#1017).
+        let mut client_builder =
+            reqwest::blocking::Client::builder().danger_accept_invalid_certs(sm.verify_ssl_certs);
+        if let Some(proxy_url) = &sm.proxy_url {
+            if let Ok(proxy) = SecretsManager::build_proxy(proxy_url) {
+                client_builder = client_builder.proxy(proxy);
+            }
         }
+        sm.http_client = client_builder.build().ok();
+
+        Ok(sm)
     }
 
     fn _init(&mut self) -> Result<Self, KSMRError> {
@@ -1194,10 +1212,12 @@ impl SecretsManager {
                 let record_result =
                     Record::new_from_json(record_hashmap_parsed, &_secret_key, None);
                 if let Ok(mut unwrapped_record) = record_result {
-                    if let Some(proxy) = &self.proxy_url {
-                        for file in &mut unwrapped_record.files {
+                    for file in &mut unwrapped_record.files {
+                        if let Some(proxy) = &self.proxy_url {
                             file.proxy_url = Some(proxy.clone());
                         }
+                        file.skip_ssl_verify = self.verify_ssl_certs;
+                        file.http_client = self.http_client.clone();
                     }
                     records_count += 1;
                     records.push(unwrapped_record);
@@ -1219,11 +1239,13 @@ impl SecretsManager {
                 if let Some(unwrapped_folder) = folder_result {
                     shared_folders_count += 1;
                     let mut folder_records = unwrapped_folder.records()?;
-                    if let Some(proxy) = &self.proxy_url {
-                        for record in &mut folder_records {
-                            for file in &mut record.files {
+                    for record in &mut folder_records {
+                        for file in &mut record.files {
+                            if let Some(proxy) = &self.proxy_url {
                                 file.proxy_url = Some(proxy.clone());
                             }
+                            file.skip_ssl_verify = self.verify_ssl_certs;
+                            file.http_client = self.http_client.clone();
                         }
                     }
                     records_count += folder_records.len();

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -1050,6 +1050,13 @@ pub struct KeeperFile {
     pub url: Option<String>,           // Download URL (v16.7.0+)
     pub thumbnail_url: Option<String>, // Thumbnail URL (v16.7.0+)
     pub proxy_url: Option<String>,     // Proxy URL for HTTP requests
+    pub skip_ssl_verify: bool, // Skip SSL cert verification (for corporate proxies like Zscaler)
+    /// Pre-built HTTP client for file downloads. Avoids constructing a new
+    /// reqwest::blocking::Client inside tokio::spawn_blocking, which fails
+    /// because reqwest's blocking module creates an internal tokio runtime.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    #[serde(skip)]
+    pub http_client: Option<reqwest::blocking::Client>,
 
     f: HashMap<String, Value>,
     record_key_bytes: Vec<u8>,
@@ -1071,6 +1078,8 @@ impl KeeperFile {
             url: self.url.clone(),
             thumbnail_url: self.thumbnail_url.clone(),
             proxy_url: self.proxy_url.clone(),
+            skip_ssl_verify: self.skip_ssl_verify,
+            http_client: self.http_client.clone(),
             f: self.f.clone(),
             record_key_bytes: self.record_key_bytes.clone(),
         }
@@ -1151,16 +1160,24 @@ impl KeeperFile {
             .get_url()
             .map_err(|_| KSMRError::FileError("File URL is invalid".to_string()))?;
 
-        // Fetch the file data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
+        // Use pre-built HTTP client if available. Building a new reqwest::blocking::Client
+        // inside tokio::spawn_blocking fails because reqwest's blocking module creates an
+        // internal tokio runtime which conflicts with the existing one.
+        // See: https://github.com/seanmonstar/reqwest/issues/1017
+        let http_client = if let Some(client) = &self.http_client {
+            client.clone()
+        } else {
+            let mut client_builder = reqwest::blocking::Client::builder()
+                .danger_accept_invalid_certs(self.skip_ssl_verify);
+            if let Some(ref proxy_url) = self.proxy_url {
+                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                    client_builder = client_builder.proxy(proxy);
+                }
             }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+            client_builder
+                .build()
+                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
+        };
         let mut response = http_client
             .get(&file_url)
             .send()
@@ -1236,16 +1253,21 @@ impl KeeperFile {
         // Decrypt the file key
         let file_key = self.decrypt_file_key()?;
 
-        // Fetch the thumbnail data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
+        // Fetch the thumbnail data from the URL (reuse pre-built client if available)
+        let http_client = if let Some(client) = &self.http_client {
+            client.clone()
+        } else {
+            let mut client_builder = reqwest::blocking::Client::builder()
+                .danger_accept_invalid_certs(self.skip_ssl_verify);
+            if let Some(ref proxy_url) = self.proxy_url {
+                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                    client_builder = client_builder.proxy(proxy);
+                }
             }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+            client_builder
+                .build()
+                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
+        };
         let mut response = http_client
             .get(&thumbnail_url)
             .send()
@@ -1300,6 +1322,8 @@ impl KeeperFile {
             url,
             thumbnail_url,
             proxy_url: None,
+            skip_ssl_verify: false,
+            http_client: None,
             f: file_dict.clone(),
             record_key_bytes,
         };
@@ -1846,6 +1870,8 @@ mod tests {
             url: None,
             thumbnail_url: None,
             proxy_url,
+            skip_ssl_verify: false,
+            http_client: None,
             f: HashMap::new(),
             record_key_bytes: vec![],
         }


### PR DESCRIPTION
## Summary
- Builds one `reqwest::blocking::Client` in `SecretsManager::new()` and reuses it for file downloads
- Fixes `get_file_data()` and `get_thumbnail_data()` failing with "builder error" when called from inside `tokio::spawn_blocking`

## Context
`reqwest::blocking::Client::builder().build()` creates an internal tokio runtime. When called inside an existing tokio runtime (via `spawn_blocking`), this panics with "Cannot drop a runtime in a context where blocking is not allowed" or silently fails with "builder error".

The main API calls (`post_query`) worked because they configured `danger_accept_invalid_certs` which changed the TLS initialization path. File downloads (`get_file_data`, `get_thumbnail_data`) built a bare client without any options, hitting the issue.

Same problem reported in: OpenTelemetry Rust (#2400), TiKV rust-prometheus (#342), reqwest (#1017, #1233).

## Changes
- `SecretsManager` struct: new `http_client: Option<reqwest::blocking::Client>` field, built once in `new()` after SSL/proxy config is resolved
- `KeeperFile` struct: new `http_client: Option<reqwest::blocking::Client>` + `skip_ssl_verify: bool` fields, propagated from `SecretsManager` when records are fetched (same pattern as existing `proxy_url` propagation)
- `get_file_data()` / `get_thumbnail_data()`: use pre-built client when available, fall back to building a new one for backward compatibility