### PR TITLE
KSM-902: add IL5 region mapping (il5.keepersecurity.us)

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,7 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
+- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
 - KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
   - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
   - Consistent with Commander and Vault which always include `"custom": []`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -706,6 +706,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             "GOV" -> "govcloud.keepersecurity.us"
             "JP" -> "keepersecurity.jp"
             "CA" -> "keepersecurity.ca"
+            "IL5" -> "il5.keepersecurity.us"
             else -> tokenParts[0]
         }
         clientKey = tokenParts[1]

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -109,6 +109,9 @@ internal class SecretsManagerTest {
         initializeStorage(storage, "eu:ONE_TIME_TOKEN")
         assertEquals("keepersecurity.eu", storage.getString("hostname"))
         storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:ONE_TIME_TOKEN")
+        assertEquals("il5.keepersecurity.us", storage.getString("hostname"))
+        storage = InMemoryStorage()
         initializeStorage(storage, "fake.keepersecurity.com:ONE_TIME_TOKEN")
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
     }


### PR DESCRIPTION
## Summary
Add IL5 (DoD Impact Level 5) region support to the Java KSM SDK. Tokens prefixed \`IL5:\` now route to \`il5.keepersecurity.us\`.

## Changes

### New Features
- **IL5 region mapping** (KSM-902): Added \`"IL5" -> "il5.keepersecurity.us"\` to the \`when\` expression in \`initializeStorage()\` in \`SecretsManager.kt\`. The existing \`else\` branch already handles unknown prefixes as raw hostnames — no other changes needed.

## Testing
\`\`\`bash
cd sdk/java/core && ./gradlew test --tests "com.keepersecurity.secretsManager.core.SecretsManagerTest.testStoragePrefixes"
\`\`\`

### Breaking Changes
None.

## Related Issues
- Jira: [KSM-902](https://keeper.atlassian.net/browse/KSM-902)

[KSM-902]: https://keeper.atlassian.net/browse/KSM-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ