### PR TITLE
fix(storage): use 12-byte AES-GCM nonce and SHA-256 for change detection (KSM-943)

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
@@ -81,6 +81,8 @@ Once setup, the Secrets Manager GCP KMS integration supports all Secrets Manager
 - Fixed CVE-2026-0994: protobuf JSON recursion DoS (upgraded to `protobuf>=6.33.5`)
 - Fixed CVE-2026-26007: cryptography subgroup attack (upgraded to `cryptography>=46.0.5`)
 - Fixed silent failure when `cloudkms.cryptoKeys.get` is denied — `GCPKeyValueStorage` now raises on init instead of leaving the config file unencrypted on disk
+- Fixed AES-GCM nonce to 96-bit/12-byte per NIST SP 800-38D (was 128-bit/16-byte PyCryptodome default); existing encrypted blobs remain readable
+- Replaced MD5 with SHA-256 for config change detection
 
 ### 1.0.1
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -162,12 +162,12 @@ class GCPKeyValueStorage(KeyValueStorage):
             # Retrieve current config
             config = self.config or {}
             config_json = json.dumps(config, sort_keys=True, indent=4)
-            config_hash = hashlib.md5(config_json.encode()).hexdigest()
+            config_hash = hashlib.sha256(config_json.encode()).hexdigest()
 
             # Compare updated_config hash with current config hash
             if updated_config:
                 updated_config_json = json.dumps(updated_config, sort_keys=True, indent=4)
-                updated_config_hash = hashlib.md5(updated_config_json.encode()).hexdigest()
+                updated_config_hash = hashlib.sha256(updated_config_json.encode()).hexdigest()
 
                 if updated_config_hash != config_hash:
                     config_hash = updated_config_hash
@@ -236,7 +236,7 @@ class GCPKeyValueStorage(KeyValueStorage):
                 if config:
                     self.config = config
                     self.__save_config(config)
-                    self.last_saved_config_hash = hashlib.md5(
+                    self.last_saved_config_hash = hashlib.sha256(
                         json.dumps(config, sort_keys=True, indent=4).encode()
                     ).hexdigest()
             except Exception as err:
@@ -257,7 +257,7 @@ class GCPKeyValueStorage(KeyValueStorage):
                 try:
                     config = json.loads(config_json)
                     self.config = config or {}
-                    self.last_saved_config_hash = hashlib.md5(
+                    self.last_saved_config_hash = hashlib.sha256(
                         json.dumps(config, sort_keys=True, indent=4).encode()
                     ).hexdigest()
                 except Exception as err:

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/utils.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/utils.py
@@ -36,8 +36,8 @@ def encrypt_buffer(is_asymmetric, message, crypto_client, key_properties,encrypt
         # Generate a random 32-byte key
         key = get_random_bytes(32)
 
-        # Create AES-GCM cipher instance
-        cipher = AES.new(key, AES.MODE_GCM)
+        # Create AES-GCM cipher instance with 96-bit nonce (NIST SP 800-38D recommended)
+        cipher = AES.new(key, AES.MODE_GCM, nonce=get_random_bytes(12))
 
         # Encrypt the message
         ciphertext, tag = cipher.encrypt_and_digest(

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -1,10 +1,36 @@
 import json
+import logging
 import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+
+
+BLOB_HEADER = b"\xff\xff"
+
+
+def _parse_blob_parts(blob):
+    """Parse a KSM GCP KMS blob into its 4 length-prefixed parts: [enc_key, nonce, tag, ciphertext]."""
+    pos = 2  # skip BLOB_HEADER
+    parts = []
+    for _ in range(4):
+        part_len = int.from_bytes(blob[pos:pos + 2], "big")
+        pos += 2
+        parts.append(blob[pos:pos + part_len])
+        pos += part_len
+    return parts
+
+
+def _make_blob(encrypted_key, nonce, tag, ciphertext):
+    buf = bytearray(BLOB_HEADER)
+    for part in [encrypted_key, nonce, tag, ciphertext]:
+        buf.extend(len(part).to_bytes(2, "big"))
+        buf.extend(part)
+    return bytes(buf)
 
 
 def make_mock_session(client_mock):
@@ -56,3 +82,64 @@ class TestGetKeyDetailsFailure:
         assert config_path.read_bytes() == original_content, (
             "Config file was modified despite init failure — credentials may have been re-written in plaintext"
         )
+
+
+class TestNonce12Bytes:
+    """KSM-943 regression: encrypt_buffer must use a 96-bit (12-byte) nonce per NIST SP 800-38D."""
+
+    def test_encrypted_blob_contains_12_byte_nonce(self):
+        from keeper_secrets_manager_storage_gcp_kms.utils import encrypt_buffer
+
+        fake_enc_key = get_random_bytes(32)
+        logger = logging.getLogger("test")
+
+        with patch(
+            "keeper_secrets_manager_storage_gcp_kms.utils.encrypt_data_and_validate_crc",
+            return_value=fake_enc_key,
+        ):
+            blob = encrypt_buffer(
+                is_asymmetric=False,
+                message="ksm-config-test",
+                crypto_client=MagicMock(),
+                key_properties=MagicMock(),
+                encryption_algorithm=MagicMock(),
+                logger=logger,
+                token=None,
+            )
+
+        assert blob[:2] == BLOB_HEADER
+        parts = _parse_blob_parts(blob)
+        nonce = parts[1]
+        assert len(nonce) == 12, f"Expected 12-byte nonce (NIST SP 800-38D), got {len(nonce)}"
+
+
+class TestBackwardCompatNonce16:
+    """KSM-943: decrypt_buffer must still handle blobs encrypted with the old 16-byte nonce."""
+
+    def test_decrypt_buffer_handles_legacy_16_byte_nonce(self):
+        from keeper_secrets_manager_storage_gcp_kms.utils import decrypt_buffer
+
+        message = '{"clientId": "legacy-id"}'
+        aes_key = get_random_bytes(32)
+        nonce_16 = get_random_bytes(16)
+
+        cipher = AES.new(aes_key, AES.MODE_GCM, nonce=nonce_16)
+        ciphertext, tag = cipher.encrypt_and_digest(message.encode())
+
+        blob = _make_blob(get_random_bytes(32), nonce_16, tag, ciphertext)
+        logger = logging.getLogger("test")
+
+        with patch(
+            "keeper_secrets_manager_storage_gcp_kms.utils.decrypt_data_and_validate_crc",
+            return_value=aes_key,
+        ):
+            result = decrypt_buffer(
+                is_asymmetric=False,
+                ciphertext=blob,
+                crypto_client=MagicMock(),
+                key_properties=MagicMock(),
+                logger=logger,
+                token=None,
+            )
+
+        assert result == message


### PR DESCRIPTION
## Summary

- `utils.py:40`: switched AES-GCM nonce from PyCryptodome's 128-bit (16-byte) default to the NIST SP 800-38D recommended 96-bit (12-byte) value (`nonce=get_random_bytes(12)`)
- `storage_gcp_kms.py` (4 occurrences): replaced `hashlib.md5` with `hashlib.sha256` for the in-process config change-detection hash

**No migration needed.** The blob format stores the nonce with a 2-byte length prefix, so `decrypt_buffer` already passes the stored bytes directly to `AES.new(..., nonce=nonce)` regardless of length. Existing blobs with 16-byte nonces continue to decrypt correctly — confirmed by the `TestBackwardCompatNonce16` regression test.

## Breaking Changes

None.

## Test plan

- [x] `TestNonce12Bytes::test_encrypted_blob_contains_12_byte_nonce` — parses raw blob from `encrypt_buffer` and asserts nonce is exactly 12 bytes
- [x] `TestBackwardCompatNonce16::test_decrypt_buffer_handles_legacy_16_byte_nonce` — hand-crafts an old-format blob with a 16-byte nonce and verifies `decrypt_buffer` recovers the original plaintext
- [x] All 4 tests pass (`pytest tests/ -v`)

Jira: [KSM-943](https://keeper.atlassian.net/browse/KSM-943)

[KSM-943]: https://keeper.atlassian.net/browse/KSM-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ