### PR TITLE
fix(gcp-kms-storage): KSM-947 housekeeping — drop dead MD5_HASH; gate publish on matrix tests; isolated build

### DIFF
--- a/.github/workflows/publish.pypi.sdk.storage.gcp.kms.yml
+++ b/.github/workflows/publish.pypi.sdk.storage.gcp.kms.yml
@@ -29,6 +29,35 @@ jobs:
           echo "Version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    needs: get-versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: ./sdk/python/storage/keeper_secrets_manager_storage_gcp_kms
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt pytest pytest-cov
+          python3 -m pip install -e .
+
+      - name: Run tests
+        run: pytest tests/
+
   validate-versions:
     name: Validate version not yet published
     needs: get-versions
@@ -111,7 +140,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [generate-sbom, validate-versions, get-versions]
+    needs: [test, generate-sbom, validate-versions, get-versions]
     if: ${{ github.event.inputs.publish == 'true' }}
     environment: prod
     runs-on: ubuntu-latest
@@ -132,13 +161,12 @@ jobs:
 
       - name: Install build tools
         run: |
-          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade pip
           python3 -m pip install build 'wheel>=0.46.3'  # wheel pin: CVE-2026-24049
-          python3 -m pip install 'setuptools_scm[toml]>=6.2'  # required by pyproject.toml build-system
 
       - name: Build
         working-directory: ./sdk/python/storage/keeper_secrets_manager_storage_gcp_kms
-        run: python3 -m build --no-isolation
+        run: python3 -m build
 
       - name: Verify import
         working-directory: ./sdk/python/storage/keeper_secrets_manager_storage_gcp_kms

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/constants.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/constants.py
@@ -38,7 +38,6 @@ BLOB_HEADER = b"\xff\xff"  # Encrypted BLOB Header: U+FFFF is a non-character
 LATIN1_ENCODING = "latin1"
 UTF_8_ENCODING = "utf-8"
 AES_256_GCM = "aes-256-gcm"
-MD5_HASH = "md5"
 HEX_DIGEST = "hex"
 DEFAULT_JSON_INDENT = 4
 OAEP_PADDING = padding.OAEP(


### PR DESCRIPTION
## Summary

Three pre-release housekeeping items on `release/storage/python/gcp-kms/v1.1.0` (KSM-947).

### Item 1 — Dead `MD5_HASH` constant
Removed from `constants.py`. KSM-943 replaced MD5 with SHA-256 in `__save_config()` but left the constant behind. Verified zero callers across the package.

### Item 2 — Publish workflow had no test gate
The existing `test.python.storage.gcp.kms.yml` runs the 3.9/3.10/3.11/3.12/3.13 matrix on push/PR, but the publish workflow itself had no dependency on test results — a `workflow_dispatch` run on a red commit could ship. Added a `test` job inside the publish workflow (same matrix, mirrors the test workflow) and gated `publish` on it via `needs: [test, generate-sbom, validate-versions, get-versions]`. Aligns with [PyPA's recommended `needs: [test]` pattern](https://github.com/pypa/gh-action-pypi-publish) for `gh-action-pypi-publish`.

The `test` job runs unconditionally so `publish=false` SBOM-only dry-runs still exercise the matrix.

### Item 3 — Vestigial `--no-isolation` + stale `setuptools_scm` install
Removed both. `setuptools_scm` was dropped from `pyproject.toml` `[build-system].requires` in commit e42564b during the v1.1.0 hardening sweep, so the flag was no longer protecting anything. Build now runs in PEP 517 isolation with just `setuptools>=45` and `wheel` per `build-system.requires` — matches the sibling Oracle KMS publish workflow.

## Test plan

- [x] `pytest tests/` → 20 passed (Python 3.13 local)
- [x] `python -m build` (isolated, no flags) → wheel + sdist produced; wheel installs and `from keeper_secrets_manager_storage_gcp_kms import GCPKeyValueStorage` succeeds
- [x] `actionlint` clean
- [x] `zizmor` unchanged from baseline — pre-existing `secrets-outside-env` on `workflow_dispatch` (acceptable per policy)
- [ ] CI: `test.python.storage.gcp.kms.yml` matrix green on PR push
- [ ] Manual: trigger the publish workflow with `publish=false` after merge to release branch to verify the new in-workflow matrix gate

## Follow-up

The same `needs: [test]` matrix gate is missing from the other 3 Keeper PyPI publish workflows (`publish.pypi.sdk.yml`, `publish.pypi.sdk.storage.yml`, `publish.pypi.sdk.storage.oracle.kms.yml`). They will get the same pattern as each respective release branch is touched (Python storage package up next).

## Breaking Changes

None.