### PR TITLE
fix(storage): fix read_storage() live ref and decrypt_config() plaintext-on-disk default (KSM-944)

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
@@ -83,6 +83,8 @@ Once setup, the Secrets Manager GCP KMS integration supports all Secrets Manager
 - Fixed silent failure when `cloudkms.cryptoKeys.get` is denied — `GCPKeyValueStorage` now raises on init instead of leaving the config file unencrypted on disk
 - Fixed AES-GCM nonce to 96-bit/12-byte per NIST SP 800-38D (was 128-bit/16-byte PyCryptodome default); existing encrypted blobs remain readable
 - Replaced MD5 with SHA-256 for config change detection
+- Fixed `read_storage()` returning a live dict reference — caller mutations no longer silently corrupt internal state without triggering encryption (KSM-944)
+- Fixed `decrypt_config()` default `autosave` from `True` to `False` — calling without arguments no longer writes plaintext credentials to disk (KSM-944)
 
 ### 1.0.1
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -117,7 +117,7 @@ class GCPKeyValueStorage(KeyValueStorage):
         except Exception as err:
             self.logger.error(f"Error creating config file: {err}")
             
-    def decrypt_config(self, autosave: bool = True) -> str:
+    def decrypt_config(self, autosave: bool = False) -> str:
         ciphertext : bytes = bytes()
         plaintext : str= ""
 
@@ -299,7 +299,7 @@ class GCPKeyValueStorage(KeyValueStorage):
     def read_storage(self) -> Dict[str, str]:
         if not self.config:
             self.load_config()
-        return self.config
+        return dict(self.config)
     
     def save_storage(self, updated_config: Dict[str, str]) -> None:
         self.__save_config(updated_config)

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -143,3 +143,79 @@ class TestBackwardCompatNonce16:
             )
 
         assert result == message
+
+
+def _make_storage_stub(config=None, config_file_location=None):
+    """Return a GCPKeyValueStorage instance with __init__ bypassed and state set directly."""
+    from keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms import GCPKeyValueStorage
+    from keeper_secrets_manager_storage_gcp_kms.constants import KeyPurpose
+    with patch.object(GCPKeyValueStorage, '__init__', return_value=None):
+        storage = GCPKeyValueStorage.__new__(GCPKeyValueStorage)
+    storage.config = config if config is not None else {}
+    storage.config_file_location = config_file_location or ""
+    storage.logger = logging.getLogger("test")
+    storage.is_asymmetric = False
+    storage.key_purpose_details = KeyPurpose.ENCRYPT_DECRYPT
+    storage.gcp_session_config = MagicMock()
+    storage.crypto_client = MagicMock()
+    storage.gcp_key_config = MagicMock()
+    return storage
+
+
+class TestReadStorageCopyIsolation:
+    """KSM-944: read_storage() must return a copy, not a live dict reference."""
+
+    def test_returned_dict_is_not_live_reference(self):
+        storage = _make_storage_stub(config={"clientId": "original", "appKey": "secret"})
+        result = storage.read_storage()
+        result["clientId"] = "hacked"
+        assert storage.config["clientId"] == "original", (
+            "read_storage() returned a live reference — caller mutation changed internal state"
+        )
+
+    def test_copy_contains_all_keys(self):
+        data = {"clientId": "test-id", "appKey": "key", "hostname": "host"}
+        storage = _make_storage_stub(config=data)
+        result = storage.read_storage()
+        assert result == data
+
+
+class TestDecryptConfigDefaultAutosaveFalse:
+    """KSM-944: decrypt_config() must not write plaintext to disk when called without arguments."""
+
+    def _write_fake_blob(self, path):
+        aes_key = get_random_bytes(32)
+        nonce = get_random_bytes(12)
+        cipher = AES.new(aes_key, AES.MODE_GCM, nonce=nonce)
+        ciphertext, tag = cipher.encrypt_and_digest(b"{}")
+        blob = _make_blob(get_random_bytes(32), nonce, tag, ciphertext)
+        path.write_bytes(blob)
+        return blob
+
+    def test_default_does_not_overwrite_file(self, tmp_path):
+        config_path = tmp_path / "ksm-config.json"
+        original_blob = self._write_fake_blob(config_path)
+
+        storage = _make_storage_stub(config_file_location=str(config_path))
+        plaintext = '{"clientId": "test-id"}'
+
+        with patch("keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.decrypt_buffer", return_value=plaintext):
+            result = storage.decrypt_config()
+
+        assert result == plaintext
+        assert config_path.read_bytes() == original_blob, (
+            "decrypt_config() with default args wrote plaintext to disk — credentials exposed"
+        )
+
+    def test_autosave_true_writes_plaintext(self, tmp_path):
+        config_path = tmp_path / "ksm-config.json"
+        self._write_fake_blob(config_path)
+
+        storage = _make_storage_stub(config_file_location=str(config_path))
+        plaintext = '{"clientId": "test-id"}'
+
+        with patch("keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.decrypt_buffer", return_value=plaintext):
+            result = storage.decrypt_config(autosave=True)
+
+        assert result == plaintext
+        assert config_path.read_text() == plaintext


### PR DESCRIPTION
## Summary

- `read_storage()` now returns `dict(self.config)` instead of a direct reference, so callers can no longer silently mutate internal state without triggering encryption or a disk write (KSM-944)
- `decrypt_config()` default changed from `autosave=True` to `autosave=False`, so calling without arguments no longer overwrites the encrypted config file with plaintext credentials on disk (KSM-944)
- Added four regression tests: two for the copy-isolation fix and two for the autosave default

## Breaking Changes

`decrypt_config()` behavior change: callers relying on the default writing plaintext to disk must now pass `autosave=True` explicitly. This was the insecure default — the change makes the safe path the default.

## Jira

[KSM-944](https://keeper.atlassian.net/browse/KSM-944)

## Test Plan

- [ ] `pytest tests/ -v` — all 8 tests pass (4 existing + 4 new)
- [ ] Verify `read_storage()` returns a copy: mutating the result does not affect `storage.config`
- [ ] Verify `decrypt_config()` without args leaves the encrypted file on disk untouched

[KSM-944]: https://keeper.atlassian.net/browse/KSM-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ