### PR TITLE
Release Rust SDK v17.2.0

### DIFF
--- a/.github/workflows/publish.crates.rust.sdk.yml
+++ b/.github/workflows/publish.crates.rust.sdk.yml
@@ -22,10 +22,12 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -53,8 +55,13 @@ jobs:
           cargo test --all-features --test integration_tests
           cargo test --all-features --test notation_tests
           cargo test --all-features --test payload_test
+          cargo test --all-features --test proxy_test
           cargo test --all-features --test totp_test
           cargo test --all-features --test update_secret_tests
+          cargo test --all-features --test caching_transmission_key_tests
+          cargo test --all-features --test download_file_by_title_tests
+          cargo test --all-features --test duplicate_uid_notation_test
+          cargo test --all-features --test empty_config_test
 
       - name: Run caching tests (serial execution required)
         run: cargo test --all-features --test caching_tests -- --test-threads=1
@@ -76,7 +83,9 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Detect Rust SDK version
         id: detect-version
@@ -92,7 +101,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: stable
 
@@ -113,7 +122,7 @@ jobs:
           jq '.metadata.component.name' rust-sdk-sbom.json
 
       - name: Publish SBOM to Manifest Cyber
-        uses: manifest-cyber/manifest-github-action@main
+        uses: manifest-cyber/manifest-github-action@9aa4e84c80e6d232c3f49506a17f0ff1151e6896 # main
         with:
           apiKey: ${{ secrets.MANIFEST_TOKEN }}
           bomFilePath: ./sdk/rust/rust-sdk-sbom.json
@@ -122,7 +131,7 @@ jobs:
           asset-labels: application,sbom-generated,rust,cargo,secrets-manager
 
       - name: Archive SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom-rust-sdk-${{ steps.detect-version.outputs.version }}
           path: ./sdk/rust/rust-sdk-sbom.json
@@ -145,15 +154,17 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: stable
 
       - name: Authenticate with crates.io via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
         id: auth
 
       - name: Dry-run publish (validates package and authentication)
@@ -180,15 +191,17 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: stable
 
       - name: Authenticate with crates.io via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
         id: auth
 
       - name: Publish to crates.io

--- a/.github/workflows/publish.crates.rust.sdk.yml
+++ b/.github/workflows/publish.crates.rust.sdk.yml
@@ -2,10 +2,46 @@ name: Publish to Crates.io (Rust SDK)
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to crates.io (uncheck to build only)'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
+  check-version:
+    name: Check version not already published
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    defaults:
+      run:
+        working-directory: ./sdk/rust
+
+    steps:
+      - name: Get the source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Verify version does not exist on crates.io
+        run: |
+          VERSION=$(grep -Po '^version\s*=\s*"\K[^"]*' Cargo.toml)
+          echo "Checking crates.io for keeper-secrets-manager-core v${VERSION}..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/keeper_secrets_manager_core/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "❌ Version ${VERSION} already exists on crates.io — bump the version before publishing"
+            exit 1
+          fi
+          echo "✅ Version ${VERSION} is new — proceeding with publish"
+
   test-rust-sdk:
     name: Test Rust SDK (${{ matrix.rust }})
+    needs: check-version
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -22,10 +58,12 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -53,8 +91,13 @@ jobs:
           cargo test --all-features --test integration_tests
           cargo test --all-features --test notation_tests
           cargo test --all-features --test payload_test
+          cargo test --all-features --test proxy_test
           cargo test --all-features --test totp_test
           cargo test --all-features --test update_secret_tests
+          cargo test --all-features --test caching_transmission_key_tests
+          cargo test --all-features --test download_file_by_title_tests
+          cargo test --all-features --test duplicate_uid_notation_test
+          cargo test --all-features --test empty_config_test
 
       - name: Run caching tests (serial execution required)
         run: cargo test --all-features --test caching_tests -- --test-threads=1
@@ -76,7 +119,9 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Detect Rust SDK version
         id: detect-version
@@ -91,42 +136,41 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-
-      - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx --locked
-
-      - name: Generate SBOM
+      - name: Install Syft and Manifest CLI
         run: |
-          echo "Generating CycloneDX SBOM with cargo-cyclonedx..."
-          cargo cyclonedx --format json --spec-version 1.5 --override-filename rust-sdk-sbom
-          echo "SBOM generated: rust-sdk-sbom.json"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.32.0
+          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b /usr/local/bin v0.30.0
 
-          echo "Updating SBOM component name to include rust-sdk identifier..."
-          jq '.metadata.component.name = "keeper-secrets-manager-rust-sdk"' rust-sdk-sbom.json > rust-sdk-sbom-fixed.json
-          mv rust-sdk-sbom-fixed.json rust-sdk-sbom.json
-
-          echo "Verifying updated component name:"
-          jq '.metadata.component.name' rust-sdk-sbom.json
-
-      - name: Publish SBOM to Manifest Cyber
-        uses: manifest-cyber/manifest-github-action@main
-        with:
-          apiKey: ${{ secrets.MANIFEST_TOKEN }}
-          bomFilePath: ./sdk/rust/rust-sdk-sbom.json
-          sbomName: keeper-secrets-manager-rust-sdk
-          sbomVersion: ${{ steps.detect-version.outputs.version }}
-          asset-labels: application,sbom-generated,rust,cargo,secrets-manager
+      - name: Generate and publish SDK SBOM
+        env:
+          MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
+          SDK_VERSION: ${{ steps.detect-version.outputs.version }}
+        run: |
+          manifest sbom . \
+            --generator=syft \
+            --name=keeper-secrets-manager-rust-sdk \
+            --version="${SDK_VERSION}" \
+            --output=cyclonedx-json \
+            --file=rust-sdk-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --asset-label=ksm,sdk,rust,cargo,secrets-manager 2>&1 || \
+          manifest sbom . \
+            --generator=syft \
+            --name=keeper-secrets-manager-rust-sdk \
+            --version="${SDK_VERSION}" \
+            --output=cyclonedx-json \
+            --file=rust-sdk-sbom.json \
+            --api-key="${MANIFEST_TOKEN}" \
+            --publish=true \
+            --label=ksm,sdk,rust,cargo,secrets-manager
 
       - name: Archive SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-rust-sdk-${{ steps.detect-version.outputs.version }}
           path: ./sdk/rust/rust-sdk-sbom.json
-          retention-days: 90
+          retention-days: 10
 
   dry-run-publish:
     name: Validate package (dry-run)
@@ -145,15 +189,17 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: stable
 
       - name: Authenticate with crates.io via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
         id: auth
 
       - name: Dry-run publish (validates package and authentication)
@@ -165,6 +211,7 @@ jobs:
 
   publish-crates:
     name: Publish Rust SDK to crates.io
+    if: ${{ github.event.inputs.publish == 'true' }}
     environment: prod
     needs: [dry-run-publish]
     runs-on: ubuntu-latest
@@ -180,15 +227,17 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: stable
 
       - name: Authenticate with crates.io via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
         id: auth
 
       - name: Publish to crates.io

--- a/.github/workflows/publish.crates.rust.sdk.yml
+++ b/.github/workflows/publish.crates.rust.sdk.yml
@@ -4,8 +4,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-version:
+    name: Check version not already published
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    defaults:
+      run:
+        working-directory: ./sdk/rust
+
+    steps:
+      - name: Get the source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Verify version does not exist on crates.io
+        run: |
+          VERSION=$(grep -Po '^version\s*=\s*"\K[^"]*' Cargo.toml)
+          echo "Checking crates.io for keeper-secrets-manager-core v${VERSION}..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/keeper_secrets_manager_core/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "❌ Version ${VERSION} already exists on crates.io — bump the version before publishing"
+            exit 1
+          fi
+          echo "✅ Version ${VERSION} is new — proceeding with publish"
+
   test-rust-sdk:
     name: Test Rust SDK (${{ matrix.rust }})
+    needs: check-version
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/test.rust.yml
+++ b/.github/workflows/test.rust.yml
@@ -32,10 +32,12 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -67,6 +69,10 @@ jobs:
           cargo test --all-features --test proxy_test
           cargo test --all-features --test totp_test
           cargo test --all-features --test update_secret_tests
+          cargo test --all-features --test caching_transmission_key_tests
+          cargo test --all-features --test download_file_by_title_tests
+          cargo test --all-features --test duplicate_uid_notation_test
+          cargo test --all-features --test empty_config_test
 
       - name: Run caching tests (serial execution required)
         run: cargo test --all-features --test caching_tests -- --test-threads=1

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## [17.2.0]
+
+### Security
+
+- **reqwest 0.12 → 0.13.3** (KSM-922): resolves four `rustls-webpki` advisories
+  - GHSA-82J2-J2CH-GFR8 (High) — certificate validation bypass
+  - GHSA-PWJX-7F5V-R8JG, GHSA-XGP8-6FX6-WHRG, GHSA-965H-77QH-FMWD (Low/Medium)
+- **openssl 0.10.75 → 0.10.78**: resolves four Critical CVEs
+  - CVE-2026-41676, CVE-2026-41677, CVE-2026-41678, CVE-2026-41681 (CVSS 9.1–9.8)
+- **TLS backend**: reqwest 0.13 switches from ring-backed rustls to `aws-lc-rs`-backed rustls — the required foundation for FIPS 140-3 compliance in the Rust SDK
+
+### Fixed
+
+- **KSM-886**: File downloads and thumbnail downloads crashed with "builder error" when called from inside a tokio runtime
+  - Root cause: `get_file_data()` and `get_thumbnail_data()` built a new `reqwest::blocking::Client` per call inside `tokio::spawn_blocking`, which creates a nested tokio runtime conflict
+  - Fix: one `reqwest::blocking::Client` is built in `SecretsManager::new()` and propagated to all `KeeperFile` instances; file operations reuse it
+  - See: [reqwest#1017](https://github.com/seanmonstar/reqwest/issues/1017)
+- **KSM-812**: `get_folders()` consumed `SecretsManager` by value, preventing any subsequent call on the same instance without cloning first
+  - Signature changed from `self` to `&mut self` to match `get_secrets()`, `create_secret()`, and the rest of the API
+  - **Note**: this is a breaking change for callers that relied on the consuming signature (e.g. via turbofish or trait bounds); the fix is to remove any `.clone()` added to work around the original bug
+- **KSM-925**: Three internal callsites (`update_folder`, `create_folder`, `create_secret`) were still calling `self.clone().get_folders()` after KSM-812 fixed the signature; each clone triggered a wasted extra network round-trip on a throwaway instance — removed
+- **KSM-926**: `post_function` (every API call) and `upload_file_function` (multipart file upload) each built a new `reqwest::blocking::Client` per call, leaving the same nested-runtime panic risk under `tokio::spawn_blocking` that KSM-886 fixed for file downloads; both callsites now reuse the shared client built in `SecretsManager::new()`
+- **KSM-926**: Resolved a long-standing semantic inversion of `verify_ssl_certs`: the field was assigned with two opposite conventions (constructor option vs. env var) and read with two opposite conventions (API path vs. multipart upload). The field now uniformly means "do verify", and all `danger_accept_invalid_certs` calls route through a single `skip_ssl_verify()` accessor. Net behavior change: `insecure_skip_verify=true` and `KSM_SKIP_VERIFY=true` now both correctly relax TLS verification on every HTTP path; the default (neither set) is now strict on every HTTP path
+- Proxy configuration errors (malformed URL, unsupported scheme) now surface at `SecretsManager::new()` with a clear `SecretManagerCreationError` instead of silently bypassing the proxy and sending traffic direct
+- Authenticated proxy URLs (`http://user:pass@host:port`) are now correctly applied when `KeeperFile` is used outside the standard `get_secrets()` fetch path (e.g. deserialized from storage)
+- TLS initialisation failures now surface at `SecretsManager::new()` instead of deferring to the first API call
+- **KSM-931**: `caching::caching_post_function` built a new `reqwest::blocking::Client` on every API call, leaving the same nested-runtime panic risk under `tokio::spawn_blocking` that KSM-886 / KSM-926 fixed for the standard paths
+  - Fix: new `caching::make_caching_post_function(client)` factory captures a `reqwest::blocking::Client` built outside any async context and reuses it across all calls; the bare `caching_post_function` is retained for synchronous callers but its docs now warn against use under async runtimes
+  - **Note**: `CustomPostFunction` is now `Arc<dyn Fn(...) + Send + Sync>` instead of a bare `fn` pointer — minor breaking change for callers that stored the alias directly; existing `options.set_custom_post_function(my_fn)` call sites compile unchanged because bare `fn` implements `Fn + Send + Sync + 'static`
+  - See: [reqwest#1017](https://github.com/seanmonstar/reqwest/issues/1017)
+- **KSM-933**: `get_secrets()` was propagating `SecretsManager.verify_ssl_certs` (positive-sense: `true` = strict) directly into `KeeperFile.skip_ssl_verify` (negative-sense: `true` = skip); in strict mode, every file attachment received `skip_ssl_verify=true` — the opposite of intended. Fix: both propagation sites (standalone record path and shared folder record path) now use the `skip_ssl_verify()` accessor, which correctly returns `!verify_ssl_certs`. Currently masked by the shared `http_client` path, but would have become a silent security regression on any future refactor.
+- **KSM-936**: `RecordField::new` unconditionally wrapped the supplied `Value` in a single-element array, so callers passing a `Value::Array` (the documented way to create multi-value fields like `phone` and `securityQuestion`) produced `[[obj1, obj2]]` on the wire instead of `[obj1, obj2]`. The server stored the wrong shape, causing `keeper://UID/field/phone[1]` to return "idx out of range: 1" and records to appear single-valued to all other SDKs. Fix: input arrays pass through unchanged; `null` becomes `[]`; scalars and objects are wrapped as before.
+- **KSM-937**: `examples/manual_tests/06_caching_function.rs` still used the deprecated bare `caching::caching_post_function` after KSM-934 updated the module doc and README. Users copying the example into a tokio app would intermittently hit the KSM-886 panic. Updated to build one `reqwest::blocking::Client` outside any async context and pass it to `caching::make_caching_post_function(client)`. Examples README updated to match.
+
+### Changed
+
+- `KeeperFile::http_client` and `KeeperFile::skip_ssl_verify` are now `pub(crate)`; they are internal propagation fields and were never part of the public API contract
+- `hex` crate removed; hex encoding now uses `data-encoding` (already a direct dependency) — no public API change (KSM-924)
+
 ## [17.1.0]
 
 ### Added

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "keeper-secrets-manager-core"
-version = "17.1.0"
+version = "17.2.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -72,38 +72,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atomic-waker"
@@ -113,9 +119,31 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base16ct"
@@ -131,15 +159,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -161,15 +189,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -179,31 +201,39 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -217,10 +247,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
+name = "cmake"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -239,6 +288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,9 +305,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -260,19 +319,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -287,15 +346,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -332,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,7 +425,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -377,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -387,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -400,41 +465,41 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -443,55 +508,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -499,15 +549,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -516,36 +566,34 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -562,13 +610,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -578,9 +628,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -600,15 +665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -625,21 +690,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -661,12 +729,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -682,12 +749,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -695,15 +762,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -715,7 +782,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -723,47 +789,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -782,14 +829,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -805,21 +853,23 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -829,103 +879,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -934,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -944,34 +962,36 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -985,15 +1005,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1004,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1014,18 +1034,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.82"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "keeper-secrets-manager-core"
-version = "17.1.0"
+version = "17.2.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1036,14 +1117,13 @@ dependencies = [
  "data-encoding",
  "ecdsa",
  "env_logger",
- "hex",
  "hmac",
  "lazy_static",
  "log",
  "mockall",
  "num-bigint",
  "p256",
- "rand",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "serde",
@@ -1068,44 +1148,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1125,13 +1216,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1158,23 +1249,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1216,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1233,48 +1307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p256"
@@ -1290,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1300,15 +1336,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1322,21 +1358,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1347,12 +1377,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polyval"
@@ -1368,24 +1392,33 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
+name = "potential_utf"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -1417,6 +1450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,18 +1470,74 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.38"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1450,14 +1549,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1467,7 +1582,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1476,23 +1601,32 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1502,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1513,15 +1647,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -1535,22 +1669,22 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1578,17 +1712,32 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.2"
+name = "rustc-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1599,10 +1748,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1611,17 +1761,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.1"
+name = "rustls-native-certs"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1629,15 +1823,18 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -1650,11 +1847,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1685,12 +1882,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1698,13 +1895,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1738,37 +1941,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+ "zmij",
 ]
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
@@ -1778,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1800,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1826,10 +2018,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1840,32 +2033,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1880,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"
@@ -1911,9 +2117,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1942,12 +2148,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1963,12 +2169,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1981,30 +2187,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.48.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -2019,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2029,20 +2269,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -2050,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2063,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2078,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2108,9 +2338,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2119,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2130,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2151,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -2171,21 +2401,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -2205,20 +2441,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -2234,21 +2465,25 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2261,24 +2496,33 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2289,22 +2533,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2312,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2325,21 +2566,74 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.82"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2359,6 +2653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,18 +2669,38 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.1.3"
+name = "windows-implement"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
@@ -2387,31 +2710,31 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2419,15 +2742,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2447,7 +2761,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2472,7 +2786,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -2581,29 +2895,110 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2611,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,19 +3018,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2644,18 +3038,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2665,15 +3059,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2682,11 +3087,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keeper-secrets-manager-core"
-version = "17.1.0"
+version = "17.2.0"
 authors = ["Keeper Security <sm@keepersecurity.com>"]
 edition = "2021"
 rust-version = "1.87"
@@ -26,14 +26,13 @@ cipher = "0.4"
 chrono = "0.4.41"
 ecdsa = "0.16"
 env_logger = "0.11"
-hex = "0.4"
 hmac = "0.12"
 log = "0.4"
 lazy_static = "1.5"
 p256 = { version = "0.13", features = ["ecdh"] }
 rand = "0.8"
 regex = "1.11"
-reqwest = { version = "0.12.22", features = ["blocking", "json", "multipart"] }
+reqwest = { version = "0.13.3", features = ["blocking", "json", "multipart"] }
 tokio = { version = "1.47", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.142", features = ["preserve_order", "arbitrary_precision"] }
@@ -41,7 +40,6 @@ sha2 = "0.10"
 sha1 = "0.10"
 strum = "0.26"
 strum_macros = "0.26"
-tempfile = "3.20"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 num-bigint = "0.4"
@@ -54,6 +52,7 @@ winapi = { version = "0.3" ,features = ["securitybaseapi","winbase","winerror","
 mockall = "0.13"
 tempfile = "3.20"
 serial_test = "3.0"
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 # Manual integration test examples
 [[example]]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keeper-secrets-manager-core"
-version = "17.1.0"
+version = "17.2.0"
 authors = ["Keeper Security <sm@keepersecurity.com>"]
 edition = "2021"
 rust-version = "1.87"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-keeper-secrets-manager-core = "17.1.0"
+keeper-secrets-manager-core = "17.2.0"
 ```
 
 ## Quick Start
@@ -526,8 +526,9 @@ let config = KvStoreType::File(storage);
 let token = "YOUR_TOKEN".to_string();
 let mut options = ClientOptions::new_client_options_with_token(token, config);
 
-// Enable disaster recovery caching
-options.set_custom_post_function(caching::caching_post_function);
+// Build the client once outside any async context (safe for spawn_blocking)
+let client = reqwest::blocking::Client::builder().build()?;
+options.set_custom_post_function(caching::make_caching_post_function(client));
 
 let mut secrets_manager = SecretsManager::new(options)?;
 
@@ -671,7 +672,7 @@ See `examples/manual_tests/README.md` for detailed setup instructions.
 - `KSM_CONFIG` - Base64-encoded JSON configuration (overrides file storage)
 - `KSM_CACHE_DIR` - Cache directory for disaster recovery caching (default: current directory)
 - `KSM_SKIP_VERIFY` - Skip SSL certificate verification (`true`/`false`)
-- `KSM_PROXY_URL` - Proxy URL used by `caching_post_function` (mirrors `ClientOptions.proxy_url` for the caching path)
+- `KSM_PROXY_URL` - Proxy URL used by the bare `caching_post_function` (not used by `make_caching_post_function` — configure proxy on the `reqwest::Client` builder instead)
 - `HTTP_PROXY` - HTTP proxy URL (automatically used if `proxy_url` not set)
 - `HTTPS_PROXY` - HTTPS proxy URL (automatically used if `proxy_url` not set)
 - `NO_PROXY` - Comma-separated list of hosts to exclude from proxying
@@ -758,17 +759,25 @@ export NO_PROXY=localhost,127.0.0.1
 
 **Priority**: Explicit `proxy_url` parameter > Environment variables (`HTTPS_PROXY`/`HTTP_PROXY`)
 
-#### Proxy with `caching_post_function`
+#### Proxy with caching
 
-`caching_post_function` uses a standalone function pointer and cannot capture `SecretsManager` state. Set `KSM_PROXY_URL` to route caching traffic through your proxy:
+With `make_caching_post_function`, configure the proxy on the `reqwest::Client` you pass in:
+
+```rust
+let client = reqwest::blocking::Client::builder()
+    .proxy(reqwest::Proxy::https("http://proxy.example.com:8080")?)
+    .build()?;
+client_options.set_custom_post_function(caching::make_caching_post_function(client));
+```
+
+The bare `caching_post_function` (non-async contexts only) reads `KSM_PROXY_URL` at call time instead:
 
 ```bash
 export KSM_PROXY_URL=http://proxy.example.com:8080
 ```
 
 ```rust
-client_options.set_custom_post_function(caching_post_function);
-// KSM_PROXY_URL is read at call time by caching_post_function
+client_options.set_custom_post_function(caching::caching_post_function);
 ```
 
 ## Dependencies

--- a/sdk/rust/examples/manual_tests/06_caching_function.rs
+++ b/sdk/rust/examples/manual_tests/06_caching_function.rs
@@ -1,7 +1,7 @@
 // Manual Integration Test 6: Disaster Recovery Caching
 //
 // This test validates:
-// - caching_post_function
+// - make_caching_post_function (recommended safe API — reuses one pre-built reqwest Client)
 // - Cache save on success
 // - Cache fallback on failure
 // - Cache file operations
@@ -30,8 +30,14 @@ fn main() -> Result<(), KSMRError> {
     let config = FileKeyValueStorage::new_config_storage("test_config.json".to_string())?;
     let mut client_options = ClientOptions::new_client_options(config);
 
+    // Build the reqwest client once outside any async context so it is safe under
+    // tokio::task::spawn_blocking. See caching::make_caching_post_function for details.
+    let client = reqwest::blocking::Client::builder()
+        .build()
+        .expect("build reqwest client");
+
     println!("\nEnabling disaster recovery caching...");
-    client_options.set_custom_post_function(caching::caching_post_function);
+    client_options.set_custom_post_function(caching::make_caching_post_function(client));
 
     let mut secrets_manager = SecretsManager::new(client_options)?;
 
@@ -76,7 +82,7 @@ fn main() -> Result<(), KSMRError> {
     // save mechanism works correctly.
 
     println!("\n=== Cache Function Validation ===");
-    println!("✅ caching_post_function() can be set");
+    println!("✅ make_caching_post_function() can be set");
     println!("✅ Cache saves on successful API call");
     println!("✅ Cache file accessible via get_cached_data()");
     println!("✅ Cache can be cleared via clear_cache()");

--- a/sdk/rust/examples/manual_tests/README.md
+++ b/sdk/rust/examples/manual_tests/README.md
@@ -104,7 +104,7 @@ cargo run --example 06_caching_function
 ```
 
 **Validates:**
-- `caching_post_function` module
+- `make_caching_post_function` (recommended safe caching API)
 - Cache save on success
 - Cache file creation
 - Cache load/clear operations

--- a/sdk/rust/src/caching.rs
+++ b/sdk/rust/src/caching.rs
@@ -24,19 +24,16 @@
 //! use keeper_secrets_manager_core::caching;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Build the client once outside any async context (safe for spawn_blocking)
+//! let client = reqwest::blocking::Client::builder().build()?;
 //! let config = FileKeyValueStorage::new_config_storage("config.json".to_string())?;
 //! let mut client_options = ClientOptions::new_client_options(config);
-//!
-//! // Use caching post function for disaster recovery
-//! client_options.set_custom_post_function(caching::caching_post_function);
+//! client_options.set_custom_post_function(caching::make_caching_post_function(client));
 //!
 //! let mut secrets_manager = SecretsManager::new(client_options)?;
 //!
-//! // First call saves to cache
+//! // First call saves to cache; if network fails, falls back to cached data
 //! let secrets = secrets_manager.get_secrets(Vec::new())?;
-//!
-//! // If network fails, falls back to cached data
-//! // let secrets = secrets_manager.get_secrets(Vec::new())?; // Uses cache on failure
 //! # Ok(())
 //! # }
 //! ```
@@ -126,11 +123,46 @@ pub fn cache_exists() -> bool {
     get_cache_file_path().exists()
 }
 
+/// Build a caching post function that captures a pre-built HTTP client.
+///
+/// Returns a closure suitable for use with `ClientOptions::set_custom_post_function`.
+/// The returned closure reuses the provided `reqwest::blocking::Client` on every call,
+/// so it is safe to invoke from inside `tokio::task::spawn_blocking`. Construct the
+/// client and the closure outside any async context, then pass it to
+/// `ClientOptions::set_custom_post_function` before calling `SecretsManager::new()`.
+///
+/// # Example
+/// ```rust,no_run
+/// use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+/// use keeper_secrets_manager_core::storage::FileKeyValueStorage;
+/// use keeper_secrets_manager_core::caching;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = reqwest::blocking::Client::builder().build()?;
+/// let config = FileKeyValueStorage::new_config_storage("config.json".to_string())?;
+/// let mut client_options = ClientOptions::new_client_options(config);
+/// client_options.set_custom_post_function(caching::make_caching_post_function(client));
+/// let mut secrets_manager = SecretsManager::new(client_options)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn make_caching_post_function(
+    client: reqwest::blocking::Client,
+) -> impl Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+       + Send
+       + Sync
+       + 'static {
+    move |url, transmission_key, encrypted_payload| {
+        run_caching_logic(url, transmission_key, encrypted_payload, &client)
+    }
+}
+
 /// Caching post function for disaster recovery.
 ///
-/// This function wraps the normal HTTP POST operation and:
-/// 1. On success: Saves the response to cache (transmission key + encrypted data)
-/// 2. On failure: Falls back to cached data if available
+/// **Warning**: This bare function builds a new `reqwest::blocking::Client` on every
+/// call. Calling it from inside `tokio::task::spawn_blocking` will panic with
+/// *"Cannot drop a runtime in a context where blocking is not allowed"*.
+/// Use [`make_caching_post_function`] instead, which captures a pre-built client.
 ///
 /// # Arguments
 /// * `url` - The API endpoint URL
@@ -139,25 +171,32 @@ pub fn cache_exists() -> bool {
 ///
 /// # Returns
 /// * `Result<KsmHttpResponse, KSMRError>` - Response object (from network or cache)
-///
-/// # Example
-/// ```rust,no_run
-/// use keeper_secrets_manager_core::core::ClientOptions;
-/// use keeper_secrets_manager_core::caching::caching_post_function;
-///
-/// # fn main() {
-/// let mut options = ClientOptions::new_client_options(keeper_secrets_manager_core::enums::KvStoreType::None);
-/// options.set_custom_post_function(caching_post_function);
-/// # }
-/// ```
 pub fn caching_post_function(
     url: String,
     transmission_key: TransmissionKey,
     encrypted_payload: EncryptedPayload,
 ) -> Result<KsmHttpResponse, KSMRError> {
     let proxy_url = std::env::var("KSM_PROXY_URL").ok();
+    let mut client_builder = Client::builder();
+    if let Some(ref proxy) = proxy_url {
+        if let Ok(p) = reqwest::Proxy::all(proxy) {
+            client_builder = client_builder.proxy(p);
+        }
+    }
+    let client = client_builder
+        .build()
+        .map_err(|e| KSMRError::HTTPError(format!("Failed to build client: {}", e)))?;
+    run_caching_logic(url, transmission_key, encrypted_payload, &client)
+}
+
+fn run_caching_logic(
+    url: String,
+    transmission_key: TransmissionKey,
+    encrypted_payload: EncryptedPayload,
+    client: &Client,
+) -> Result<KsmHttpResponse, KSMRError> {
     // Try network request first
-    match make_http_request(url, transmission_key.clone(), encrypted_payload, proxy_url) {
+    match make_http_request(client, url, transmission_key.clone(), encrypted_payload) {
         Ok(response) if response.status_code == 200 => {
             // On success, save to cache (transmission key + encrypted response body)
             let mut cache_data = transmission_key.key.clone();
@@ -221,26 +260,12 @@ pub fn caching_post_function(
     }
 }
 
-/// Make HTTP request - extracted to be testable
-///
-/// This duplicates some logic from SecretsManager#process_post_request
-/// because we need a standalone function for the caching pattern.
 fn make_http_request(
+    client: &Client,
     url: String,
     transmission_key: TransmissionKey,
     encrypted_payload: EncryptedPayload,
-    proxy_url: Option<String>,
 ) -> Result<KsmHttpResponse, KSMRError> {
-    let mut client_builder = Client::builder();
-    if let Some(ref proxy) = proxy_url {
-        if let Ok(p) = reqwest::Proxy::all(proxy) {
-            client_builder = client_builder.proxy(p);
-        }
-    }
-    let client = client_builder
-        .build()
-        .map_err(|e| KSMRError::HTTPError(format!("Failed to build client: {}", e)))?;
-
     // Build headers
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -50,20 +50,17 @@ use regex::Regex;
 use reqwest::header;
 use serde_json::Value;
 
-/// Custom post function type for HTTP request injection (used for testing and mocking)
+/// Custom post function type for HTTP request injection (used for testing and mocking).
 ///
-/// # Arguments
-/// * `url` - The URL to make the request to
-/// * `transmission_key` - The transmission key for encrypting the request
-/// * `encrypted_payload` - The encrypted payload to send
-///
-/// # Returns
-/// * `Result<KsmHttpResponse, KSMRError>` - The HTTP response or an error
-pub type CustomPostFunction = fn(
-    url: String,
-    transmission_key: TransmissionKey,
-    encrypted_payload: EncryptedPayload,
-) -> Result<KsmHttpResponse, KSMRError>;
+/// Changed in v17.2.0 (KSM-931) from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>` to allow
+/// closures that capture state (e.g. a shared `reqwest::blocking::Client`). Existing call
+/// sites using `options.set_custom_post_function(my_fn)` continue to compile unchanged
+/// because bare `fn` pointers implement `Fn + Send + Sync + 'static`.
+pub type CustomPostFunction = std::sync::Arc<
+    dyn Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+        + Send
+        + Sync,
+>;
 
 pub struct ClientOptions {
     pub token: String,
@@ -149,13 +146,15 @@ impl ClientOptions {
         self.cache = cache;
     }
 
-    /// Set a custom post function for HTTP requests (primarily for testing and mocking)
+    /// Set a custom post function for HTTP requests (primarily for testing and mocking).
     ///
-    /// # Arguments
-    /// * `post_function` - The custom function to handle HTTP POST requests
+    /// Accepts any closure or bare function pointer that matches the
+    /// `(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>`
+    /// signature and is `Send + Sync + 'static`. The value is wrapped in an `Arc`
+    /// internally, so it is cheap to clone inside `SecretsManager`.
     ///
     /// # Example
-    /// ```no_run,no_run
+    /// ```no_run
     /// use keeper_secrets_manager_core::core::ClientOptions;
     /// use keeper_secrets_manager_core::dto::{TransmissionKey, EncryptedPayload, KsmHttpResponse};
     /// use keeper_secrets_manager_core::custom_error::KSMRError;
@@ -169,8 +168,14 @@ impl ClientOptions {
     /// options.set_custom_post_function(my_mock_post);
     /// # }
     /// ```
-    pub fn set_custom_post_function(&mut self, post_function: CustomPostFunction) {
-        self.custom_post_function = Some(post_function);
+    pub fn set_custom_post_function<F>(&mut self, f: F)
+    where
+        F: Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.custom_post_function = Some(std::sync::Arc::new(f));
     }
 
     /// Sets the logging level for SDK operations.
@@ -195,12 +200,16 @@ pub struct SecretsManager {
     pub cache: KSMCache,
     pub proxy_url: Option<String>,
     custom_post_function: Option<CustomPostFunction>,
+    /// Pre-built HTTP client shared across all operations (API calls + file downloads).
+    /// Built once during init to avoid constructing reqwest::blocking::Client inside
+    /// tokio::spawn_blocking, which fails due to nested runtime conflicts.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    http_client: Option<reqwest::blocking::Client>,
 }
 
 impl Clone for SecretsManager {
     fn clone(&self) -> Self {
         SecretsManager {
-            // Clone each field of the struct
             token: self.token.clone(),
             hostname: self.hostname.clone(),
             verify_ssl_certs: self.verify_ssl_certs,
@@ -208,7 +217,8 @@ impl Clone for SecretsManager {
             log_level: self.log_level,
             cache: self.cache.clone(),
             proxy_url: self.proxy_url.clone(),
-            custom_post_function: self.custom_post_function,
+            custom_post_function: self.custom_post_function.clone(),
+            http_client: self.http_client.clone(),
         }
     }
 }
@@ -251,10 +261,11 @@ impl SecretsManager {
             hostname: String::new(),
             verify_ssl_certs: false,
             config: KvStoreType::None,
-            log_level: Level::Info, // Default to Info if not provided
-            cache: KSMCache::None,  // Default is no cache
+            log_level: Level::Info,
+            cache: KSMCache::None,
             proxy_url: client_options.proxy_url.clone(),
             custom_post_function: client_options.custom_post_function,
+            http_client: None, // built after SSL/proxy config is resolved
         };
 
         let mut config = client_options.config;
@@ -312,7 +323,7 @@ impl SecretsManager {
             secrets_manager.cache = client_options.cache;
         }
 
-        secrets_manager.verify_ssl_certs = client_options.insecure_skip_verify.unwrap_or(false);
+        secrets_manager.verify_ssl_certs = !client_options.insecure_skip_verify.unwrap_or(false);
         if env::var("KSM_SKIP_VERIFY").is_ok() {
             let env_skip_verify = env::var("KSM_SKIP_VERIFY").unwrap().parse::<bool>();
             match env_skip_verify {
@@ -389,10 +400,30 @@ impl SecretsManager {
         }
         secrets_manager.config = config.clone();
 
-        match secrets_manager._init() {
-            Ok(secrets_manager) => Ok(secrets_manager),
-            Err(e) => Err(e),
+        let mut sm = secrets_manager._init()?;
+
+        // Build a shared HTTP client once, outside any async runtime.
+        // Reused for API calls and file downloads. Avoids constructing
+        // reqwest::blocking::Client inside tokio::spawn_blocking which fails
+        // due to nested runtime conflicts (reqwest#1017).
+        let mut client_builder =
+            reqwest::blocking::Client::builder().danger_accept_invalid_certs(sm.skip_ssl_verify());
+        if let Some(proxy_url) = &sm.proxy_url {
+            let proxy = SecretsManager::build_proxy(proxy_url)?;
+            client_builder = client_builder.proxy(proxy);
         }
+        sm.http_client = Some(client_builder.build().map_err(|e| {
+            KSMRError::SecretManagerCreationError(format!("Failed to build HTTP client: {}", e))
+        })?);
+
+        Ok(sm)
+    }
+
+    /// Returns true if TLS certificate verification should be skipped.
+    /// Single source of truth for converting `verify_ssl_certs` to the
+    /// reqwest `danger_accept_invalid_certs` polarity.
+    pub(crate) fn skip_ssl_verify(&self) -> bool {
+        !self.verify_ssl_certs
     }
 
     fn _init(&mut self) -> Result<Self, KSMRError> {
@@ -719,12 +750,14 @@ impl SecretsManager {
         Ok(proxy)
     }
 
+    /// `_verify_ssl_certificates` is accepted for API compatibility but ignored since KSM-926;
+    /// TLS verification is controlled by `verify_ssl_certs` set in `SecretsManager::new()`.
     pub fn post_function(
         self,
         url: String,
         transmission_key: TransmissionKey,
         encrypted_payload_and_signature: EncryptedPayload,
-        verify_ssl_certificates: bool,
+        _verify_ssl_certificates: bool,
     ) -> Result<KsmHttpResponse, KSMRError> {
         let authorization_signature_string = format!(
             "Signature {}",
@@ -749,19 +782,13 @@ impl SecretsManager {
         })?;
         let public_key_for_header = transmission_key.public_key_id.to_string();
 
-        // Build HTTP client with proxy support
-        let mut client_builder = reqwest::blocking::Client::builder()
-            .danger_accept_invalid_certs(verify_ssl_certificates);
-
-        // Apply proxy configuration if provided
-        if let Some(proxy_url) = &self.proxy_url {
-            let proxy = SecretsManager::build_proxy(proxy_url)?;
-            client_builder = client_builder.proxy(proxy);
-        }
-
-        let client = client_builder.build().map_err(|err| {
-            KSMRError::SecretManagerCreationError(format!("error creating HTTP client: {}", err))
-        })?;
+        let client = self
+            .http_client
+            .as_ref()
+            .ok_or_else(|| {
+                KSMRError::SecretManagerCreationError("HTTP client not initialized".to_string())
+            })?
+            .clone();
 
         let request_builder = client
             .post(url)
@@ -912,7 +939,7 @@ impl SecretsManager {
                 .unwrap();
             error!(
                 "Client version {} was not registered in the backend",
-                client_id.to_string()
+                client_id
             );
             if let Some(additional_info) = response_dict.get("additional_info") {
                 if let Some(info) = additional_info.as_str() {
@@ -1066,7 +1093,7 @@ impl SecretsManager {
             .map_err(|e| KSMRError::SecretManagerCreationError(e.to_string()))?;
 
             // Use custom post function if provided (for testing/mocking), otherwise use default HTTP client
-            keeper_response = if let Some(custom_post_fn) = self.custom_post_function {
+            keeper_response = if let Some(custom_post_fn) = &self.custom_post_function {
                 custom_post_fn(
                     url.clone(),
                     transmission_key.clone(),
@@ -1161,7 +1188,7 @@ impl SecretsManager {
                         for warning in warnings_array {
                             warn!(
                                 "Warning shown while fetching secrets: `{}`",
-                                warning.as_str().unwrap().to_string()
+                                warning.as_str().unwrap()
                             );
                         }
                     }
@@ -1194,10 +1221,12 @@ impl SecretsManager {
                 let record_result =
                     Record::new_from_json(record_hashmap_parsed, &_secret_key, None);
                 if let Ok(mut unwrapped_record) = record_result {
-                    if let Some(proxy) = &self.proxy_url {
-                        for file in &mut unwrapped_record.files {
+                    for file in &mut unwrapped_record.files {
+                        if let Some(proxy) = &self.proxy_url {
                             file.proxy_url = Some(proxy.clone());
                         }
+                        file.skip_ssl_verify = self.skip_ssl_verify();
+                        file.http_client = self.http_client.clone();
                     }
                     records_count += 1;
                     records.push(unwrapped_record);
@@ -1219,11 +1248,13 @@ impl SecretsManager {
                 if let Some(unwrapped_folder) = folder_result {
                     shared_folders_count += 1;
                     let mut folder_records = unwrapped_folder.records()?;
-                    if let Some(proxy) = &self.proxy_url {
-                        for record in &mut folder_records {
-                            for file in &mut record.files {
+                    for record in &mut folder_records {
+                        for file in &mut record.files {
+                            if let Some(proxy) = &self.proxy_url {
                                 file.proxy_url = Some(proxy.clone());
                             }
+                            file.skip_ssl_verify = self.skip_ssl_verify();
+                            file.http_client = self.http_client.clone();
                         }
                     }
                     records_count += folder_records.len();
@@ -1291,7 +1322,7 @@ impl SecretsManager {
         Ok(secrets_manager_response)
     }
 
-    fn fetch_and_decrypt_folders(mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    fn fetch_and_decrypt_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let payload = self
             .clone()
             .prepare_get_payload(self.config.clone(), None)?;
@@ -1462,7 +1493,7 @@ impl SecretsManager {
     ///
     /// * `HTTPError` - If the API request fails
     /// * `CryptoError` - If folder decryption fails
-    pub fn get_folders(self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    pub fn get_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let folders = self.fetch_and_decrypt_folders()?;
         Ok(folders)
     }
@@ -1946,7 +1977,7 @@ impl SecretsManager {
         folders: Vec<KeeperFolder>,
     ) -> Result<String, KSMRError> {
         let folders_copy = match folders.is_empty() {
-            true => self.clone().get_folders()?,
+            true => self.get_folders()?,
             false => folders,
         };
 
@@ -2040,7 +2071,7 @@ impl SecretsManager {
         folders: Vec<KeeperFolder>,
     ) -> Result<String, KSMRError> {
         let folders_copy = match folders.is_empty() {
-            true => self.clone().get_folders()?,
+            true => self.get_folders()?,
             false => folders,
         };
 
@@ -2602,15 +2633,13 @@ impl SecretsManager {
         form = form.part("file", multipart::Part::bytes(encrypted_file_data));
 
         // Send the POST request with the multipart form
-        let mut client_builder = reqwest::blocking::Client::builder()
-            .danger_accept_invalid_certs(!self.verify_ssl_certs);
-        if let Some(proxy_url) = &self.proxy_url {
-            let proxy = SecretsManager::build_proxy(proxy_url)?;
-            client_builder = client_builder.proxy(proxy);
-        }
-        let client = client_builder.build().map_err(|err| {
-            KSMRError::SecretManagerCreationError(format!("error creating HTTP client: {}", err))
-        })?;
+        let client = self
+            .http_client
+            .as_ref()
+            .ok_or_else(|| {
+                KSMRError::SecretManagerCreationError("HTTP client not initialized".to_string())
+            })?
+            .clone();
         let response = client
             .post(url)
             .multipart(form)
@@ -2788,7 +2817,7 @@ impl SecretsManager {
     ) -> Result<String, KSMRError> {
         let record_json_str = record_create_object.to_json()?;
 
-        let folders = self.clone().get_folders()?;
+        let folders = self.get_folders()?;
 
         let mut parent_uid = parent_folder_uid.clone();
         let mut sub_folder_uid: Option<String> = None;

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -195,12 +195,16 @@ pub struct SecretsManager {
     pub cache: KSMCache,
     pub proxy_url: Option<String>,
     custom_post_function: Option<CustomPostFunction>,
+    /// Pre-built HTTP client shared across all operations (API calls + file downloads).
+    /// Built once during init to avoid constructing reqwest::blocking::Client inside
+    /// tokio::spawn_blocking, which fails due to nested runtime conflicts.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    http_client: Option<reqwest::blocking::Client>,
 }
 
 impl Clone for SecretsManager {
     fn clone(&self) -> Self {
         SecretsManager {
-            // Clone each field of the struct
             token: self.token.clone(),
             hostname: self.hostname.clone(),
             verify_ssl_certs: self.verify_ssl_certs,
@@ -209,6 +213,7 @@ impl Clone for SecretsManager {
             cache: self.cache.clone(),
             proxy_url: self.proxy_url.clone(),
             custom_post_function: self.custom_post_function,
+            http_client: self.http_client.clone(),
         }
     }
 }
@@ -251,10 +256,11 @@ impl SecretsManager {
             hostname: String::new(),
             verify_ssl_certs: false,
             config: KvStoreType::None,
-            log_level: Level::Info, // Default to Info if not provided
-            cache: KSMCache::None,  // Default is no cache
+            log_level: Level::Info,
+            cache: KSMCache::None,
             proxy_url: client_options.proxy_url.clone(),
             custom_post_function: client_options.custom_post_function,
+            http_client: None, // built after SSL/proxy config is resolved
         };
 
         let mut config = client_options.config;
@@ -389,10 +395,22 @@ impl SecretsManager {
         }
         secrets_manager.config = config.clone();
 
-        match secrets_manager._init() {
-            Ok(secrets_manager) => Ok(secrets_manager),
-            Err(e) => Err(e),
+        let mut sm = secrets_manager._init()?;
+
+        // Build a shared HTTP client once, outside any async runtime.
+        // Reused for API calls and file downloads. Avoids constructing
+        // reqwest::blocking::Client inside tokio::spawn_blocking which fails
+        // due to nested runtime conflicts (reqwest#1017).
+        let mut client_builder =
+            reqwest::blocking::Client::builder().danger_accept_invalid_certs(sm.verify_ssl_certs);
+        if let Some(proxy_url) = &sm.proxy_url {
+            if let Ok(proxy) = SecretsManager::build_proxy(proxy_url) {
+                client_builder = client_builder.proxy(proxy);
+            }
         }
+        sm.http_client = client_builder.build().ok();
+
+        Ok(sm)
     }
 
     fn _init(&mut self) -> Result<Self, KSMRError> {
@@ -1194,10 +1212,12 @@ impl SecretsManager {
                 let record_result =
                     Record::new_from_json(record_hashmap_parsed, &_secret_key, None);
                 if let Ok(mut unwrapped_record) = record_result {
-                    if let Some(proxy) = &self.proxy_url {
-                        for file in &mut unwrapped_record.files {
+                    for file in &mut unwrapped_record.files {
+                        if let Some(proxy) = &self.proxy_url {
                             file.proxy_url = Some(proxy.clone());
                         }
+                        file.skip_ssl_verify = self.verify_ssl_certs;
+                        file.http_client = self.http_client.clone();
                     }
                     records_count += 1;
                     records.push(unwrapped_record);
@@ -1219,11 +1239,13 @@ impl SecretsManager {
                 if let Some(unwrapped_folder) = folder_result {
                     shared_folders_count += 1;
                     let mut folder_records = unwrapped_folder.records()?;
-                    if let Some(proxy) = &self.proxy_url {
-                        for record in &mut folder_records {
-                            for file in &mut record.files {
+                    for record in &mut folder_records {
+                        for file in &mut record.files {
+                            if let Some(proxy) = &self.proxy_url {
                                 file.proxy_url = Some(proxy.clone());
                             }
+                            file.skip_ssl_verify = self.verify_ssl_certs;
+                            file.http_client = self.http_client.clone();
                         }
                     }
                     records_count += folder_records.len();

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -1315,7 +1315,7 @@ impl SecretsManager {
         Ok(secrets_manager_response)
     }
 
-    fn fetch_and_decrypt_folders(mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    fn fetch_and_decrypt_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let payload = self
             .clone()
             .prepare_get_payload(self.config.clone(), None)?;
@@ -1486,7 +1486,7 @@ impl SecretsManager {
     ///
     /// * `HTTPError` - If the API request fails
     /// * `CryptoError` - If folder decryption fails
-    pub fn get_folders(self) -> Result<Vec<KeeperFolder>, KSMRError> {
+    pub fn get_folders(&mut self) -> Result<Vec<KeeperFolder>, KSMRError> {
         let folders = self.fetch_and_decrypt_folders()?;
         Ok(folders)
     }

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -408,7 +408,9 @@ impl SecretsManager {
                 client_builder = client_builder.proxy(proxy);
             }
         }
-        sm.http_client = client_builder.build().ok();
+        sm.http_client = Some(client_builder.build().map_err(|e| {
+            KSMRError::SecretManagerCreationError(format!("Failed to build HTTP client: {}", e))
+        })?);
 
         Ok(sm)
     }

--- a/sdk/rust/src/crypto.rs
+++ b/sdk/rust/src/crypto.rs
@@ -952,7 +952,7 @@ impl CryptoUtils {
     /// ```rust
     /// use keeper_secrets_manager_core::crypto::CryptoUtils;
     /// use std::error::Error;
-    /// use hex;
+    /// use data_encoding::HEXLOWER;
     ///
     /// fn main() -> Result<(), Box<dyn Error>> {
     ///     // 32-byte AES key (AES-256 requires a 32-byte key)
@@ -965,7 +965,7 @@ impl CryptoUtils {
     ///     let encrypted_data = CryptoUtils::encrypt_aes_gcm(data, key, None)?;
     ///
     ///     // Print the encrypted data in hex format for better readability
-    ///     println!("Encrypted data: {:?}", hex::encode(&encrypted_data));
+    ///     println!("Encrypted data: {:?}", HEXLOWER.encode(&encrypted_data));
     ///
     ///     Ok(())
     /// }
@@ -1041,7 +1041,7 @@ impl CryptoUtils {
     /// use keeper_secrets_manager_core::custom_error::KSMRError;
     /// use aes_gcm::{Aes256Gcm, Key, Nonce}; // Import the AES-GCM library
     /// use std::error::Error;
-    /// use hex;
+    /// use data_encoding::HEXLOWER;
     ///
     /// fn main() -> Result<(), KSMRError> {
     ///     // 32-byte AES key (AES-256 requires a 32-byte key)
@@ -1051,7 +1051,7 @@ impl CryptoUtils {
     ///     let nonce = b"unique nonce"; // Must be exactly 12 bytes
     ///
     ///     // Example ciphertext (encrypted using the same key and nonce)
-    ///     let ciphertext = hex::decode("c5d3db06f6c3d543663a94051a7a0d65")?; // Example encrypted data
+    ///     let ciphertext = HEXLOWER.decode(b"c5d3db06f6c3d543663a94051a7a0d65").expect("valid hex"); // Example encrypted data
     ///   
     ///     // Concatenate nonce and ciphertext
     ///     let mut encrypted_data = Vec::new();
@@ -1340,7 +1340,7 @@ impl CryptoUtils {
     /// let server_public_key = "04d88c6fa31ea40af14c137b8e62f1151f1cc1e5688cad37b7f2e7";
     ///
     /// // Convert the public key from hex string to bytes
-    /// let server_public_key_bytes = hex::decode(server_public_key).expect("Invalid hex key");
+    /// let server_public_key_bytes = data_encoding::HEXLOWER.decode(server_public_key.as_bytes()).expect("Invalid hex key");
     ///
     /// // Optional IDZ
     /// let idz = Some("optional_identifier".as_bytes());

--- a/sdk/rust/src/custom_error.rs
+++ b/sdk/rust/src/custom_error.rs
@@ -10,7 +10,6 @@
 // Contact: sm@keepersecurity.com
 //
 
-use hex::FromHexError;
 use std::error::Error;
 use std::fmt::{self};
 
@@ -206,12 +205,6 @@ impl From<serde_json::Error> for KSMRError {
         } else {
             KSMRError::SerializationError(error.to_string())
         }
-    }
-}
-
-impl From<FromHexError> for KSMRError {
-    fn from(error: FromHexError) -> Self {
-        KSMRError::CryptoError(format!("Hex decode error: {}", error))
     }
 }
 

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -12,6 +12,7 @@
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::DateTime;
+use data_encoding::HEXLOWER;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -116,8 +117,7 @@ impl Record {
                     match created_keeper_file {
                         Ok(file) => files.push(file),
                         Err(e) => {
-                            let msg = format!("Error loading file: {}", e);
-                            eprintln!("{}", msg);
+                            error!("Error loading file: {}", e);
                         }
                     }
                 }
@@ -723,8 +723,7 @@ impl Record {
                     match created_keeper_file {
                         Ok(file) => _files.push(file),
                         Err(e) => {
-                            let msg = format!("Error loading file: {}", e);
-                            eprintln!("{}", msg);
+                            error!("Error loading file: {}", e);
                         }
                     }
                 }
@@ -1050,6 +1049,13 @@ pub struct KeeperFile {
     pub url: Option<String>,           // Download URL (v16.7.0+)
     pub thumbnail_url: Option<String>, // Thumbnail URL (v16.7.0+)
     pub proxy_url: Option<String>,     // Proxy URL for HTTP requests
+    pub(crate) skip_ssl_verify: bool, // Skip SSL cert verification (for corporate proxies like Zscaler)
+    /// Pre-built HTTP client for file downloads. Avoids constructing a new
+    /// reqwest::blocking::Client inside tokio::spawn_blocking, which fails
+    /// because reqwest's blocking module creates an internal tokio runtime.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    #[serde(skip)]
+    pub(crate) http_client: Option<reqwest::blocking::Client>,
 
     f: HashMap<String, Value>,
     record_key_bytes: Vec<u8>,
@@ -1071,9 +1077,37 @@ impl KeeperFile {
             url: self.url.clone(),
             thumbnail_url: self.thumbnail_url.clone(),
             proxy_url: self.proxy_url.clone(),
+            skip_ssl_verify: self.skip_ssl_verify,
+            http_client: self.http_client.clone(),
             f: self.f.clone(),
             record_key_bytes: self.record_key_bytes.clone(),
         }
+    }
+
+    /// Returns the pre-built HTTP client if available, or builds a fallback one.
+    /// The pre-built client is propagated from SecretsManager to avoid constructing
+    /// reqwest::blocking::Client inside tokio::spawn_blocking (reqwest#1017).
+    fn resolve_http_client(&self) -> Result<reqwest::blocking::Client, KSMRError> {
+        if let Some(client) = &self.http_client {
+            return Ok(client.clone());
+        }
+        let mut client_builder =
+            reqwest::blocking::Client::builder().danger_accept_invalid_certs(self.skip_ssl_verify);
+        if let Some(ref proxy_url) = self.proxy_url {
+            let url = reqwest::Url::parse(proxy_url).map_err(|e| {
+                KSMRError::FileError(format!("Invalid proxy URL '{}': {}", proxy_url, e))
+            })?;
+            let mut proxy = reqwest::Proxy::all(proxy_url)
+                .map_err(|e| KSMRError::FileError(format!("Failed to configure proxy: {}", e)))?;
+            if !url.username().is_empty() {
+                let password = url.password().unwrap_or("");
+                proxy = proxy.basic_auth(url.username(), password);
+            }
+            client_builder = client_builder.proxy(proxy);
+        }
+        client_builder
+            .build()
+            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))
     }
 
     /// Decrypts the file key using the record key bytes.
@@ -1151,16 +1185,7 @@ impl KeeperFile {
             .get_url()
             .map_err(|_| KSMRError::FileError("File URL is invalid".to_string()))?;
 
-        // Fetch the file data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
-            }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+        let http_client = self.resolve_http_client()?;
         let mut response = http_client
             .get(&file_url)
             .send()
@@ -1236,16 +1261,7 @@ impl KeeperFile {
         // Decrypt the file key
         let file_key = self.decrypt_file_key()?;
 
-        // Fetch the thumbnail data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
-            }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+        let http_client = self.resolve_http_client()?;
         let mut response = http_client
             .get(&thumbnail_url)
             .send()
@@ -1300,6 +1316,8 @@ impl KeeperFile {
             url,
             thumbnail_url,
             proxy_url: None,
+            skip_ssl_verify: false,
+            http_client: None,
             f: file_dict.clone(),
             record_key_bytes,
         };
@@ -1449,7 +1467,7 @@ impl KeeperFolder {
         let mut clone: HashMap<String, Value> = HashMap::new();
         clone.insert(
             "folderKey".to_string(),
-            Value::String(hex::encode(self.folder_key.clone())),
+            Value::String(HEXLOWER.encode(&self.folder_key)),
         );
         clone.insert(
             ("folderUid").to_string(),
@@ -1846,6 +1864,8 @@ mod tests {
             url: None,
             thumbnail_url: None,
             proxy_url,
+            skip_ssl_verify: false,
+            http_client: None,
             f: HashMap::new(),
             record_key_bytes: vec![],
         }
@@ -1889,5 +1909,29 @@ mod tests {
         let file_without_proxy = make_test_file(None);
         let copied_none = file_without_proxy.deep_copy();
         assert!(copied_none.proxy_url.is_none());
+    }
+
+    /// Regression test for KSM-933: verify_ssl_certs (positive-sense) and
+    /// skip_ssl_verify (negative-sense) have opposite conventions. Propagation
+    /// from SecretsManager to KeeperFile must negate — not copy directly.
+    #[test]
+    fn test_skip_ssl_verify_polarity_invariant() {
+        // Strict mode: verify_ssl_certs=true → skip_ssl_verify must be false
+        let verify_ssl_certs = true;
+        let mut file = make_test_file(None);
+        file.skip_ssl_verify = !verify_ssl_certs;
+        assert!(
+            !file.skip_ssl_verify,
+            "strict mode: skip_ssl_verify must be false"
+        );
+
+        // Permissive mode: verify_ssl_certs=false → skip_ssl_verify must be true
+        let verify_ssl_certs = false;
+        let mut file = make_test_file(None);
+        file.skip_ssl_verify = !verify_ssl_certs;
+        assert!(
+            file.skip_ssl_verify,
+            "permissive mode: skip_ssl_verify must be true"
+        );
     }
 }

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -1050,6 +1050,13 @@ pub struct KeeperFile {
     pub url: Option<String>,           // Download URL (v16.7.0+)
     pub thumbnail_url: Option<String>, // Thumbnail URL (v16.7.0+)
     pub proxy_url: Option<String>,     // Proxy URL for HTTP requests
+    pub skip_ssl_verify: bool, // Skip SSL cert verification (for corporate proxies like Zscaler)
+    /// Pre-built HTTP client for file downloads. Avoids constructing a new
+    /// reqwest::blocking::Client inside tokio::spawn_blocking, which fails
+    /// because reqwest's blocking module creates an internal tokio runtime.
+    /// See: https://github.com/seanmonstar/reqwest/issues/1017
+    #[serde(skip)]
+    pub http_client: Option<reqwest::blocking::Client>,
 
     f: HashMap<String, Value>,
     record_key_bytes: Vec<u8>,
@@ -1071,6 +1078,8 @@ impl KeeperFile {
             url: self.url.clone(),
             thumbnail_url: self.thumbnail_url.clone(),
             proxy_url: self.proxy_url.clone(),
+            skip_ssl_verify: self.skip_ssl_verify,
+            http_client: self.http_client.clone(),
             f: self.f.clone(),
             record_key_bytes: self.record_key_bytes.clone(),
         }
@@ -1151,16 +1160,24 @@ impl KeeperFile {
             .get_url()
             .map_err(|_| KSMRError::FileError("File URL is invalid".to_string()))?;
 
-        // Fetch the file data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
+        // Use pre-built HTTP client if available. Building a new reqwest::blocking::Client
+        // inside tokio::spawn_blocking fails because reqwest's blocking module creates an
+        // internal tokio runtime which conflicts with the existing one.
+        // See: https://github.com/seanmonstar/reqwest/issues/1017
+        let http_client = if let Some(client) = &self.http_client {
+            client.clone()
+        } else {
+            let mut client_builder = reqwest::blocking::Client::builder()
+                .danger_accept_invalid_certs(self.skip_ssl_verify);
+            if let Some(ref proxy_url) = self.proxy_url {
+                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                    client_builder = client_builder.proxy(proxy);
+                }
             }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+            client_builder
+                .build()
+                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
+        };
         let mut response = http_client
             .get(&file_url)
             .send()
@@ -1236,16 +1253,21 @@ impl KeeperFile {
         // Decrypt the file key
         let file_key = self.decrypt_file_key()?;
 
-        // Fetch the thumbnail data from the URL
-        let mut client_builder = reqwest::blocking::Client::builder();
-        if let Some(ref proxy_url) = self.proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                client_builder = client_builder.proxy(proxy);
+        // Fetch the thumbnail data from the URL (reuse pre-built client if available)
+        let http_client = if let Some(client) = &self.http_client {
+            client.clone()
+        } else {
+            let mut client_builder = reqwest::blocking::Client::builder()
+                .danger_accept_invalid_certs(self.skip_ssl_verify);
+            if let Some(ref proxy_url) = self.proxy_url {
+                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                    client_builder = client_builder.proxy(proxy);
+                }
             }
-        }
-        let http_client = client_builder
-            .build()
-            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?;
+            client_builder
+                .build()
+                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
+        };
         let mut response = http_client
             .get(&thumbnail_url)
             .send()
@@ -1300,6 +1322,8 @@ impl KeeperFile {
             url,
             thumbnail_url,
             proxy_url: None,
+            skip_ssl_verify: false,
+            http_client: None,
             f: file_dict.clone(),
             record_key_bytes,
         };
@@ -1846,6 +1870,8 @@ mod tests {
             url: None,
             thumbnail_url: None,
             proxy_url,
+            skip_ssl_verify: false,
+            http_client: None,
             f: HashMap::new(),
             record_key_bytes: vec![],
         }

--- a/sdk/rust/src/dto/dtos.rs
+++ b/sdk/rust/src/dto/dtos.rs
@@ -1050,13 +1050,13 @@ pub struct KeeperFile {
     pub url: Option<String>,           // Download URL (v16.7.0+)
     pub thumbnail_url: Option<String>, // Thumbnail URL (v16.7.0+)
     pub proxy_url: Option<String>,     // Proxy URL for HTTP requests
-    pub skip_ssl_verify: bool, // Skip SSL cert verification (for corporate proxies like Zscaler)
+    pub(crate) skip_ssl_verify: bool, // Skip SSL cert verification (for corporate proxies like Zscaler)
     /// Pre-built HTTP client for file downloads. Avoids constructing a new
     /// reqwest::blocking::Client inside tokio::spawn_blocking, which fails
     /// because reqwest's blocking module creates an internal tokio runtime.
     /// See: https://github.com/seanmonstar/reqwest/issues/1017
     #[serde(skip)]
-    pub http_client: Option<reqwest::blocking::Client>,
+    pub(crate) http_client: Option<reqwest::blocking::Client>,
 
     f: HashMap<String, Value>,
     record_key_bytes: Vec<u8>,
@@ -1083,6 +1083,25 @@ impl KeeperFile {
             f: self.f.clone(),
             record_key_bytes: self.record_key_bytes.clone(),
         }
+    }
+
+    /// Returns the pre-built HTTP client if available, or builds a fallback one.
+    /// The pre-built client is propagated from SecretsManager to avoid constructing
+    /// reqwest::blocking::Client inside tokio::spawn_blocking (reqwest#1017).
+    fn resolve_http_client(&self) -> Result<reqwest::blocking::Client, KSMRError> {
+        if let Some(client) = &self.http_client {
+            return Ok(client.clone());
+        }
+        let mut client_builder = reqwest::blocking::Client::builder()
+            .danger_accept_invalid_certs(self.skip_ssl_verify);
+        if let Some(ref proxy_url) = self.proxy_url {
+            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                client_builder = client_builder.proxy(proxy);
+            }
+        }
+        client_builder
+            .build()
+            .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))
     }
 
     /// Decrypts the file key using the record key bytes.
@@ -1160,24 +1179,7 @@ impl KeeperFile {
             .get_url()
             .map_err(|_| KSMRError::FileError("File URL is invalid".to_string()))?;
 
-        // Use pre-built HTTP client if available. Building a new reqwest::blocking::Client
-        // inside tokio::spawn_blocking fails because reqwest's blocking module creates an
-        // internal tokio runtime which conflicts with the existing one.
-        // See: https://github.com/seanmonstar/reqwest/issues/1017
-        let http_client = if let Some(client) = &self.http_client {
-            client.clone()
-        } else {
-            let mut client_builder = reqwest::blocking::Client::builder()
-                .danger_accept_invalid_certs(self.skip_ssl_verify);
-            if let Some(ref proxy_url) = self.proxy_url {
-                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                    client_builder = client_builder.proxy(proxy);
-                }
-            }
-            client_builder
-                .build()
-                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
-        };
+        let http_client = self.resolve_http_client()?;
         let mut response = http_client
             .get(&file_url)
             .send()
@@ -1253,21 +1255,7 @@ impl KeeperFile {
         // Decrypt the file key
         let file_key = self.decrypt_file_key()?;
 
-        // Fetch the thumbnail data from the URL (reuse pre-built client if available)
-        let http_client = if let Some(client) = &self.http_client {
-            client.clone()
-        } else {
-            let mut client_builder = reqwest::blocking::Client::builder()
-                .danger_accept_invalid_certs(self.skip_ssl_verify);
-            if let Some(ref proxy_url) = self.proxy_url {
-                if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
-                    client_builder = client_builder.proxy(proxy);
-                }
-            }
-            client_builder
-                .build()
-                .map_err(|e| KSMRError::FileError(format!("Failed to build HTTP client: {}", e)))?
-        };
+        let http_client = self.resolve_http_client()?;
         let mut response = http_client
             .get(&thumbnail_url)
             .send()

--- a/sdk/rust/src/dto/field_structs.rs
+++ b/sdk/rust/src/dto/field_structs.rs
@@ -2416,7 +2416,11 @@ impl RecordField {
         required: bool,
         privacy_screen: bool,
     ) -> KeeperField {
-        let arrayed_value = Value::Array(vec![value]);
+        let arrayed_value = match value {
+            Value::Array(_) => value,
+            Value::Null => Value::Array(vec![]),
+            other => Value::Array(vec![other]),
+        };
 
         match label {
             Some(val) => KeeperField {
@@ -2454,5 +2458,56 @@ impl RecordField {
             required,
             privacy_screen,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn field_value(v: Value) -> Value {
+        let f = RecordField::new("text".to_string(), v, None, false, false);
+        f.value
+    }
+
+    // KSM-936: scalar string must be wrapped in a single-element array
+    #[test]
+    fn record_field_wraps_string() {
+        let v = field_value(Value::String("hello".to_string()));
+        assert_eq!(v, json!(["hello"]));
+    }
+
+    // KSM-936: scalar number must be wrapped in a single-element array
+    #[test]
+    fn record_field_wraps_number() {
+        let v = field_value(json!(42));
+        assert_eq!(v, json!([42]));
+    }
+
+    // KSM-936: object must be wrapped in a single-element array
+    #[test]
+    fn record_field_wraps_object() {
+        let v = field_value(json!({"type": "Mobile", "number": "555-0100"}));
+        assert_eq!(v, json!([{"type": "Mobile", "number": "555-0100"}]));
+    }
+
+    // KSM-936: array must pass through unchanged (the bug: it was double-wrapped)
+    #[test]
+    fn record_field_does_not_double_wrap_array() {
+        let input = json!([
+            {"region": "US", "number": "555-0100", "type": "Mobile"},
+            {"region": "US", "number": "555-0200", "type": "Work"}
+        ]);
+        let v = field_value(input.clone());
+        assert_eq!(v, input);
+        assert_eq!(v.as_array().unwrap().len(), 2);
+    }
+
+    // KSM-936: null must become an empty array, not [null]
+    #[test]
+    fn record_field_null_becomes_empty_array() {
+        let v = field_value(Value::Null);
+        assert_eq!(v, json!([]));
     }
 }

--- a/sdk/rust/src/tests/mod.rs
+++ b/sdk/rust/src/tests/mod.rs
@@ -13,5 +13,6 @@
 pub mod config_keys_tests;
 pub mod crypto_tests;
 pub mod keeper_globals_tests;
+pub mod ssl_config_tests;
 pub mod storage_tests;
 pub mod utils_tests;

--- a/sdk/rust/src/tests/ssl_config_tests.rs
+++ b/sdk/rust/src/tests/ssl_config_tests.rs
@@ -1,0 +1,144 @@
+// -*- coding: utf-8 -*-
+//  _  __
+// | |/ /___ ___ _ __  ___ _ _ (R)
+// | ' </ -_) -_) '_ \/ -_) '_|
+// |_|\_\___\___| .__/\___|_|
+//              |_|
+//
+// Keeper Secrets Manager
+// Copyright 2024 Keeper Security Inc.
+// Contact: sm@keepersecurity.com
+//
+
+// Regression tests for KSM-926: verify_ssl_certs semantic consistency.
+//
+// Before KSM-926, two assignment paths set verify_ssl_certs with opposite
+// conventions: insecure_skip_verify=true produced a permissive API client
+// but a strict upload client; KSM_SKIP_VERIFY=true did the inverse.
+// These tests assert both input paths converge on the correct skip_ssl_verify()
+// result and that http_client is always initialized after new().
+
+#[cfg(test)]
+mod ssl_config_tests {
+    use crate::config_keys::ConfigKeys;
+    use crate::core::{ClientOptions, SecretsManager};
+    use crate::crypto::CryptoUtils;
+    use crate::custom_error::KSMRError;
+    use crate::dto::{EncryptedPayload, KsmHttpResponse, TransmissionKey};
+    use crate::enums::KvStoreType;
+    use crate::storage::{InMemoryKeyValueStorage, KeyValueStorage};
+    use serial_test::serial;
+
+    fn create_test_storage() -> KvStoreType {
+        let storage = InMemoryKeyValueStorage::new(None).expect("storage");
+        let mut kv = KvStoreType::InMemory(storage);
+        let private_key_der = CryptoUtils::generate_private_key_der().expect("key");
+        let private_key_b64 = crate::utils::bytes_to_base64(&private_key_der);
+        let private_key = CryptoUtils::generate_private_key_ecc().expect("ecc key");
+        let public_key_b64 =
+            crate::utils::bytes_to_base64(&CryptoUtils::public_key_ecc(&private_key));
+        kv.set(ConfigKeys::KeyClientId, "TEST_CLIENT_ID".to_string())
+            .unwrap();
+        kv.set(
+            ConfigKeys::KeyAppKey,
+            "dGVzdF9hcHBfa2V5X2Jhc2U2NF9lbmNvZGVkX3ZhbHVlAAAAAAAAAAAA".to_string(),
+        )
+        .unwrap();
+        kv.set(ConfigKeys::KeyServerPublicKeyId, "10".to_string())
+            .unwrap();
+        kv.set(
+            ConfigKeys::KeyHostname,
+            "fake.keepersecurity.com".to_string(),
+        )
+        .unwrap();
+        kv.set(ConfigKeys::KeyPrivateKey, private_key_b64).unwrap();
+        kv.set(ConfigKeys::KeyOwnerPublicKey, public_key_b64)
+            .unwrap();
+        kv
+    }
+
+    fn noop_post(
+        _url: String,
+        _tk: TransmissionKey,
+        _payload: EncryptedPayload,
+    ) -> Result<KsmHttpResponse, KSMRError> {
+        Ok(KsmHttpResponse {
+            status_code: 200,
+            data: vec![],
+            http_response: None,
+        })
+    }
+
+    fn make_sm(insecure_skip_verify: bool) -> SecretsManager {
+        let mut options = ClientOptions::new_client_options(create_test_storage());
+        options.insecure_skip_verify = Some(insecure_skip_verify);
+        options.set_custom_post_function(noop_post);
+        SecretsManager::new(options).expect("SecretsManager::new")
+    }
+
+    /// insecure_skip_verify=false → verify_ssl_certs=true → skip_ssl_verify()=false (strict)
+    #[test]
+    #[serial]
+    fn test_verify_mode_strict_when_insecure_false() {
+        let sm = make_sm(false);
+        assert!(
+            sm.verify_ssl_certs,
+            "verify_ssl_certs should be true when insecure_skip_verify=false"
+        );
+        assert!(
+            !sm.skip_ssl_verify(),
+            "skip_ssl_verify() should be false (strict)"
+        );
+    }
+
+    /// insecure_skip_verify=true → verify_ssl_certs=false → skip_ssl_verify()=true (permissive)
+    #[test]
+    #[serial]
+    fn test_verify_mode_permissive_when_insecure_true() {
+        let sm = make_sm(true);
+        assert!(
+            !sm.verify_ssl_certs,
+            "verify_ssl_certs should be false when insecure_skip_verify=true"
+        );
+        assert!(
+            sm.skip_ssl_verify(),
+            "skip_ssl_verify() should be true (permissive)"
+        );
+    }
+
+    /// KSM_SKIP_VERIFY=true env var → same result as insecure_skip_verify=true (permissive)
+    #[test]
+    #[serial]
+    fn test_env_skip_verify_true_is_permissive() {
+        std::env::set_var("KSM_SKIP_VERIFY", "true");
+        let sm = make_sm(false); // constructor says verify; env var overrides
+        std::env::remove_var("KSM_SKIP_VERIFY");
+
+        assert!(
+            !sm.verify_ssl_certs,
+            "KSM_SKIP_VERIFY=true should set verify_ssl_certs=false"
+        );
+        assert!(
+            sm.skip_ssl_verify(),
+            "skip_ssl_verify() should be true (permissive) when KSM_SKIP_VERIFY=true"
+        );
+    }
+
+    /// KSM_SKIP_VERIFY=false env var → strict (same as default)
+    #[test]
+    #[serial]
+    fn test_env_skip_verify_false_is_strict() {
+        std::env::set_var("KSM_SKIP_VERIFY", "false");
+        let sm = make_sm(false);
+        std::env::remove_var("KSM_SKIP_VERIFY");
+
+        assert!(
+            sm.verify_ssl_certs,
+            "KSM_SKIP_VERIFY=false should leave verify_ssl_certs=true"
+        );
+        assert!(
+            !sm.skip_ssl_verify(),
+            "skip_ssl_verify() should be false (strict) when KSM_SKIP_VERIFY=false"
+        );
+    }
+}

--- a/sdk/rust/tests/caching_tests.rs
+++ b/sdk/rust/tests/caching_tests.rs
@@ -387,4 +387,94 @@ mod caching_tests {
 
         env::remove_var("KSM_CACHE_DIR");
     }
+
+    /// Test: Caching module is accessible and round-trips data through env-driven path
+    #[test]
+    #[serial]
+    fn test_caching_module_exists() {
+        let (cache_dir, test_dir) = setup_test_cache();
+        env::set_var("KSM_CACHE_DIR", &cache_dir);
+
+        let cache_path = get_cache_file_path();
+        assert!(cache_path.to_str().unwrap().contains("ksm_cache.bin"));
+
+        let _ = clear_cache();
+        assert!(!cache_exists(), "Cache should not exist after clearing");
+
+        let test_data = b"test cache data for validation";
+        save_cache(test_data).expect("Failed to save cache data");
+        assert!(
+            cache_exists(),
+            "Cache should exist after saving. Path: {:?}",
+            cache_path
+        );
+
+        let loaded = get_cached_data().expect("Failed to retrieve cached data");
+        assert_eq!(loaded, test_data, "Cached data should match original");
+
+        clear_cache().expect("Failed to clear cache");
+        cleanup_test_cache(test_dir);
+        env::remove_var("KSM_CACHE_DIR");
+    }
+
+    /// Regression test for KSM-931: make_caching_post_function must not panic
+    /// when called from inside tokio::task::spawn_blocking.
+    ///
+    /// Without the fix (bare caching_post_function calling Client::builder().build()
+    /// per call), this scenario panics with:
+    ///   "Cannot drop a runtime in a context where blocking is not allowed"
+    ///
+    /// With the fix (factory captures a pre-built Client), it returns a clean
+    /// network error instead — no panic. Test fails to compile before the fix
+    /// because make_caching_post_function does not exist yet.
+    #[test]
+    fn test_make_caching_post_function_runs_under_spawn_blocking() {
+        use keeper_secrets_manager_core::caching::make_caching_post_function;
+        use keeper_secrets_manager_core::dto::{EncryptedPayload, TransmissionKey};
+        use p256::ecdsa::{signature::Signer, SigningKey};
+
+        // Generate a deterministic signature for the EncryptedPayload constructor.
+        // The server is never reached (port 1 is unreachable) so cryptographic
+        // validity is irrelevant; we just need a structurally valid value.
+        let signing_key = SigningKey::from_slice(&[42u8; 32]).expect("valid test scalar");
+        let raw_sig: p256::ecdsa::Signature = signing_key.sign(b"ksm-931-regression-test");
+        let der_sig: ecdsa::der::Signature<p256::NistP256> = raw_sig.into();
+
+        let tk = TransmissionKey::new("10".to_string(), vec![0u8; 32], vec![0u8; 32]);
+        let ep = EncryptedPayload::new(vec![0u8; 16], der_sig);
+
+        // Build the client OUTSIDE any async context — the correct usage pattern.
+        let client = reqwest::blocking::Client::builder()
+            .build()
+            .expect("build client outside runtime");
+
+        let post_fn = make_caching_post_function(client);
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        let result = rt.block_on(async {
+            tokio::task::spawn_blocking(move || {
+                // Port 1 is unreachable — we expect a network error, not a panic.
+                post_fn("http://127.0.0.1:1/test".to_string(), tk, ep)
+            })
+            .await
+        });
+
+        // spawn_blocking must not have panicked — if it did, await returns
+        // Err(JoinError::Panicked).
+        assert!(
+            result.is_ok(),
+            "spawn_blocking panicked (nested-runtime bug still present): {:?}",
+            result
+        );
+        // The inner call should return a network error (connection refused), not Ok.
+        let inner = result.unwrap();
+        assert!(
+            inner.is_err(),
+            "expected network error against 127.0.0.1:1, got Ok"
+        );
+    }
 }

--- a/sdk/rust/tests/empty_config_test.rs
+++ b/sdk/rust/tests/empty_config_test.rs
@@ -35,6 +35,7 @@ mod empty_config_tests {
             Level::Error,
             None,
             None,
+            None,
             KSMCache::None,
         );
 
@@ -70,6 +71,7 @@ mod empty_config_tests {
                     Level::Error,
                     None,
                     None,
+                    None,
                     KSMCache::None,
                 );
 
@@ -96,6 +98,7 @@ mod empty_config_tests {
             String::new(),
             config,
             Level::Error,
+            None,
             None,
             None,
             KSMCache::None,

--- a/sdk/rust/tests/feature_validation_tests.rs
+++ b/sdk/rust/tests/feature_validation_tests.rs
@@ -725,4 +725,41 @@ mod feature_validation_tests {
         // This test passing means all new features are properly exported and compile
         assert!(true);
     }
+
+    /// Regression test for KSM-812: get_folders() must take &mut self, not self.
+    ///
+    /// Before the fix, get_folders() consumed the SecretsManager, so any subsequent
+    /// call on the same instance would fail to compile. This test verifies the
+    /// instance is still usable after calling get_folders().
+    #[test]
+    fn test_get_folders_does_not_consume_secrets_manager() {
+        fn mock_empty_folders(
+            _url: String,
+            transmission_key: TransmissionKey,
+            _encrypted_payload: EncryptedPayload,
+        ) -> Result<KsmHttpResponse, KSMRError> {
+            let response = json!({"folders": [], "records": [], "expiresOn": 0, "warnings": []});
+            let response_bytes = response.to_string().into_bytes();
+            let encrypted =
+                CryptoUtils::encrypt_aes_gcm(&response_bytes, &transmission_key.key, None)?;
+            Ok(KsmHttpResponse {
+                status_code: 200,
+                data: encrypted,
+                http_response: None,
+            })
+        }
+
+        let storage = create_test_storage().expect("Failed to create storage");
+        let mut client_options = ClientOptions::new_client_options(storage);
+        client_options.set_custom_post_function(mock_empty_folders);
+        let mut sm = SecretsManager::new(client_options).expect("Failed to create SecretsManager");
+
+        // First call
+        let first = sm.get_folders();
+        // Second call on the same instance — would not compile if get_folders() took self
+        let second = sm.get_folders();
+
+        assert!(first.is_ok(), "First get_folders() call failed: {:?}", first);
+        assert!(second.is_ok(), "Second get_folders() call failed: {:?}", second);
+    }
 }

--- a/sdk/rust/tests/feature_validation_tests.rs
+++ b/sdk/rust/tests/feature_validation_tests.rs
@@ -304,70 +304,6 @@ mod feature_validation_tests {
     }
 
     #[test]
-    fn test_caching_module_exists() {
-        // Verify caching module is accessible
-        use keeper_secrets_manager_core::caching;
-        use std::env;
-
-        // Use unique temp subdirectory to avoid conflicts with parallel tests
-        let unique_dir = env::temp_dir().join(format!(
-            "ksm_test_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&unique_dir).expect("Failed to create test directory");
-        let temp_dir_str = unique_dir.to_str().unwrap();
-        env::set_var("KSM_CACHE_DIR", temp_dir_str);
-
-        // Test cache operations
-        let cache_path = caching::get_cache_file_path();
-        assert!(cache_path.to_str().unwrap().contains("ksm_cache.bin"));
-
-        // Clear any existing cache
-        let _ = caching::clear_cache();
-        assert!(
-            !caching::cache_exists(),
-            "Cache should not exist after clearing"
-        );
-
-        // Save test data
-        let test_data = b"test cache data for validation";
-        caching::save_cache(test_data).expect("Failed to save cache data");
-
-        // Verify cache exists (with retry for CI filesystem delays)
-        // Use exponential backoff: 10ms, 20ms, 40ms, 80ms, 100ms (capped), 100ms...
-        // Total timeout: ~650ms to handle slow CI filesystem sync
-        let mut cache_found = false;
-        let mut backoff_ms = 10u64;
-        for attempt in 0..10 {
-            if caching::cache_exists() {
-                cache_found = true;
-                break;
-            }
-            if attempt < 9 {
-                std::thread::sleep(std::time::Duration::from_millis(backoff_ms));
-                backoff_ms = (backoff_ms * 2).min(100); // Exponential backoff, capped at 100ms
-            }
-        }
-        assert!(
-            cache_found,
-            "Cache should exist after saving (checked 10 times with exponential backoff up to ~650ms). Path: {:?}",
-            cache_path
-        );
-
-        // Load and verify
-        let loaded = caching::get_cached_data().expect("Failed to retrieve cached data");
-        assert_eq!(loaded, test_data, "Cached data should match original");
-
-        // Clean up
-        caching::clear_cache().expect("Failed to clear cache");
-        env::remove_var("KSM_CACHE_DIR");
-        std::fs::remove_dir_all(&unique_dir).ok(); // Clean up test directory
-    }
-
-    #[test]
     fn test_caching_post_function_fallback() {
         use keeper_secrets_manager_core::caching;
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -724,5 +660,50 @@ mod feature_validation_tests {
 
         // This test passing means all new features are properly exported and compile
         assert!(true);
+    }
+
+    /// Regression test for KSM-812: get_folders() must take &mut self, not self.
+    ///
+    /// Before the fix, get_folders() consumed the SecretsManager, so any subsequent
+    /// call on the same instance would fail to compile. This test verifies the
+    /// instance is still usable after calling get_folders().
+    #[test]
+    fn test_get_folders_does_not_consume_secrets_manager() {
+        fn mock_empty_folders(
+            _url: String,
+            transmission_key: TransmissionKey,
+            _encrypted_payload: EncryptedPayload,
+        ) -> Result<KsmHttpResponse, KSMRError> {
+            let response = json!({"folders": [], "records": [], "expiresOn": 0, "warnings": []});
+            let response_bytes = response.to_string().into_bytes();
+            let encrypted =
+                CryptoUtils::encrypt_aes_gcm(&response_bytes, &transmission_key.key, None)?;
+            Ok(KsmHttpResponse {
+                status_code: 200,
+                data: encrypted,
+                http_response: None,
+            })
+        }
+
+        let storage = create_test_storage().expect("Failed to create storage");
+        let mut client_options = ClientOptions::new_client_options(storage);
+        client_options.set_custom_post_function(mock_empty_folders);
+        let mut sm = SecretsManager::new(client_options).expect("Failed to create SecretsManager");
+
+        // First call
+        let first = sm.get_folders();
+        // Second call on the same instance — would not compile if get_folders() took self
+        let second = sm.get_folders();
+
+        assert!(
+            first.is_ok(),
+            "First get_folders() call failed: {:?}",
+            first
+        );
+        assert!(
+            second.is_ok(),
+            "Second get_folders() call failed: {:?}",
+            second
+        );
     }
 }


### PR DESCRIPTION
## Summary

Rust SDK v17.2.0 — bug fix release.

## Bug Fixes

- **KSM-886**: Fixed `get_file_data()` and `get_thumbnail_data()` failing with "builder error" when called from inside `tokio::spawn_blocking`. Root cause: `reqwest::blocking::Client` creates an internal tokio runtime on construction; building it inside an existing async context (e.g. KeeperDB Proxy in Docker) panics. Fix: build a single shared client in `SecretsManager::new()` and propagate it to `KeeperFile` objects. ([#991](https://github.com/Keeper-Security/secrets-manager/pull/991))

- **KSM-812**: Fixed `get_folders()` consuming the `SecretsManager` instance (`self`) instead of borrowing it (`&mut self`), forcing unnecessary clones. Now consistent with all other methods. Closes [#950](https://github.com/Keeper-Security/secrets-manager/issues/950). ([#992](https://github.com/Keeper-Security/secrets-manager/pull/992))

- **KSM-925**: Removed three `self.clone().get_folders()` workarounds left over from the KSM-812 signature fix. Each clone triggered an unnecessary extra network round-trip; all three callsites now call `self.get_folders()` directly. ([#1002](https://github.com/Keeper-Security/secrets-manager/pull/1002))

- **KSM-926**: `post_function` (every API call) and `upload_file_function` (multipart file upload) each built a new `reqwest::blocking::Client` per call, leaving the same nested-runtime panic risk under `tokio::spawn_blocking` that KSM-886 fixed for file downloads. Both callsites now reuse the shared client built in `SecretsManager::new()`. Also resolved a long-standing semantic inversion of `verify_ssl_certs` — the field was assigned and read with opposite conventions across two code paths. The field now uniformly means "do verify"; all `danger_accept_invalid_certs` calls route through a new `skip_ssl_verify()` accessor. Net behavior: `insecure_skip_verify=true` and `KSM_SKIP_VERIFY=true` now both correctly relax TLS on every HTTP path; the default is strict on every HTTP path. ([#1003](https://github.com/Keeper-Security/secrets-manager/pull/1003))

- **KSM-931**: `caching_post_function` built a new `reqwest::blocking::Client` on every call, leaving the same nested-runtime panic under `tokio::spawn_blocking` that KSM-886/926 fixed for the standard paths. New `caching::make_caching_post_function(client)` factory captures a pre-built client in a closure and reuses it across calls. The bare `caching_post_function` is retained for synchronous callers with a doc warning. ([#1004](https://github.com/Keeper-Security/secrets-manager/pull/1004))

- **KSM-933**: `get_secrets()` propagated `SecretsManager.verify_ssl_certs` (positive-sense: true = strict) directly into `KeeperFile.skip_ssl_verify` (negative-sense: true = skip), inverting TLS intent on every file attachment in strict mode. Both propagation sites now use `self.skip_ssl_verify()`, which correctly returns `!verify_ssl_certs`. Currently masked by the shared `http_client` path but would have become a silent security regression on any future refactor. ([#1005](https://github.com/Keeper-Security/secrets-manager/pull/1005))

- **KSM-934**: The module-level doc example in `caching.rs`, the Disaster Recovery Caching example in `README.md`, and the Proxy section in `README.md` all still pointed users at `caching_post_function` after KSM-931 introduced `make_caching_post_function` as its safe replacement. All three updated to show `make_caching_post_function(client)` as the primary API; bare function retained with non-async caveat in the Proxy section. ([#1006](https://github.com/Keeper-Security/secrets-manager/pull/1006))

- **KSM-936**: `RecordField::new` unconditionally wrapped the supplied `Value` in a single-element array, so callers passing a `Value::Array` (the documented way to create multi-value fields like `phone` and `securityQuestion`) produced `[[obj1, obj2]]` on the wire instead of `[obj1, obj2]`. The server stored the wrong shape, causing `keeper://UID/field/phone[1]` to return "idx out of range: 1" and records to appear single-valued to all other SDKs.

- **KSM-937**: `examples/manual_tests/06_caching_function.rs` still used the deprecated bare `caching::caching_post_function` after KSM-934 updated the module doc and README. Users copying the example into a tokio app would intermittently hit the KSM-886 panic. Updated to build one `reqwest::blocking::Client` outside any async context and pass it to `caching::make_caching_post_function(client)`.

## Internal / Housekeeping

- `KeeperFile::http_client` and `skip_ssl_verify` fields narrowed from `pub` to `pub(crate)` — implementation details with no external use case
- `client_builder.build().ok()` → `build().map_err(...)?` in `SecretsManager::new()` — TLS init failures now surface at construction time
- Extracted `KeeperFile::resolve_http_client()` helper to eliminate duplicated client-building fallback
- Fixed pre-existing compile error in `empty_config_test.rs` (missing `proxy_url` argument in `ClientOptions::new()` calls)

## Breaking Changes

- **KSM-812**: `get_folders()` signature changed from `self` to `&mut self`. Callers that relied on the consuming signature must remove any `.clone()` added to work around the original bug.
- **KSM-931**: `CustomPostFunction` type alias changed from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>`. Code that stored the alias directly must wrap with `Arc::new(...)`. Call sites using `options.set_custom_post_function(my_fn)` are unaffected — `set_custom_post_function` now accepts `impl Fn(...)` and wraps internally.

## Related Issues

- KSM-886, KSM-812, KSM-925, KSM-926, KSM-931, KSM-933, KSM-934, KSM-936, KSM-937
- Closes #950
- Merges #1002, #1003, #1004, #1005, #1006