### PR TITLE
docs(rust): update caching.rs module example to use make_caching_post_function

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -526,8 +526,9 @@ let config = KvStoreType::File(storage);
 let token = "YOUR_TOKEN".to_string();
 let mut options = ClientOptions::new_client_options_with_token(token, config);
 
-// Enable disaster recovery caching
-options.set_custom_post_function(caching::caching_post_function);
+// Build the client once outside any async context (safe for spawn_blocking)
+let client = reqwest::blocking::Client::builder().build()?;
+options.set_custom_post_function(caching::make_caching_post_function(client));
 
 let mut secrets_manager = SecretsManager::new(options)?;
 
@@ -671,7 +672,7 @@ See `examples/manual_tests/README.md` for detailed setup instructions.
 - `KSM_CONFIG` - Base64-encoded JSON configuration (overrides file storage)
 - `KSM_CACHE_DIR` - Cache directory for disaster recovery caching (default: current directory)
 - `KSM_SKIP_VERIFY` - Skip SSL certificate verification (`true`/`false`)
-- `KSM_PROXY_URL` - Proxy URL used by `caching_post_function` (mirrors `ClientOptions.proxy_url` for the caching path)
+- `KSM_PROXY_URL` - Proxy URL used by the bare `caching_post_function` (not used by `make_caching_post_function` — configure proxy on the `reqwest::Client` builder instead)
 - `HTTP_PROXY` - HTTP proxy URL (automatically used if `proxy_url` not set)
 - `HTTPS_PROXY` - HTTPS proxy URL (automatically used if `proxy_url` not set)
 - `NO_PROXY` - Comma-separated list of hosts to exclude from proxying
@@ -758,17 +759,25 @@ export NO_PROXY=localhost,127.0.0.1
 
 **Priority**: Explicit `proxy_url` parameter > Environment variables (`HTTPS_PROXY`/`HTTP_PROXY`)
 
-#### Proxy with `caching_post_function`
+#### Proxy with caching
 
-`caching_post_function` uses a standalone function pointer and cannot capture `SecretsManager` state. Set `KSM_PROXY_URL` to route caching traffic through your proxy:
+With `make_caching_post_function`, configure the proxy on the `reqwest::Client` you pass in:
+
+```rust
+let client = reqwest::blocking::Client::builder()
+    .proxy(reqwest::Proxy::https("http://proxy.example.com:8080")?)
+    .build()?;
+client_options.set_custom_post_function(caching::make_caching_post_function(client));
+```
+
+The bare `caching_post_function` (non-async contexts only) reads `KSM_PROXY_URL` at call time instead:
 
 ```bash
 export KSM_PROXY_URL=http://proxy.example.com:8080
 ```
 
 ```rust
-client_options.set_custom_post_function(caching_post_function);
-// KSM_PROXY_URL is read at call time by caching_post_function
+client_options.set_custom_post_function(caching::caching_post_function);
 ```
 
 ## Dependencies

--- a/sdk/rust/src/caching.rs
+++ b/sdk/rust/src/caching.rs
@@ -24,19 +24,16 @@
 //! use keeper_secrets_manager_core::caching;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Build the client once outside any async context (safe for spawn_blocking)
+//! let client = reqwest::blocking::Client::builder().build()?;
 //! let config = FileKeyValueStorage::new_config_storage("config.json".to_string())?;
 //! let mut client_options = ClientOptions::new_client_options(config);
-//!
-//! // Use caching post function for disaster recovery
-//! client_options.set_custom_post_function(caching::caching_post_function);
+//! client_options.set_custom_post_function(caching::make_caching_post_function(client));
 //!
 //! let mut secrets_manager = SecretsManager::new(client_options)?;
 //!
-//! // First call saves to cache
+//! // First call saves to cache; if network fails, falls back to cached data
 //! let secrets = secrets_manager.get_secrets(Vec::new())?;
-//!
-//! // If network fails, falls back to cached data
-//! // let secrets = secrets_manager.get_secrets(Vec::new())?; // Uses cache on failure
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
## Summary

The module-level doc example in \`caching.rs\`, the Disaster Recovery Caching example in \`README.md\`, and the Proxy section in \`README.md\` all still showed \`caching_post_function\` as the primary API after KSM-931 introduced \`make_caching_post_function\` as its safe replacement. Anyone reading docs.rs or the README would follow the example into the panicking code path when running under \`tokio::task::spawn_blocking\`.

## Changes

### Fixed
- Update \`caching.rs\` module-level doc example to demonstrate \`caching::make_caching_post_function(client)\` with a pre-built \`reqwest::blocking::Client\` (KSM-934)
- Update \`README.md\` Disaster Recovery Caching example to use \`make_caching_post_function\` (KSM-934)
- Update \`README.md\` Proxy section to show proxy-configured client with \`make_caching_post_function\`; clarify \`KSM_PROXY_URL\` applies to bare function only (KSM-934)

## Testing

\`\`\`bash
cd sdk/rust
cargo test
# All 66 tests pass; doc examples with \`no_run\` compile-check as part of the suite
\`\`\`

## Breaking Changes
None.

## Related Issues
- Closes KSM-934