### PR TITLE
fix(storage): delete_all() removes config file instead of re-encrypting (KSM-940)

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -341,9 +341,10 @@ class GCPKeyValueStorage(KeyValueStorage):
 
     def delete_all(self):
         with self._lock:
-            self.read_storage()
+            if os.path.exists(self.config_file_location):
+                os.remove(self.config_file_location)
             self.config.clear()
-            self.save_storage(self.config)
+            self.last_saved_config_hash = ""
             return dict(self.config)
 
     def contains(self, key: ConfigKeys):

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -451,3 +451,50 @@ class TestEncryptBufferPropagatesKMSError:
         ), patch.object(storage, "create_config_file_if_missing"):
             with pytest.raises(Exception, match="KMS unavailable"):
                 storage.set(ConfigKeys.KEY_CLIENT_ID, "new-value")
+
+
+class TestDeleteAllWipesDisk:
+    """KSM-940 regression: delete_all() must remove the config file from disk so no credential
+    bytes remain readable; file removal happens before clearing in-memory state so a failed
+    os.remove() does not leave both sides inconsistent.
+    """
+
+    def test_delete_all_removes_config_file(self, tmp_path):
+        config_path = tmp_path / "ksm-config.json"
+        config_path.write_bytes(b"fake-encrypted-credentials-blob")
+
+        storage = _make_storage_stub(
+            config={"clientId": "test-id", "appKey": "secret"},
+            config_file_location=str(config_path),
+        )
+
+        storage.delete_all()
+
+        assert not config_path.exists(), (
+            "delete_all() left the config file on disk — credentials may still be readable"
+        )
+        assert storage.config == {}
+
+    def test_delete_all_removes_file_before_clearing_memory(self, tmp_path):
+        """os.remove() must run before self.config.clear() so that a failed remove cannot
+        self-heal via read_storage() re-loading credentials from the untouched file."""
+        config_path = tmp_path / "ksm-config.json"
+        config_path.write_bytes(b"fake-encrypted-credentials-blob")
+
+        storage = _make_storage_stub(
+            config={"clientId": "test-id", "appKey": "secret"},
+            config_file_location=str(config_path),
+        )
+
+        config_at_remove_time = {}
+
+        def recording_remove(path):
+            config_at_remove_time.update(storage.config)
+
+        with patch("keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.os.remove", side_effect=recording_remove), \
+             patch("keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.os.path.exists", return_value=True):
+            storage.delete_all()
+
+        assert config_at_remove_time == {"clientId": "test-id", "appKey": "secret"}, (
+            "os.remove() ran after config.clear() — config was already empty at removal time"
+        )


### PR DESCRIPTION
## Summary

`delete_all()` previously called `save_storage({})` which needed KMS to encrypt a replacement file. If KMS was unavailable the call raised and the original credential file was left untouched on disk. This replaces that with a direct `os.remove()` so credentials are wiped regardless of KMS availability.

## Changes

### Fixed
- **delete_all() wipes disk** (KSM-940): config file is now removed directly; `last_saved_config_hash` is reset so the next write creates a fresh encrypted file via `create_config_file_if_missing()`

## Testing

```bash
cd sdk/python/storage/keeper_secrets_manager_storage_gcp_kms
python -m pytest tests/test_storage_gcp_kms.py::TestDeleteAllWipesDisk -v
# full suite
python -m pytest tests/ -v
```

## Breaking Changes

None.

## Related Issues

- Jira: [KSM-940](https://keeper.atlassian.net/browse/KSM-940)
- Part of release PR [#964](https://github.com/Keeper-Security/secrets-manager/pull/964)

[KSM-940]: https://keeper.atlassian.net/browse/KSM-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ