### PR TITLE
KSM-901: JavaScript IL5 dynamic server public key support

### DIFF
--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -7,6 +7,7 @@ export {KeyValueStorage} from './platform'
 let packageVersion = '[VI]{version}[/VI]'
 const KEY_HOSTNAME = 'hostname' // base url for the Secrets Manager service
 const KEY_SERVER_PUBLIC_KEY_ID = 'serverPublicKeyId'
+const KEY_SERVER_PUBLIC_KEY = 'serverPublicKey'
 const KEY_CLIENT_ID = 'clientId'
 const KEY_CLIENT_KEY = 'clientKey' // The key that is used to identify the client before public key
 const KEY_APP_KEY = 'appKey' // The application key with which all secrets are encrypted
@@ -44,6 +45,7 @@ export type SecretManagerOptions = {
     storage: KeyValueStorage
     queryFunction?: (url: string, transmissionKey: TransmissionKey, payload: EncryptedPayload, allowUnverifiedCertificate?: boolean) => Promise<KeeperHttpResponse>
     allowUnverifiedCertificate?: boolean
+    serverPublicKey?: string
 }
 
 export type QueryOptions = {
@@ -502,6 +504,12 @@ export const generateTransmissionKey = async (storage: KeyValueStorage): Promise
     const transmissionKey = platform.getRandomBytes(32)
     const keyNumberString = await storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
     const keyNumber = keyNumberString ? Number(keyNumberString) : 7
+    const customPublicKeyB64 = await storage.getString(KEY_SERVER_PUBLIC_KEY)
+    if (customPublicKeyB64) {
+        const customPublicKey = webSafe64ToBytes(customPublicKeyB64)
+        const encryptedKey = await platform.publicEncrypt(transmissionKey, customPublicKey)
+        return { publicKeyId: keyNumber, key: transmissionKey, encryptedKey }
+    }
     const keeperPublicKey = keeperPublicKeys[keyNumber]
     if (!keeperPublicKey) {
         throw new Error(`Key number ${keyNumber} is not supported`)
@@ -524,6 +532,9 @@ const encryptAndSignPayload = async (storage: KeyValueStorage, transmissionKey: 
     return {payload: encryptedPayload, signature}
 }
 const postQuery = async (options: SecretManagerOptions, path: string, payload: AnyPayload): Promise<Uint8Array> => {
+    if (options.serverPublicKey) {
+        await options.storage.saveString(KEY_SERVER_PUBLIC_KEY, options.serverPublicKey)
+    }
     const hostName = await options.storage.getString(KEY_HOSTNAME)
     if (!hostName) {
         throw new Error('hostname is missing from the configuration')
@@ -591,6 +602,9 @@ const decryptRecord = async (record: SecretsManagerResponseRecord, storage?: Key
 
 const fetchAndDecryptSecrets = async (options: SecretManagerOptions, queryOptions?: QueryOptions): Promise<{ secrets: KeeperSecrets, justBound: boolean }> => {
     const storage = options.storage
+    if (options.serverPublicKey) {
+        await storage.saveString(KEY_SERVER_PUBLIC_KEY, options.serverPublicKey)
+    }
     const payload = await prepareGetPayload(storage, queryOptions)
     const responseData = await postQuery(options, 'get_secret', payload)
     const response = JSON.parse(platform.bytesToString(responseData)) as SecretsManagerResponse
@@ -731,6 +745,9 @@ export const initializeStorage = async (
             host = tokenParts[0]
         }
         clientKey = tokenParts[1]
+        if (tokenParts.length >= 3) {
+            await storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[2])
+        }
     }
     const clientKeyBytes = webSafe64ToBytes(clientKey)
     const clientKeyHash = await platform.hash(clientKeyBytes, CLIENT_ID_HASH_TAG)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -46,6 +46,7 @@ export type SecretManagerOptions = {
     queryFunction?: (url: string, transmissionKey: TransmissionKey, payload: EncryptedPayload, allowUnverifiedCertificate?: boolean) => Promise<KeeperHttpResponse>
     allowUnverifiedCertificate?: boolean
     serverPublicKey?: string
+    serverPublicKeyId?: string
 }
 
 export type QueryOptions = {
@@ -551,8 +552,11 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                 try {
                     const errorObj: KeeperError = JSON.parse(errorMessage)
                     if (errorObj.error === 'key') {
-                        await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, errorObj.key_id!.toString())
-                        continue
+                        const customKey = await options.storage.getString(KEY_SERVER_PUBLIC_KEY)
+                        if (!customKey) {
+                            await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, errorObj.key_id!.toString())
+                            continue
+                        }
                     }
                 } catch {
                 }
@@ -604,6 +608,9 @@ const fetchAndDecryptSecrets = async (options: SecretManagerOptions, queryOption
     const storage = options.storage
     if (options.serverPublicKey) {
         await storage.saveString(KEY_SERVER_PUBLIC_KEY, options.serverPublicKey)
+    }
+    if (options.serverPublicKeyId) {
+        await storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, options.serverPublicKeyId)
     }
     const payload = await prepareGetPayload(storage, queryOptions)
     const responseData = await postQuery(options, 'get_secret', payload)
@@ -745,8 +752,9 @@ export const initializeStorage = async (
             host = tokenParts[0]
         }
         clientKey = tokenParts[1]
-        if (tokenParts.length >= 3) {
-            await storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[2])
+        if (tokenParts[0].toUpperCase() === 'IL5' && tokenParts.length === 4) {
+            await storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, tokenParts[2])
+            await storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
         }
     }
     const clientKeyBytes = webSafe64ToBytes(clientKey)

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -263,20 +263,29 @@ test('IL5 dynamic key - Layer 1: generateTransmissionKey uses serverPublicKey fr
     expect(transmissionKey.key.length).toBe(32)
 })
 
-test('IL5 dynamic key - Layer 2: initializeStorage saves serverPublicKey from OTT third segment', async () => {
+test('IL5 dynamic key - Layer 2: initializeStorage saves serverPublicKeyId and serverPublicKey from 4-segment IL5 OTT', async () => {
     const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
     const storage = inMemoryStorage({})
-    await initializeStorage(storage, `IL5:ONE_TIME_TOKEN:${fakeKey}`)
+    await initializeStorage(storage, `IL5:ONE_TIME_TOKEN:20:${fakeKey}`)
     expect(await storage.getString('hostname')).toBe('il5.keepersecurity.us')
+    expect(await storage.getString('serverPublicKeyId')).toBe('20')
     expect(await storage.getString('serverPublicKey')).toBe(fakeKey)
 })
 
-test('IL5 dynamic key - Layer 3: getSecrets writes serverPublicKey from options to storage', async () => {
+test('IL5 dynamic key - Layer 2: initializeStorage ignores extra segments for non-IL5 regions', async () => {
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, 'US:ONE_TIME_TOKEN:garbage:garbage2')
+    expect(await storage.getString('hostname')).toBe('keepersecurity.com')
+    expect(await storage.getString('serverPublicKey')).toBeUndefined()
+})
+
+test('IL5 dynamic key - Layer 3: getSecrets writes serverPublicKey and serverPublicKeyId from options to storage', async () => {
     const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
     const storage = inMemoryStorage({})
     const options: SecretManagerOptions = {
         storage,
         serverPublicKey: fakeKey,
+        serverPublicKeyId: '20',
         queryFunction: async () => ({ statusCode: 200, data: new Uint8Array(0), headers: [] })
     }
     try {
@@ -285,4 +294,29 @@ test('IL5 dynamic key - Layer 3: getSecrets writes serverPublicKey from options 
         // expected — storage is not fully initialized; we only care that serverPublicKey was written
     }
     expect(await storage.getString('serverPublicKey')).toBe(fakeKey)
+    expect(await storage.getString('serverPublicKeyId')).toBe('20')
+})
+
+test('IL5 dynamic key - rotation suppression: server key_id hint ignored when serverPublicKey is in storage', async () => {
+    const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
+    const storage = inMemoryStorage({
+        hostname: 'il5.keepersecurity.us',
+        serverPublicKey: fakeKey,
+        serverPublicKeyId: '20'
+    })
+    const keyError = JSON.stringify({ error: 'key', key_id: 7 })
+    const options: SecretManagerOptions = {
+        storage,
+        queryFunction: async () => ({
+            statusCode: 400,
+            data: new TextEncoder().encode(keyError),
+            headers: []
+        })
+    }
+    try {
+        await getSecrets(options)
+    } catch {
+        // expected error — we care that serverPublicKeyId was NOT overwritten
+    }
+    expect(await storage.getString('serverPublicKeyId')).toBe('20')
 })

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -2,6 +2,7 @@ import {
     KeeperHttpResponse,
     getSecrets,
     initializeStorage,
+    generateTransmissionKey,
     platform,
     localConfigStorage, SecretManagerOptions, inMemoryStorage, loadJsonConfig, getTotpCode, generatePassword
 } from '../'
@@ -248,4 +249,40 @@ test('GeneratePassword', async () => {
     expect(password).not.toBeNull()
     expect(password.length).toBe(32)
     expect(/^["!@#$%()+;<>=?[\]{}^.,]{32}$/.test(password)).toBe(true)
+})
+
+test('IL5 dynamic key - Layer 1: generateTransmissionKey uses serverPublicKey from storage', async () => {
+    const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
+    const storage = inMemoryStorage({
+        serverPublicKey: fakeKey,
+        serverPublicKeyId: '20'
+    })
+    platform.getRandomBytes = () => new Uint8Array(32)
+    const transmissionKey = await generateTransmissionKey(storage)
+    expect(transmissionKey.publicKeyId).toBe(20)
+    expect(transmissionKey.key.length).toBe(32)
+})
+
+test('IL5 dynamic key - Layer 2: initializeStorage saves serverPublicKey from OTT third segment', async () => {
+    const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, `IL5:ONE_TIME_TOKEN:${fakeKey}`)
+    expect(await storage.getString('hostname')).toBe('il5.keepersecurity.us')
+    expect(await storage.getString('serverPublicKey')).toBe(fakeKey)
+})
+
+test('IL5 dynamic key - Layer 3: getSecrets writes serverPublicKey from options to storage', async () => {
+    const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
+    const storage = inMemoryStorage({})
+    const options: SecretManagerOptions = {
+        storage,
+        serverPublicKey: fakeKey,
+        queryFunction: async () => ({ statusCode: 200, data: new Uint8Array(0), headers: [] })
+    }
+    try {
+        await getSecrets(options)
+    } catch {
+        // expected — storage is not fully initialized; we only care that serverPublicKey was written
+    }
+    expect(await storage.getString('serverPublicKey')).toBe(fakeKey)
 })


### PR DESCRIPTION
## Summary

Adds dynamic server public key injection for IL5 ([KSM-901](https://keeper.atlassian.net/browse/KSM-901)), so IL5 customers can supply key ID 20 without embedding it in the shipped SDK. Builds on the IL5 region hostname mapping merged in #998.

Three complementary layers (all three required):

- **Layer 1 — config field**: when `serverPublicKey` is present in storage, the transmission key code uses those bytes instead of the embedded table.
- **Layer 2 — extended one-time token**: OTT parser handles a 4-segment IL5 token (`IL5:clientKey:keyId:pubKey`), saving both `serverPublicKeyId` and `serverPublicKey` on bind. Non-IL5 region tokens are unchanged.
- **Layer 3 — constructor param**: `SecretManagerOptions` accepts `serverPublicKey` (and `serverPublicKeyId`), persisted on first use.

Rotation suppression: when `serverPublicKey` is in storage (override mode), server-pushed `key_id` rotation hints are ignored to prevent bricking an IL5 client that's been configured with a custom key.

16 unit tests pass, including non-IL5 isolation and rotation suppression. E2E verified against IL5 (2026-05-15) — connects and pulls secrets end-to-end.

## Breaking Changes

None. Default behaviour is unchanged; the new field/param/token format are opt-in.

## Test plan

- [ ] CI green (`packages/core` test suite)
- [ ] QA against IL5 keeperapp/connections (week of 2026-05-18)

[KSM-901]: https://keeper.atlassian.net/browse/KSM-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ