### PR TITLE
fix(rust-sdk): KSM-812 get_folders() borrows instead of consuming SecretsManager

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -1315,7 +1315,7 @@ impl SecretsManager {
         Ok(secrets_manager_response)
     }
 
-    fn fetch_and_decrypt_folders(mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    fn fetch_and_decrypt_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let payload = self
             .clone()
             .prepare_get_payload(self.config.clone(), None)?;
@@ -1486,7 +1486,7 @@ impl SecretsManager {
     ///
     /// * `HTTPError` - If the API request fails
     /// * `CryptoError` - If folder decryption fails
-    pub fn get_folders(self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    pub fn get_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let folders = self.fetch_and_decrypt_folders()?;
         Ok(folders)
     }

--- a/sdk/rust/tests/empty_config_test.rs
+++ b/sdk/rust/tests/empty_config_test.rs
@@ -35,6 +35,7 @@ mod empty_config_tests {
             Level::Error,
             None,
             None,
+            None,
             KSMCache::None,
         );
 
@@ -70,6 +71,7 @@ mod empty_config_tests {
                     Level::Error,
                     None,
                     None,
+                    None,
                     KSMCache::None,
                 );
 
@@ -96,6 +98,7 @@ mod empty_config_tests {
             String::new(),
             config,
             Level::Error,
+            None,
             None,
             None,
             KSMCache::None,

--- a/sdk/rust/tests/feature_validation_tests.rs
+++ b/sdk/rust/tests/feature_validation_tests.rs
@@ -725,4 +725,41 @@ mod feature_validation_tests {
         // This test passing means all new features are properly exported and compile
         assert!(true);
     }
+
+    /// Regression test for KSM-812: get_folders() must take &mut self, not self.
+    ///
+    /// Before the fix, get_folders() consumed the SecretsManager, so any subsequent
+    /// call on the same instance would fail to compile. This test verifies the
+    /// instance is still usable after calling get_folders().
+    #[test]
+    fn test_get_folders_does_not_consume_secrets_manager() {
+        fn mock_empty_folders(
+            _url: String,
+            transmission_key: TransmissionKey,
+            _encrypted_payload: EncryptedPayload,
+        ) -> Result<KsmHttpResponse, KSMRError> {
+            let response = json!({"folders": [], "records": [], "expiresOn": 0, "warnings": []});
+            let response_bytes = response.to_string().into_bytes();
+            let encrypted =
+                CryptoUtils::encrypt_aes_gcm(&response_bytes, &transmission_key.key, None)?;
+            Ok(KsmHttpResponse {
+                status_code: 200,
+                data: encrypted,
+                http_response: None,
+            })
+        }
+
+        let storage = create_test_storage().expect("Failed to create storage");
+        let mut client_options = ClientOptions::new_client_options(storage);
+        client_options.set_custom_post_function(mock_empty_folders);
+        let mut sm = SecretsManager::new(client_options).expect("Failed to create SecretsManager");
+
+        // First call
+        let first = sm.get_folders();
+        // Second call on the same instance — would not compile if get_folders() took self
+        let second = sm.get_folders();
+
+        assert!(first.is_ok(), "First get_folders() call failed: {:?}", first);
+        assert!(second.is_ok(), "Second get_folders() call failed: {:?}", second);
+    }
 }


### PR DESCRIPTION
## Summary

- `get_folders()` and its internal `fetch_and_decrypt_folders()` both took `self` by value, consuming the `SecretsManager` instance
- This forced callers to clone before calling `get_folders()` if they needed the instance afterward — inconsistent with every other method (`get_secrets`, `create_secret`, etc.) which take `&mut self`
- Changed both signatures to `&mut self`; the existing `self.clone()` calls inside `fetch_and_decrypt_folders` for methods that still require ownership are unaffected

Also fixes a pre-existing compile error in `empty_config_test.rs` where `ClientOptions::new()` calls were missing the `proxy_url` argument after it was added to the function signature.

## Related Issues

- Closes #950
- Internal: KSM-812