### PR TITLE
KSM-758: replace rollup-plugin-sourcemaps with rollup-plugin-sourcemaps2

### DIFF
--- a/sdk/javascript/packages/core/package-lock.json
+++ b/sdk/javascript/packages/core/package-lock.json
@@ -18,7 +18,7 @@
         "https-proxy-agent": "^7.0.6",
         "jest": "^30.2.0",
         "rollup": "^4.52.3",
-        "rollup-plugin-sourcemaps": "^0.6.3",
+        "rollup-plugin-sourcemaps2": "^0.5.4",
         "rollup-plugin-typescript2": "^0.36.0",
         "rollup-plugin-version-injector": "^1.3.3",
         "ts-jest": "^29.4.4",
@@ -3244,19 +3244,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -3793,16 +3780,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/dedent": {
@@ -5855,22 +5832,21 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-sourcemaps": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz",
-      "integrity": "sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==",
+    "node_modules/rollup-plugin-sourcemaps2": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps2/-/rollup-plugin-sourcemaps2-0.5.4.tgz",
+      "integrity": "sha512-XK6ITvEsKtUFN1GQbYKoqilwh1yKxTS9BLaFlVsm0IaYUYe3eVnhBWzKP4AHbkBO2BNOheGNlf407K7wCj6Rrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^3.0.9",
-        "source-map-resolve": "^0.6.0"
+        "@rollup/pluginutils": "5.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@types/node": ">=10.0.0",
-        "rollup": ">=0.31.2"
+        "@types/node": ">=18.0.0",
+        "rollup": ">=4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -5878,37 +5854,41 @@
         }
       }
     },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+    "node_modules/rollup-plugin-sourcemaps2/node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+    "node_modules/rollup-plugin-sourcemaps2/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/rollup-plugin-typescript2": {
       "version": "0.36.0",
@@ -6017,18 +5997,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/source-map-support": {

--- a/sdk/javascript/packages/core/package.json
+++ b/sdk/javascript/packages/core/package.json
@@ -25,7 +25,7 @@
     "jest": "^30.2.0",
     "https-proxy-agent": "^7.0.6",
     "rollup": "^4.52.3",
-    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-sourcemaps2": "^0.5.4",
     "rollup-plugin-typescript2": "^0.36.0",
     "rollup-plugin-version-injector": "^1.3.3",
     "ts-jest": "^29.4.4",

--- a/sdk/javascript/packages/core/rollup.config.js
+++ b/sdk/javascript/packages/core/rollup.config.js
@@ -1,6 +1,6 @@
 import typescript from "rollup-plugin-typescript2"
 import pkg from './package.json'
-import sourcemaps from "rollup-plugin-sourcemaps";
+import sourcemaps from "rollup-plugin-sourcemaps2";
 import versionInjector from "rollup-plugin-version-injector";
 
 export default [


### PR DESCRIPTION
## Summary
Replaces the deprecated `rollup-plugin-sourcemaps@0.6.3` with its maintained fork `rollup-plugin-sourcemaps2@0.5.4`, eliminating peer dependency warnings when building with Rollup 4.x.

## Changes

### Maintenance
- **Rollup sourcemaps plugin** (KSM-758): swaps `rollup-plugin-sourcemaps` for `rollup-plugin-sourcemaps2` in `package.json` and `rollup.config.js` — no API changes, drop-in replacement

## Testing
```
cd sdk/javascript/packages/core
npm install && npm run prepublishOnly
```
Build should complete without peer dependency warnings.

## Breaking Changes
None.

## Related Issues
- Jira: [KSM-758](https://keeper.atlassian.net/browse/KSM-758)

[KSM-758]: https://keeper.atlassian.net/browse/KSM-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ