### PR TITLE
KSM-901: add IL5 region mapping (il5.keepersecurity.us)

### DIFF
--- a/sdk/javascript/packages/core/README.md
+++ b/sdk/javascript/packages/core/README.md
@@ -4,6 +4,9 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
+## 17.4.1
+- KSM-901 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
+
 ## 17.4.0
 - KSM-669 - Crypto issues when using getFolders() on Cloudflare workers with JS SDK
 - KSM-697 - Fix file permissions for config files (write with 0600 permissions for security)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -723,7 +723,8 @@ export const initializeStorage = async (
             AU: 'keepersecurity.com.au',
             GOV: 'govcloud.keepersecurity.us',
             JP: 'keepersecurity.jp',
-            CA: 'keepersecurity.ca'
+            CA: 'keepersecurity.ca',
+            IL5: 'il5.keepersecurity.us'
 
         }[tokenParts[0].toUpperCase()]
         if (!host) {

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -65,6 +65,10 @@ test('Storage prefixes', async () => {
     expect(await storage.getString('hostname')).toBe('keepersecurity.eu')
 
     storage = inMemoryStorage({})
+    await initializeStorage(storage, 'IL5:ONE_TIME_TOKEN')
+    expect(await storage.getString('hostname')).toBe('il5.keepersecurity.us')
+
+    storage = inMemoryStorage({})
     await initializeStorage(storage, 'fake.keepersecurity.com:ONE_TIME_TOKEN')
     expect(await storage.getString('hostname')).toBe('fake.keepersecurity.com')
 })


### PR DESCRIPTION
## Summary
Adds IL5 (DoD Impact Level 5) region support to the JavaScript SDK by mapping the `IL5` token prefix to `il5.keepersecurity.us`, consistent with the Python SDK (KSM-900) and Java SDK (KSM-902) implementations.

## Changes

### New Features
- **IL5 region mapping** (KSM-901): adds `IL5: 'il5.keepersecurity.us'` to the region lookup object in `initializeStorage()` — `IL5:ONE_TIME_TOKEN` now resolves to the correct IL5 hostname

## Testing
```
cd sdk/javascript/packages/core
npm install && npm test
```

The `Storage prefixes` test block includes an IL5 assertion:
```
storage = inMemoryStorage({})
await initializeStorage(storage, 'IL5:ONE_TIME_TOKEN')
expect(await storage.getString('hostname')).toBe('il5.keepersecurity.us')
```

## Breaking Changes
None.

## Related Issues
- Jira: [KSM-901](https://keeper.atlassian.net/browse/KSM-901)

[KSM-901]: https://keeper.atlassian.net/browse/KSM-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ