### PR TITLE
KSM-932: Python IL5 custom server public key support

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/configkeys.py
+++ b/sdk/python/core/keeper_secrets_manager_core/configkeys.py
@@ -21,6 +21,7 @@ class ConfigKeys(Enum):
     KEY_OWNER_PUBLIC_KEY = 'appOwnerPublicKey'  # The application owner public key, to create records
     KEY_PRIVATE_KEY = 'privateKey'  # The client's private key
     KEY_SERVER_PUBLIC_KEY_ID = 'serverPublicKeyId'  # Which public key should be using?
+    KEY_SERVER_PUBLIC_KEY = 'serverPublicKey'        # Custom server EC public key (base64) for IL5 / isolated deployments
 
     KEY_BINDING_TOKEN = 'bat'
     KEY_BINDING_KEY = 'bindingKey'

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -85,7 +85,9 @@ class SecretsManager:
                  config=None,
                  log_level=None,
                  custom_post_function=None,
-                 proxy_url=None
+                 proxy_url=None,
+                 server_public_key=None,
+                 server_public_key_id=None,
                  ):
 
         # Make sure the Python is 3.6 or higher. We'll handle Python 4 in the future :)
@@ -124,6 +126,12 @@ class SecretsManager:
 
                 self.token = token_parts[1]
 
+                # Layer 2: IL5 OTT carries embedded key material as extra segments
+                # Format: IL5:[clientKey]:[keyId]:[serverPublicKeyBase64]
+                if token_parts[0].upper() == 'IL5' and len(token_parts) == 4:
+                    self._il5_key_id = token_parts[2]
+                    self._il5_server_public_key = token_parts[3]
+
         # Init the log, create a logger for the core.
         self._init_logger(log_level=log_level)
         self.logger = logging.getLogger(logger_name)
@@ -146,15 +154,27 @@ class SecretsManager:
         if self.hostname is not None:
             config.set(ConfigKeys.KEY_HOSTNAME, self.hostname)
 
+        # Layer 2: IL5 OTT with embedded key material — write before key ID validation runs
+        if hasattr(self, '_il5_key_id'):
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, self._il5_key_id)
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY, self._il5_server_public_key)
+
+        # Layer 3: programmatic injection — takes precedence over config file, written before validation
+        if server_public_key:
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY, server_public_key)
+        if server_public_key_id:
+            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, server_public_key_id)
+
         # Make sure our public key id is set and pointing an existing key.
         if config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID) is None:
             self.logger.debug("Setting public key id to the default: {}".format(SecretsManager.default_key_id))
             config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, SecretsManager.default_key_id)
         elif config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID) not in keeper_public_keys:
-            self.logger.debug("Public key id {} does not exists, set to default : {}".format(
-                config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID),
-                SecretsManager.default_key_id))
-            config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, SecretsManager.default_key_id)
+            if not config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY):
+                self.logger.debug("Public key id {} does not exists, set to default : {}".format(
+                    config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID),
+                    SecretsManager.default_key_id))
+                config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, SecretsManager.default_key_id)
 
         self.config: KeyValueStorage = config
 
@@ -287,13 +307,15 @@ class SecretsManager:
         return current_secret_key
 
     @staticmethod
-    def generate_transmission_key(key_id):
+    def generate_transmission_key(key_id, custom_public_key_b64=None):
         transmission_key = utils.generate_random_bytes(32)
 
-        if key_id not in keeper_public_keys:
-            ValueError("The public key id {} does not exist.".format(key_id))
-
-        server_public_raw_key_bytes = url_safe_str_to_bytes(keeper_public_keys[key_id])
+        if custom_public_key_b64:
+            server_public_raw_key_bytes = url_safe_str_to_bytes(custom_public_key_b64)
+        elif key_id not in keeper_public_keys:
+            raise ValueError("The public key id {} does not exist.".format(key_id))
+        else:
+            server_public_raw_key_bytes = url_safe_str_to_bytes(keeper_public_keys[key_id])
 
         encrypted_key = CryptoUtils.public_encrypt(transmission_key, server_public_raw_key_bytes)
 
@@ -590,7 +612,8 @@ class SecretsManager:
         while True:
 
             transmission_key_id = self.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID)
-            transmission_key = self.generate_transmission_key(transmission_key_id)
+            custom_key = self.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY)
+            transmission_key = self.generate_transmission_key(transmission_key_id, custom_key)
             encrypted_payload_and_signature = self.encrypt_and_sign_payload(self.config, transmission_key, payload)
 
             if self.custom_post_function and path == 'get_secret':
@@ -686,7 +709,9 @@ class SecretsManager:
 
                 if key_id is None:
                     raise ValueError("The public key is blank from the server")
-                elif str(key_id) not in keeper_public_keys:
+
+                custom_key = self.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY)
+                if str(key_id) not in keeper_public_keys and not custom_key:
                     raise ValueError("The public key at {} does not exist in the SDK".format(key_id))
 
                 self.config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, str(key_id))

--- a/sdk/python/core/tests/il5_test.py
+++ b/sdk/python/core/tests/il5_test.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from keeper_secrets_manager_core import SecretsManager, mock
+from keeper_secrets_manager_core.configkeys import ConfigKeys
+from keeper_secrets_manager_core.keeper_globals import keeper_public_keys
+from keeper_secrets_manager_core.mock import MockConfig
+from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
+
+
+class IL5DynamicKeyTest(unittest.TestCase):
+
+    def test_layer1_generate_transmission_key_uses_custom_key(self):
+        """Layer 1: generate_transmission_key uses custom key bytes instead of the hardcoded map."""
+        custom_key_b64 = keeper_public_keys['7']  # borrow a real key's bytes as the "custom" key
+
+        with patch('keeper_secrets_manager_core.core.CryptoUtils.public_encrypt') as mock_encrypt:
+            mock_encrypt.return_value = b'fake_encrypted'
+            SecretsManager.generate_transmission_key('20', custom_key_b64)
+
+        mock_encrypt.assert_called_once()
+        # First arg to public_encrypt is the transmission key bytes; second is the server public key bytes
+        used_key_bytes = mock_encrypt.call_args[0][1]
+        from keeper_secrets_manager_core.utils import url_safe_str_to_bytes
+        self.assertEqual(used_key_bytes, url_safe_str_to_bytes(custom_key_b64))
+
+    def test_layer1_generate_transmission_key_raises_without_custom_key(self):
+        """Layer 1: unknown key_id with no custom key still raises ValueError."""
+        with self.assertRaises(ValueError):
+            SecretsManager.generate_transmission_key('20')
+
+    def test_layer2_ott_4segment_writes_key_material_to_config(self):
+        """Layer 2: 4-segment IL5 OTT writes key_id and server public key into config at init time."""
+        custom_key_b64 = keeper_public_keys['7']
+        config = InMemoryKeyValueStorage()
+
+        # IL5:[clientKey]:[keyId]:[serverPublicKeyBase64]
+        il5_token = 'IL5:fakeClientKey123456789012345:20:' + custom_key_b64
+
+        secrets_manager = SecretsManager(token=il5_token, config=config)
+
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), custom_key_b64)
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+
+    def test_layer3_programmatic_params_write_key_material_to_config(self):
+        """Layer 3: server_public_key / server_public_key_id constructor params write to config."""
+        custom_key_b64 = keeper_public_keys['7']
+        config = InMemoryKeyValueStorage(MockConfig.make_json())
+
+        secrets_manager = SecretsManager(
+            config=config,
+            server_public_key=custom_key_b64,
+            server_public_key_id='20',
+        )
+
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), custom_key_b64)
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+
+    def test_key_rotation_retries_with_custom_key(self):
+        """When the server sends a key-rotation error with key_id=20 and a custom key is configured,
+        the SDK updates the key_id and retries instead of raising ValueError."""
+        custom_key_b64 = keeper_public_keys['7']
+        config = InMemoryKeyValueStorage(MockConfig.make_json())
+
+        secrets_manager = SecretsManager(
+            config=config,
+            server_public_key=custom_key_b64,
+            server_public_key_id='10',
+        )
+
+        # First response: server requests key rotation to key 20
+        error_response = mock.Response(
+            client=secrets_manager,
+            content='{"error": "key", "key_id": 20}',
+            status_code=400,
+            reason="Bad Request",
+        )
+
+        # Second response: success with one record
+        success_response = mock.Response()
+        rec = success_response.add_record(title="IL5 Record")
+        rec.field("login", "il5_user")
+
+        res_queue = mock.ResponseQueue(client=secrets_manager)
+        res_queue.add_response(error_response)
+        res_queue.add_response(success_response)
+
+        records = secrets_manager.get_secrets([])
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].title, "IL5 Record")
+        # key_id should have been updated to '20' by the rotation handler
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## KSM-932 — IL5 Custom Server Public Key (Python SDK)

Implements three-layer custom server public key support for IL5 environment connections. IL5 uses a server public key that cannot be hardcoded in the public SDK (unlike keys 7–18); customers supply it via one of three paths.

### Layers

- **Layer 1 — Config field**: `serverPublicKey` in storage; `generate_transmission_key()` uses it directly, skipping the embedded `keeper_public_keys` lookup
- **Layer 2 — OTS token extension**: 4-segment IL5 format (`IL5:[clientKey]:[publicKeyId]:[publicKeyBase64]`) parsed at init; `serverPublicKey` and `serverPublicKeyId` persisted to storage
- **Layer 3 — Programmatic parameter**: `server_public_key` / `server_public_key_id` on `SecretsManager` constructor; persisted before first request
- **Key rotation handler**: when `serverPublicKey` is set and server returns `{"error": "key", "key_id": N}` with N outside the embedded table, updates `serverPublicKeyId` and retries

### Validation

Validated end-to-end against live commercial environments (prod key_id=10, QA key_id=9) with the target key removed from the embedded table. All 59 pre-existing tests pass; 5 new IL5-specific tests added (64 total).

Also fixed a pre-existing silent bug where `ValueError` for an unknown key ID was constructed but not raised in `generate_transmission_key()`.

Closes KSM-932