### PR TITLE
fix(storage): add RLock to prevent concurrent set()/save() races (KSM-946)

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
@@ -87,6 +87,7 @@ Once setup, the Secrets Manager GCP KMS integration supports all Secrets Manager
 - Fixed `decrypt_config()` default `autosave` from `True` to `False` — calling without arguments no longer writes plaintext credentials to disk (KSM-944)
 - Fixed `delete()` of the last config key silently lost — key remained in memory and on disk after deletion due to interaction between the copy-isolation fix and an empty-dict falsy-check in the save path
 - Fixed `key_version` silently ignored on symmetric decrypt — `client.decrypt()` now uses the version-pinned key name, preventing GCP silent fallback to the primary key version
+- Fixed thread-safety: added `threading.RLock` to `GCPKeyValueStorage` — concurrent `set()` / `delete()` calls no longer race on the config dict or the encrypt-and-write sequence (KSM-946)
 
 ### 1.0.1
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -13,6 +13,7 @@ import logging
 import os
 import hashlib
 import json
+import threading
 
 from typing import Optional,Dict
 
@@ -39,6 +40,7 @@ class GCPKeyValueStorage(KeyValueStorage):
     gcp_session_config: GCPKMSClientConfig
     is_asymmetric: bool = False
     key_purpose_details: Optional[str] = None
+    _lock: threading.RLock
     
     def __init__(self, key_vault_config_file_location: str , gcp_key_config: GCPKeyConfig, gcp_session_config: GCPKMSClientConfig, logger: Logger = None):
         self.config_file_location = os.path.abspath(key_vault_config_file_location) or os.getenv('KSM_CONFIG_FILE') or os.path.abspath(self.default_config_file_location)
@@ -47,7 +49,7 @@ class GCPKeyValueStorage(KeyValueStorage):
         self.gcp_session_config = gcp_session_config
         self.gcp_key_config = gcp_key_config
         self.crypto_client = self.gcp_session_config.get_crypto_client()
-        
+        self._lock = threading.RLock()
         self.last_saved_config_hash = ""
         self.get_key_details()
         self.load_config()
@@ -297,39 +299,43 @@ class GCPKeyValueStorage(KeyValueStorage):
         return True
     
     def read_storage(self) -> Dict[str, str]:
-        if not self.config:
-            self.load_config()
-        return dict(self.config)
-    
+        with self._lock:
+            if not self.config:
+                self.load_config()
+            return dict(self.config)
+
     def save_storage(self, updated_config: Dict[str, str]) -> None:
-        self.__save_config(updated_config)
-        
+        with self._lock:
+            self.__save_config(updated_config)
+
     def get(self, key: ConfigKeys) -> str:
         config = self.read_storage()
         return config.get(key.value)
-    
+
     def set(self, key: ConfigKeys, value):
-        config = self.read_storage()
-        config[key.value] = value
-        self.save_storage(config)
-        return config
+        with self._lock:
+            config = self.read_storage()
+            config[key.value] = value
+            self.save_storage(config)
+            return config
 
     def delete(self, key: ConfigKeys):
-        kv = key.value
-        if kv in self.config:
-            del self.config[kv]
-            self.logger.debug("Removed key %s" % kv)
-        else:
-            self.logger.debug("No key %s was found in config" % kv)
-
-        self.save_storage(self.config)
-        return dict(self.config)
+        with self._lock:
+            kv = key.value
+            if kv in self.config:
+                del self.config[kv]
+                self.logger.debug("Removed key %s" % kv)
+            else:
+                self.logger.debug("No key %s was found in config" % kv)
+            self.save_storage(self.config)
+            return dict(self.config)
 
     def delete_all(self):
-        self.read_storage()
-        self.config.clear()
-        self.save_storage(self.config)
-        return dict(self.config)
+        with self._lock:
+            self.read_storage()
+            self.config.clear()
+            self.save_storage(self.config)
+            return dict(self.config)
 
     def contains(self, key: ConfigKeys):
         config = self.read_storage()

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -148,6 +148,7 @@ class TestBackwardCompatNonce16:
 
 def _make_storage_stub(config=None, config_file_location=None):
     """Return a GCPKeyValueStorage instance with __init__ bypassed and state set directly."""
+    import threading
     from keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms import GCPKeyValueStorage
     from keeper_secrets_manager_storage_gcp_kms.constants import KeyPurpose
     with patch.object(GCPKeyValueStorage, '__init__', return_value=None):
@@ -161,6 +162,7 @@ def _make_storage_stub(config=None, config_file_location=None):
     storage.crypto_client = MagicMock()
     storage.gcp_key_config = MagicMock()
     storage.encryption_algorithm = MagicMock()
+    storage._lock = threading.RLock()
     return storage
 
 
@@ -292,3 +294,47 @@ class TestDeleteLastKeyPersists:
         assert storage.config == {}, (
             "delete() of the last config key left internal state non-empty — deletion was silently lost"
         )
+
+
+class TestConcurrentSet:
+    """KSM-946 regression: concurrent set() calls must not raise or corrupt internal state."""
+
+    def test_concurrent_set_no_data_loss(self, tmp_path):
+        import threading
+        from keeper_secrets_manager_core.configkeys import ConfigKeys
+
+        config_path = tmp_path / "ksm-config.json"
+        config_path.write_bytes(b"placeholder")
+
+        storage = _make_storage_stub(
+            config={"clientId": "initial"},
+            config_file_location=str(config_path),
+        )
+        storage.last_saved_config_hash = ""
+
+        errors = []
+
+        with patch(
+            "keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.encrypt_buffer",
+            return_value=b"fake-blob",
+        ), patch.object(storage, "create_config_file_if_missing"):
+            barrier = threading.Barrier(2)
+
+            def writer(value):
+                try:
+                    barrier.wait()
+                    for _ in range(200):
+                        storage.set(ConfigKeys.KEY_CLIENT_ID, value)
+                except Exception as e:
+                    errors.append(e)
+
+            t1 = threading.Thread(target=writer, args=("value_A",))
+            t2 = threading.Thread(target=writer, args=("value_B",))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+        assert not errors, f"Concurrent set() raised: {errors}"
+        final = storage.config.get("clientId")
+        assert final in ("value_A", "value_B"), f"Config corrupted: {storage.config}"


### PR DESCRIPTION
## Summary

`GCPKeyValueStorage` had no threading primitives. `set()` split its work into two separate method calls — `read_storage()` then `save_storage()` — with no lock held across the pair. Two threads calling `set()` concurrently would both read the same stale config, apply their write to their own copy, and the last writer would silently discard the first's change. `delete()` and `delete_all()` had the same TOCTOU pattern. SecretsManager's token refresh can trigger this without the caller explicitly doing anything concurrent.

- Added `threading.RLock` (`self._lock`) initialized in `__init__`
- `read_storage()` and `save_storage()` each acquire the lock individually
- `set()`, `delete()`, and `delete_all()` wrap their full read-modify-write cycle under the lock, making the compound operation atomic
- `RLock` (reentrant) is required because `set()` holds the lock while calling `read_storage()` / `save_storage()`, which also acquire it
- `fcntl.flock` cross-process safety is noted in the ticket as "consider" — deferred to a future ticket
- Updated `_make_storage_stub` test helper to initialize `_lock` since it bypasses `__init__`

Fixes [KSM-946](https://keeper.atlassian.net/browse/KSM-946).

## Breaking Changes

None.

## Test plan

- [ ] `pytest sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/ -v` — all 11 tests pass including new `TestConcurrentSet::test_concurrent_set_no_data_loss`
- [ ] `TestConcurrentSet` runs 400 concurrent `set()` iterations across two threads and asserts no exceptions and a consistent final state

[KSM-946]: https://keeper.atlassian.net/browse/KSM-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ