### PR TITLE
KSM-948: fix load_config() leaving self.config = None after empty-dict bootstrap

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/README.md
@@ -97,6 +97,7 @@ Once setup, the Secrets Manager GCP KMS integration supports all Secrets Manager
 - `change_key()` rolls back cleanly on failure; a failed rotation no longer leaves the storage in an inconsistent state
 - `GCPKeyValueStorage` is now thread-safe for concurrent `set()`, `delete()`, `change_key()`, and `decrypt_config()` calls (KSM-946)
 - `key_version` on `GCPKeyConfig` applies only to encrypt and asymmetric operations; symmetric `client.decrypt` uses the unversioned CryptoKey name as required by the GCP API (the server selects the version from the ciphertext envelope)
+- `load_config()` now always leaves `self.config` as a dict (never `None`) after parsing a plaintext `{}` bootstrap config; previously every subsequent `read`/`set`/`delete` crashed with `TypeError: 'NoneType' object is not iterable` (KSM-948)
 
 ### 1.0.1
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/keeper_secrets_manager_storage_gcp_kms/storage_gcp_kms.py
@@ -240,13 +240,16 @@ class GCPKeyValueStorage(KeyValueStorage):
             try:
                 config_data = contents.decode()
                 config = json.loads(config_data)
-                # Encrypt and save the config if it's plain JSON
+                # `{}` is a legitimate empty state from the documented fresh-install
+                # bootstrap, so self.config must be assigned even when the parsed dict
+                # is empty — leaving it as None crashes every subsequent read/set/delete.
+                self.config = config
+                # Re-encrypt any plaintext content to migrate a legacy on-disk config.
                 if config:
-                    self.config = config
                     self.__save_config(config)
-                    self.last_saved_config_hash = hashlib.sha256(
-                        json.dumps(config, sort_keys=True, indent=4).encode()
-                    ).hexdigest()
+                self.last_saved_config_hash = hashlib.sha256(
+                    json.dumps(config, sort_keys=True, indent=4).encode()
+                ).hexdigest()
             except (json.JSONDecodeError, UnicodeDecodeError) as err:
                 json_error = err
 

--- a/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storage_gcp_kms/tests/test_storage_gcp_kms.py
@@ -595,3 +595,40 @@ class TestSetRaisesOnReadOnlyFile:
                     storage.set(ConfigKeys.KEY_CLIENT_ID, "new-value")
         finally:
             config_path.chmod(0o644)
+
+
+class TestLoadConfigEmptyDictBootstrap:
+    """KSM-948 regression: load_config() must leave self.config as a dict (never None)
+    when the on-disk file's parsed JSON is an empty dict — the documented fresh-install
+    bootstrap pattern from the README."""
+
+    def test_init_with_plaintext_empty_dict_file_leaves_config_as_dict(self, tmp_path):
+        from keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms import GCPKeyValueStorage
+        from keeper_secrets_manager_storage_gcp_kms.constants import KeyPurpose
+        from keeper_secrets_manager_core.configkeys import ConfigKeys
+
+        config_path = tmp_path / "ksm-config.json"
+        config_path.write_bytes(b"{}")
+
+        key_obj = MagicMock()
+        key_obj.purpose = KeyPurpose.ENCRYPT_DECRYPT
+        key_obj.version_template.algorithm = MagicMock()
+        client_mock = MagicMock()
+        client_mock.get_crypto_key.return_value = key_obj
+        session_mock = make_mock_session(client_mock)
+        key_cfg = make_key_config()
+
+        with patch(
+            "keeper_secrets_manager_storage_gcp_kms.storage_gcp_kms.encrypt_buffer",
+            return_value=b"fake-blob",
+        ):
+            storage = GCPKeyValueStorage(str(config_path), key_cfg, session_mock)
+
+            assert storage.config == {}, (
+                "KSM-948: load_config() left self.config as None after empty-dict bootstrap"
+            )
+
+            # Subsequent operations must not crash on dict(None).
+            storage.set(ConfigKeys.KEY_CLIENT_ID, "abc")
+
+        assert storage.config[ConfigKeys.KEY_CLIENT_ID.value] == "abc"


### PR DESCRIPTION
## Summary
- Fix `load_config()` so `self.config` is always a dict after the call, never `None`.
- Regression introduced by 61bea48 when the class-level default flipped from `{}` to `None`.
- Restores the documented fresh-install bootstrap from a plaintext `{}` config file.

## Root cause
Commit 61bea48 changed `self.config`'s class-level default to `None` to prevent a spurious reload after `delete_all()`, but `load_config()` was not updated in lockstep. When the parsed JSON is an empty dict, the `if config:` branch is skipped and `self.config` is never assigned. Every subsequent `read_storage()` / `set()` / `delete()` / `contains()` then crashes with `TypeError: 'NoneType' object is not iterable` — and the README documents creating the config file as plaintext `{}`, so this broke the most common new-user path.

## Fix
- `load_config()`: assign `self.config = config` and update `last_saved_config_hash` unconditionally after JSON parse succeeds. Only call `__save_config()` when the dict is non-empty (the branch exists to migrate legacy plaintext content; an empty dict has nothing to migrate, and `create_config_file_if_missing()` already wrote an encrypted `{}` blob).
- Comment added to mark `{}` as a legitimate empty state and explain why `self.config` must always be a dict.

## Tests
- New `TestLoadConfigEmptyDictBootstrap` regression test in `tests/test_storage_gcp_kms.py`. Fails before the fix (`AssertionError: assert None == {}`), passes after.
- Full storage-package pytest suite passes (21/21).

## Documentation
- README change log updated under 1.1.0 Bug fixes with a bullet for KSM-948.

## Breaking Changes
None.

## Related Issues
- Jira: [KSM-948](https://keeper.atlassian.net/browse/KSM-948)

[KSM-948]: https://keeper.atlassian.net/browse/KSM-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ