### PR TITLE
fix(rust-sdk): drop unused self.clone() in folder/secret callsites (KSM-925)

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -1969,7 +1969,7 @@ impl SecretsManager {
         folders: Vec<KeeperFolder>,
     ) -> Result<String, KSMRError> {
         let folders_copy = match folders.is_empty() {
-            true => self.clone().get_folders()?,
+            true => self.get_folders()?,
             false => folders,
         };
 
@@ -2063,7 +2063,7 @@ impl SecretsManager {
         folders: Vec<KeeperFolder>,
     ) -> Result<String, KSMRError> {
         let folders_copy = match folders.is_empty() {
-            true => self.clone().get_folders()?,
+            true => self.get_folders()?,
             false => folders,
         };
 
@@ -2811,7 +2811,7 @@ impl SecretsManager {
     ) -> Result<String, KSMRError> {
         let record_json_str = record_create_object.to_json()?;
 
-        let folders = self.clone().get_folders()?;
+        let folders = self.get_folders()?;
 
         let mut parent_uid = parent_folder_uid.clone();
         let mut sub_folder_uid: Option<String> = None;


### PR DESCRIPTION
## Summary

Three internal callsites introduced by KSM-812 still called `self.clone().get_folders()` after that PR changed the method signature from consuming `self` to borrowing `&mut self`. Each clone triggered a wasted network round-trip on a throwaway `SecretsManager` instance. This removes the clones.

## Changes

### Fixed
- `update_folder` (core.rs:1972), `create_folder` (core.rs:2066), `create_secret` (core.rs:2814): replace `self.clone().get_folders()?` with `self.get_folders()?` now that the method takes `&mut self` (KSM-925)

## Testing

```bash
cd sdk/rust && cargo test --all-features
```

## Breaking Changes

None.

## Related Issues

- Jira: KSM-925