### PR TITLE
fix(rust-sdk): share reqwest::blocking::Client in caching path (KSM-931)

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to this project will be documented in this file.
 - Proxy configuration errors (malformed URL, unsupported scheme) now surface at `SecretsManager::new()` with a clear `SecretManagerCreationError` instead of silently bypassing the proxy and sending traffic direct
 - Authenticated proxy URLs (`http://user:pass@host:port`) are now correctly applied when `KeeperFile` is used outside the standard `get_secrets()` fetch path (e.g. deserialized from storage)
 - TLS initialisation failures now surface at `SecretsManager::new()` instead of deferring to the first API call
+- **KSM-931**: `caching::caching_post_function` built a new `reqwest::blocking::Client` on every API call, leaving the same nested-runtime panic risk under `tokio::spawn_blocking` that KSM-886 / KSM-926 fixed for the standard paths
+  - Fix: new `caching::make_caching_post_function(client)` factory captures a `reqwest::blocking::Client` built outside any async context and reuses it across all calls; the bare `caching_post_function` is retained for synchronous callers but its docs now warn against use under async runtimes
+  - **Note**: `CustomPostFunction` is now `Arc<dyn Fn(...) + Send + Sync>` instead of a bare `fn` pointer — minor breaking change for callers that stored the alias directly; existing `options.set_custom_post_function(my_fn)` call sites compile unchanged because bare `fn` implements `Fn + Send + Sync + 'static`
+  - See: [reqwest#1017](https://github.com/seanmonstar/reqwest/issues/1017)
 
 ### Changed
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -52,6 +52,7 @@ winapi = { version = "0.3" ,features = ["securitybaseapi","winbase","winerror","
 mockall = "0.13"
 tempfile = "3.20"
 serial_test = "3.0"
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 # Manual integration test examples
 [[example]]

--- a/sdk/rust/src/caching.rs
+++ b/sdk/rust/src/caching.rs
@@ -126,11 +126,46 @@ pub fn cache_exists() -> bool {
     get_cache_file_path().exists()
 }
 
+/// Build a caching post function that captures a pre-built HTTP client.
+///
+/// Returns a closure suitable for use with `ClientOptions::set_custom_post_function`.
+/// The returned closure reuses the provided `reqwest::blocking::Client` on every call,
+/// so it is safe to invoke from inside `tokio::task::spawn_blocking`. Construct the
+/// client and the closure outside any async context, then pass it to
+/// `ClientOptions::set_custom_post_function` before calling `SecretsManager::new()`.
+///
+/// # Example
+/// ```rust,no_run
+/// use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+/// use keeper_secrets_manager_core::storage::FileKeyValueStorage;
+/// use keeper_secrets_manager_core::caching;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = reqwest::blocking::Client::builder().build()?;
+/// let config = FileKeyValueStorage::new_config_storage("config.json".to_string())?;
+/// let mut client_options = ClientOptions::new_client_options(config);
+/// client_options.set_custom_post_function(caching::make_caching_post_function(client));
+/// let mut secrets_manager = SecretsManager::new(client_options)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn make_caching_post_function(
+    client: reqwest::blocking::Client,
+) -> impl Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+       + Send
+       + Sync
+       + 'static {
+    move |url, transmission_key, encrypted_payload| {
+        run_caching_logic(url, transmission_key, encrypted_payload, &client)
+    }
+}
+
 /// Caching post function for disaster recovery.
 ///
-/// This function wraps the normal HTTP POST operation and:
-/// 1. On success: Saves the response to cache (transmission key + encrypted data)
-/// 2. On failure: Falls back to cached data if available
+/// **Warning**: This bare function builds a new `reqwest::blocking::Client` on every
+/// call. Calling it from inside `tokio::task::spawn_blocking` will panic with
+/// *"Cannot drop a runtime in a context where blocking is not allowed"*.
+/// Use [`make_caching_post_function`] instead, which captures a pre-built client.
 ///
 /// # Arguments
 /// * `url` - The API endpoint URL
@@ -139,25 +174,32 @@ pub fn cache_exists() -> bool {
 ///
 /// # Returns
 /// * `Result<KsmHttpResponse, KSMRError>` - Response object (from network or cache)
-///
-/// # Example
-/// ```rust,no_run
-/// use keeper_secrets_manager_core::core::ClientOptions;
-/// use keeper_secrets_manager_core::caching::caching_post_function;
-///
-/// # fn main() {
-/// let mut options = ClientOptions::new_client_options(keeper_secrets_manager_core::enums::KvStoreType::None);
-/// options.set_custom_post_function(caching_post_function);
-/// # }
-/// ```
 pub fn caching_post_function(
     url: String,
     transmission_key: TransmissionKey,
     encrypted_payload: EncryptedPayload,
 ) -> Result<KsmHttpResponse, KSMRError> {
     let proxy_url = std::env::var("KSM_PROXY_URL").ok();
+    let mut client_builder = Client::builder();
+    if let Some(ref proxy) = proxy_url {
+        if let Ok(p) = reqwest::Proxy::all(proxy) {
+            client_builder = client_builder.proxy(p);
+        }
+    }
+    let client = client_builder
+        .build()
+        .map_err(|e| KSMRError::HTTPError(format!("Failed to build client: {}", e)))?;
+    run_caching_logic(url, transmission_key, encrypted_payload, &client)
+}
+
+fn run_caching_logic(
+    url: String,
+    transmission_key: TransmissionKey,
+    encrypted_payload: EncryptedPayload,
+    client: &Client,
+) -> Result<KsmHttpResponse, KSMRError> {
     // Try network request first
-    match make_http_request(url, transmission_key.clone(), encrypted_payload, proxy_url) {
+    match make_http_request(client, url, transmission_key.clone(), encrypted_payload) {
         Ok(response) if response.status_code == 200 => {
             // On success, save to cache (transmission key + encrypted response body)
             let mut cache_data = transmission_key.key.clone();
@@ -221,26 +263,12 @@ pub fn caching_post_function(
     }
 }
 
-/// Make HTTP request - extracted to be testable
-///
-/// This duplicates some logic from SecretsManager#process_post_request
-/// because we need a standalone function for the caching pattern.
 fn make_http_request(
+    client: &Client,
     url: String,
     transmission_key: TransmissionKey,
     encrypted_payload: EncryptedPayload,
-    proxy_url: Option<String>,
 ) -> Result<KsmHttpResponse, KSMRError> {
-    let mut client_builder = Client::builder();
-    if let Some(ref proxy) = proxy_url {
-        if let Ok(p) = reqwest::Proxy::all(proxy) {
-            client_builder = client_builder.proxy(p);
-        }
-    }
-    let client = client_builder
-        .build()
-        .map_err(|e| KSMRError::HTTPError(format!("Failed to build client: {}", e)))?;
-
     // Build headers
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -50,20 +50,17 @@ use regex::Regex;
 use reqwest::header;
 use serde_json::Value;
 
-/// Custom post function type for HTTP request injection (used for testing and mocking)
+/// Custom post function type for HTTP request injection (used for testing and mocking).
 ///
-/// # Arguments
-/// * `url` - The URL to make the request to
-/// * `transmission_key` - The transmission key for encrypting the request
-/// * `encrypted_payload` - The encrypted payload to send
-///
-/// # Returns
-/// * `Result<KsmHttpResponse, KSMRError>` - The HTTP response or an error
-pub type CustomPostFunction = fn(
-    url: String,
-    transmission_key: TransmissionKey,
-    encrypted_payload: EncryptedPayload,
-) -> Result<KsmHttpResponse, KSMRError>;
+/// Changed in v17.2.0 (KSM-931) from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>` to allow
+/// closures that capture state (e.g. a shared `reqwest::blocking::Client`). Existing call
+/// sites using `options.set_custom_post_function(my_fn)` continue to compile unchanged
+/// because bare `fn` pointers implement `Fn + Send + Sync + 'static`.
+pub type CustomPostFunction = std::sync::Arc<
+    dyn Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+        + Send
+        + Sync,
+>;
 
 pub struct ClientOptions {
     pub token: String,
@@ -149,13 +146,15 @@ impl ClientOptions {
         self.cache = cache;
     }
 
-    /// Set a custom post function for HTTP requests (primarily for testing and mocking)
+    /// Set a custom post function for HTTP requests (primarily for testing and mocking).
     ///
-    /// # Arguments
-    /// * `post_function` - The custom function to handle HTTP POST requests
+    /// Accepts any closure or bare function pointer that matches the
+    /// `(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>`
+    /// signature and is `Send + Sync + 'static`. The value is wrapped in an `Arc`
+    /// internally, so it is cheap to clone inside `SecretsManager`.
     ///
     /// # Example
-    /// ```no_run,no_run
+    /// ```no_run
     /// use keeper_secrets_manager_core::core::ClientOptions;
     /// use keeper_secrets_manager_core::dto::{TransmissionKey, EncryptedPayload, KsmHttpResponse};
     /// use keeper_secrets_manager_core::custom_error::KSMRError;
@@ -169,8 +168,14 @@ impl ClientOptions {
     /// options.set_custom_post_function(my_mock_post);
     /// # }
     /// ```
-    pub fn set_custom_post_function(&mut self, post_function: CustomPostFunction) {
-        self.custom_post_function = Some(post_function);
+    pub fn set_custom_post_function<F>(&mut self, f: F)
+    where
+        F: Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.custom_post_function = Some(std::sync::Arc::new(f));
     }
 
     /// Sets the logging level for SDK operations.
@@ -212,7 +217,7 @@ impl Clone for SecretsManager {
             log_level: self.log_level,
             cache: self.cache.clone(),
             proxy_url: self.proxy_url.clone(),
-            custom_post_function: self.custom_post_function,
+            custom_post_function: self.custom_post_function.clone(),
             http_client: self.http_client.clone(),
         }
     }
@@ -1088,7 +1093,7 @@ impl SecretsManager {
             .map_err(|e| KSMRError::SecretManagerCreationError(e.to_string()))?;
 
             // Use custom post function if provided (for testing/mocking), otherwise use default HTTP client
-            keeper_response = if let Some(custom_post_fn) = self.custom_post_function {
+            keeper_response = if let Some(custom_post_fn) = &self.custom_post_function {
                 custom_post_fn(
                     url.clone(),
                     transmission_key.clone(),

--- a/sdk/rust/tests/caching_tests.rs
+++ b/sdk/rust/tests/caching_tests.rs
@@ -416,4 +416,65 @@ mod caching_tests {
         cleanup_test_cache(test_dir);
         env::remove_var("KSM_CACHE_DIR");
     }
+
+    /// Regression test for KSM-931: make_caching_post_function must not panic
+    /// when called from inside tokio::task::spawn_blocking.
+    ///
+    /// Without the fix (bare caching_post_function calling Client::builder().build()
+    /// per call), this scenario panics with:
+    ///   "Cannot drop a runtime in a context where blocking is not allowed"
+    ///
+    /// With the fix (factory captures a pre-built Client), it returns a clean
+    /// network error instead — no panic. Test fails to compile before the fix
+    /// because make_caching_post_function does not exist yet.
+    #[test]
+    fn test_make_caching_post_function_runs_under_spawn_blocking() {
+        use keeper_secrets_manager_core::caching::make_caching_post_function;
+        use keeper_secrets_manager_core::dto::{EncryptedPayload, TransmissionKey};
+        use p256::ecdsa::{signature::Signer, SigningKey};
+
+        // Generate a deterministic signature for the EncryptedPayload constructor.
+        // The server is never reached (port 1 is unreachable) so cryptographic
+        // validity is irrelevant; we just need a structurally valid value.
+        let signing_key = SigningKey::from_slice(&[42u8; 32]).expect("valid test scalar");
+        let raw_sig: p256::ecdsa::Signature = signing_key.sign(b"ksm-931-regression-test");
+        let der_sig: ecdsa::der::Signature<p256::NistP256> = raw_sig.into();
+
+        let tk = TransmissionKey::new("10".to_string(), vec![0u8; 32], vec![0u8; 32]);
+        let ep = EncryptedPayload::new(vec![0u8; 16], der_sig);
+
+        // Build the client OUTSIDE any async context — the correct usage pattern.
+        let client = reqwest::blocking::Client::builder()
+            .build()
+            .expect("build client outside runtime");
+
+        let post_fn = make_caching_post_function(client);
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        let result = rt.block_on(async {
+            tokio::task::spawn_blocking(move || {
+                // Port 1 is unreachable — we expect a network error, not a panic.
+                post_fn("http://127.0.0.1:1/test".to_string(), tk, ep)
+            })
+            .await
+        });
+
+        // spawn_blocking must not have panicked — if it did, await returns
+        // Err(JoinError::Panicked).
+        assert!(
+            result.is_ok(),
+            "spawn_blocking panicked (nested-runtime bug still present): {:?}",
+            result
+        );
+        // The inner call should return a network error (connection refused), not Ok.
+        let inner = result.unwrap();
+        assert!(
+            inner.is_err(),
+            "expected network error against 127.0.0.1:1, got Ok"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes the last KSM-886 / KSM-926 gap: `caching_post_function` still called `Client::builder().build()` on every invocation, leaving the same nested-runtime panic under `tokio::spawn_blocking` that the earlier fixes eliminated for the standard post path and file downloads.

## Changes

### Fixed

- `caching::caching_post_function` built a new `reqwest::blocking::Client` on every call, panicking with *"Cannot drop a runtime in a context where blocking is not allowed"* when called from inside `tokio::task::spawn_blocking` (KSM-931)

### Maintenance

- New `caching::make_caching_post_function(client)` factory: accepts a pre-built `reqwest::blocking::Client`, returns a closure that reuses it. Eliminates `Client::builder().build()` from the hot path entirely (KSM-931)
- Bare `caching_post_function` retained for synchronous callers; updated docs warn against async use
- `CustomPostFunction` alias widened from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>` so closures capturing state (e.g. the shared client) can satisfy the type. Existing `set_custom_post_function(my_fn)` call sites compile unchanged (KSM-931)

## Testing

```bash
cd sdk/rust

# Regression test: make_caching_post_function runs inside spawn_blocking without panic
cargo test --test caching_tests test_make_caching_post_function_runs_under_spawn_blocking

# Full suite
cargo test
```

## Breaking Changes

`CustomPostFunction` type alias changed from:
```rust
fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
```
to:
```rust
Arc<dyn Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError> + Send + Sync>
```

Code that stored the alias directly (e.g. `let f: CustomPostFunction = my_fn;`) must wrap with `Arc::new(my_fn)`. Code that calls `options.set_custom_post_function(my_fn)` is unaffected — `set_custom_post_function` now accepts `impl Fn(...)` and wraps internally.

## Related Issues

- Jira: KSM-931