### PR TITLE
KSM-938: raise on get_key_details failure to prevent plaintext config

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
@@ -13,6 +13,7 @@ Keeper Secrets Manager integrates with GCP KMS in order to provide protection fo
   * Cloud KMS CryptoKey Decrypter
   * Cloud KMS CryptoKey Encrypter
   * Cloud KMS CryptoKey Public Key Viewer
+  * Cloud KMS Viewer (provides `cloudkms.cryptoKeys.get`, required for key introspection on init)
 
 ## Setup
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -38,7 +38,7 @@ class GCPKeyValueStorage(KeyValueStorage):
     config_file_location: str
     gcp_session_config: GCPKMSClientConfig
     is_asymmetric: bool = False
-    key_purpose_details: str
+    key_purpose_details: Optional[str] = None
     
     def __init__(self, key_vault_config_file_location: str , gcp_key_config: GCPKeyConfig, gcp_session_config: GCPKMSClientConfig, logger: Logger = None):
         self.config_file_location = os.path.abspath(key_vault_config_file_location) or os.getenv('KSM_CONFIG_FILE') or os.path.abspath(self.default_config_file_location)
@@ -80,8 +80,9 @@ class GCPKeyValueStorage(KeyValueStorage):
 
         except Exception as err:
             self.logger.error(f"Failed to get key details: {err}")
-            
-            
+            raise
+
+
     def create_config_file_if_missing(self):
         try:
             self.logger.info(f"config file path {self.config_file_location}")
@@ -204,7 +205,8 @@ class GCPKeyValueStorage(KeyValueStorage):
 
         except Exception as err:
             self.logger.error(f"Error saving config: {err}")
-            
+            raise
+
     def load_config(self) -> None:
         self.create_config_file_if_missing()
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -1,0 +1,58 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def make_mock_session(client_mock):
+    session = MagicMock()
+    session.get_crypto_client.return_value = client_mock
+    session.getToken.return_value = "fake-token"
+    return session
+
+
+def make_key_config(resource_uri="projects/p/locations/global/keyRings/r/cryptoKeys/k"):
+    from keeper_secrets_manager_storage_gcp_kms.kms_key_config import GCPKeyConfig
+    cfg = MagicMock(spec=GCPKeyConfig)
+    cfg.to_key_name.return_value = resource_uri
+    return cfg
+
+
+class TestGetKeyDetailsFailure:
+    """KSM-938 regression: missing cloudkms.cryptoKeys.get permission must raise, not silently continue."""
+
+    def test_init_raises_on_get_crypto_key_permission_denied(self, tmp_path):
+        from keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms import GCPKeyValueStorage
+
+        client_mock = MagicMock()
+        client_mock.get_crypto_key.side_effect = Exception("403 Permission denied: cloudkms.cryptoKeys.get")
+        session_mock = make_mock_session(client_mock)
+        key_cfg = make_key_config()
+
+        config_path = str(tmp_path / "ksm-config.json")
+
+        with pytest.raises(Exception, match="403"):
+            GCPKeyValueStorage(config_path, key_cfg, session_mock)
+
+    def test_config_not_written_plaintext_on_init_failure(self, tmp_path):
+        """When init fails due to permission denied, an existing plaintext config must not be re-written."""
+        from keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms import GCPKeyValueStorage
+
+        config_path = tmp_path / "ksm-config.json"
+        original_content = json.dumps({"clientId": "test-id", "appKey": "secret"}).encode()
+        config_path.write_bytes(original_content)
+
+        client_mock = MagicMock()
+        client_mock.get_crypto_key.side_effect = Exception("403 Permission denied: cloudkms.cryptoKeys.get")
+        session_mock = make_mock_session(client_mock)
+        key_cfg = make_key_config()
+
+        with pytest.raises(Exception):
+            GCPKeyValueStorage(str(config_path), key_cfg, session_mock)
+
+        assert config_path.read_bytes() == original_content, (
+            "Config file was modified despite init failure — credentials may have been re-written in plaintext"
+        )


### PR DESCRIPTION
## Summary

When a GCP service account lacks `cloudkms.cryptoKeys.get`, `get_key_details()` caught the 403 silently. The `key_purpose_details` attribute was never assigned (annotation-only on line 41), causing an `AttributeError` in `__save_config()` — also swallowed silently. Net result: KSM credentials sat on disk as plaintext JSON with no error surfaced to the caller.

## Changes

### Fixed
- `get_key_details()` now re-raises after logging, so `__init__` fails loudly when key introspection is denied (KSM-938)
- `__save_config()` now re-raises after logging — encryption failures on this security-critical path must never be silently swallowed (KSM-938)
- `key_purpose_details` class annotation changed to `Optional[str] = None` so the attribute always exists as a safety net (KSM-938)
- README prerequisites updated to include Cloud KMS Viewer role (`cloudkms.cryptoKeys.get`), which was always required but undocumented (KSM-938)

## Testing

```bash
cd sdk/python/storage/keeper_secrets_manager_storage_gcp_kms
pip install -e .
pytest tests/ -v
```

## Breaking Changes

None. The only observable behavior change is that `GCPKeyValueStorage(...)` now raises when `cloudkms.cryptoKeys.get` is denied, instead of silently constructing a broken object that leaves credentials in plaintext. Callers that previously ignored the missing error will now see the exception — which is the intended behavior.

## Related Issues

- Jira: KSM-938