### PR TITLE
KSM-932: Python SDK v17.2.2 follow-up — LICENSE, Python 3.9 guard, parser hardening, docs

### DIFF
--- a/integration/keeper_secrets_manager_cli/LICENSE
+++ b/integration/keeper_secrets_manager_cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Keeper Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/python/core/LICENSE.txt
+++ b/sdk/python/core/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Keeper Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -4,6 +4,33 @@ For more information see our official documentation page https://docs.keeper.io/
 
 **Python Requirements**: Python 3.9 or higher
 
+## Custom Server Public Key (Isolated Deployments)
+
+For deployments where the server public key is not shipped with the SDK,
+a caller-supplied EC P-256 public key can be supplied via any of three
+paths (precedence is programmatic > one-time token > pre-existing config):
+
+```python
+from keeper_secrets_manager_core import SecretsManager
+from keeper_secrets_manager_core.storage import FileKeyValueStorage
+
+# Programmatic — wins over the other two if all are present
+sm = SecretsManager(
+    token='REGION:ONE_TIME_TOKEN',
+    server_public_key='url-safe-base64-EC-P256-public-key',
+    server_public_key_id='your-key-id',
+    config=FileKeyValueStorage(),
+)
+```
+
+The one-time-token form embeds the key material directly:
+`REGION:clientKey:keyId:serverPublicKeyBase64` (4 colon-separated
+segments). The config-file form sets `serverPublicKey` and
+`serverPublicKeyId` in the JSON config before the first call.
+
+For deployment-specific details (region prefixes, key id assignments)
+see the official docs link above.
+
 # Change Log
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -89,11 +89,31 @@ class SecretsManager:
                  server_public_key=None,
                  server_public_key_id=None,
                  ):
+        """Construct a SecretsManager client.
 
-        # Make sure the Python is 3.6 or higher. We'll handle Python 4 in the future :)
+        Custom-server-key parameters (KSM-932) — both optional, intended for
+        isolated deployments where the server public key is not shipped with
+        the SDK. Unused for standard Keeper deployments.
+
+        :param server_public_key: Url-safe base64 of an EC P-256 public key
+            to override the SDK's built-in server public key table. When
+            provided, this key is persisted to config under
+            ``serverPublicKey`` and used for all subsequent transmission-key
+            encryption.
+        :param server_public_key_id: Optional public key id to pair with
+            ``server_public_key``. Persisted to config under
+            ``serverPublicKeyId``. If omitted, an existing value in config
+            is preserved.
+
+        Precedence when multiple provisioning paths supply a custom key:
+        programmatic params (this constructor) > one-time-token segments
+        > pre-existing config file values.
+        """
+
+        # Make sure the Python is 3.9 or higher. We'll handle Python 4 in the future :)
         python_version = sys.version_info
-        if python_version.major < 3 or (python_version.major == 3 and python_version.minor < 6):
-            raise Exception("KSM SDK requires Python 3.6 or greater")
+        if python_version.major < 3 or (python_version.major == 3 and python_version.minor < 9):
+            raise Exception("KSM SDK requires Python 3.9 or greater")
 
         self.token = None
         self.hostname = None
@@ -128,7 +148,19 @@ class SecretsManager:
 
                 # Layer 2: IL5 OTT carries embedded key material as extra segments
                 # Format: IL5:[clientKey]:[keyId]:[serverPublicKeyBase64]
-                if token_parts[0].upper() == 'IL5' and len(token_parts) == 4:
+                if token_parts[0].upper() == 'IL5' and len(token_parts) > 2:
+                    if len(token_parts) != 4:
+                        raise ValueError(
+                            "Malformed IL5 one-time token: expected exactly 4 segments "
+                            "'IL5:clientKey:keyId:serverPublicKeyBase64', got {}".format(len(token_parts)))
+                    if not token_parts[2] or not token_parts[3]:
+                        raise ValueError(
+                            "Malformed IL5 one-time token: keyId and serverPublicKey segments must be non-empty")
+                    try:
+                        url_safe_str_to_bytes(token_parts[3])
+                    except Exception:
+                        raise ValueError(
+                            "Malformed IL5 one-time token: serverPublicKey segment is not valid url-safe base64")
                     self._il5_key_id = token_parts[2]
                     self._il5_server_public_key = token_parts[3]
 
@@ -308,6 +340,18 @@ class SecretsManager:
 
     @staticmethod
     def generate_transmission_key(key_id, custom_public_key_b64=None):
+        """Generate a per-request transmission key wrapped with the server public key.
+
+        :param key_id: Public key id used to look up the wrapping key in the
+            built-in ``keeper_public_keys`` registry. When
+            ``custom_public_key_b64`` is provided, ``key_id`` is treated as
+            opaque metadata and not looked up.
+        :param custom_public_key_b64: Optional url-safe base64 of an EC P-256
+            public key (KSM-932). When supplied, this key wraps the
+            transmission key instead of the built-in registry — supports
+            isolated deployments where the server public key is not shipped
+            with the SDK.
+        """
         transmission_key = utils.generate_random_bytes(32)
 
         if custom_public_key_b64:

--- a/sdk/python/core/tests/il5_test.py
+++ b/sdk/python/core/tests/il5_test.py
@@ -10,13 +10,18 @@ from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
 
 class IL5DynamicKeyTest(unittest.TestCase):
 
+    # Synthetic key id that is not in the built-in keeper_public_keys registry —
+    # used throughout these tests as the "custom" key id without referencing
+    # any specific deployment's id.
+    CUSTOM_KEY_ID = '99'
+
     def test_layer1_generate_transmission_key_uses_custom_key(self):
         """Layer 1: generate_transmission_key uses custom key bytes instead of the hardcoded map."""
         custom_key_b64 = keeper_public_keys['7']  # borrow a real key's bytes as the "custom" key
 
         with patch('keeper_secrets_manager_core.core.CryptoUtils.public_encrypt') as mock_encrypt:
             mock_encrypt.return_value = b'fake_encrypted'
-            SecretsManager.generate_transmission_key('20', custom_key_b64)
+            SecretsManager.generate_transmission_key(self.CUSTOM_KEY_ID, custom_key_b64)
 
         mock_encrypt.assert_called_once()
         # First arg to public_encrypt is the transmission key bytes; second is the server public key bytes
@@ -27,7 +32,7 @@ class IL5DynamicKeyTest(unittest.TestCase):
     def test_layer1_generate_transmission_key_raises_without_custom_key(self):
         """Layer 1: unknown key_id with no custom key still raises ValueError."""
         with self.assertRaises(ValueError):
-            SecretsManager.generate_transmission_key('20')
+            SecretsManager.generate_transmission_key(self.CUSTOM_KEY_ID)
 
     def test_layer2_ott_4segment_writes_key_material_to_config(self):
         """Layer 2: 4-segment IL5 OTT writes key_id and server public key into config at init time."""
@@ -35,12 +40,12 @@ class IL5DynamicKeyTest(unittest.TestCase):
         config = InMemoryKeyValueStorage()
 
         # IL5:[clientKey]:[keyId]:[serverPublicKeyBase64]
-        il5_token = 'IL5:fakeClientKey123456789012345:20:' + custom_key_b64
+        il5_token = 'IL5:fakeClientKey123456789012345:' + self.CUSTOM_KEY_ID + ':' + custom_key_b64
 
         secrets_manager = SecretsManager(token=il5_token, config=config)
 
         self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), custom_key_b64)
-        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), self.CUSTOM_KEY_ID)
 
     def test_layer3_programmatic_params_write_key_material_to_config(self):
         """Layer 3: server_public_key / server_public_key_id constructor params write to config."""
@@ -50,15 +55,16 @@ class IL5DynamicKeyTest(unittest.TestCase):
         secrets_manager = SecretsManager(
             config=config,
             server_public_key=custom_key_b64,
-            server_public_key_id='20',
+            server_public_key_id=self.CUSTOM_KEY_ID,
         )
 
         self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), custom_key_b64)
-        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), self.CUSTOM_KEY_ID)
 
     def test_key_rotation_retries_with_custom_key(self):
-        """When the server sends a key-rotation error with key_id=20 and a custom key is configured,
-        the SDK updates the key_id and retries instead of raising ValueError."""
+        """When the server sends a key-rotation error pointing at a key id not in the built-in
+        registry and a custom key is configured, the SDK updates the key_id and retries instead
+        of raising ValueError."""
         custom_key_b64 = keeper_public_keys['7']
         config = InMemoryKeyValueStorage(MockConfig.make_json())
 
@@ -68,18 +74,18 @@ class IL5DynamicKeyTest(unittest.TestCase):
             server_public_key_id='10',
         )
 
-        # First response: server requests key rotation to key 20
+        # First response: server requests key rotation to an id outside the built-in registry
         error_response = mock.Response(
             client=secrets_manager,
-            content='{"error": "key", "key_id": 20}',
+            content='{"error": "key", "key_id": ' + self.CUSTOM_KEY_ID + '}',
             status_code=400,
             reason="Bad Request",
         )
 
         # Second response: success with one record
         success_response = mock.Response()
-        rec = success_response.add_record(title="IL5 Record")
-        rec.field("login", "il5_user")
+        rec = success_response.add_record(title="Custom-Key Record")
+        rec.field("login", "test_user")
 
         res_queue = mock.ResponseQueue(client=secrets_manager)
         res_queue.add_response(error_response)
@@ -88,9 +94,106 @@ class IL5DynamicKeyTest(unittest.TestCase):
         records = secrets_manager.get_secrets([])
 
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0].title, "IL5 Record")
-        # key_id should have been updated to '20' by the rotation handler
-        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), '20')
+        self.assertEqual(records[0].title, "Custom-Key Record")
+        # key_id should have been updated by the rotation handler
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), self.CUSTOM_KEY_ID)
+
+
+    def test_layer1_config_file_supplies_custom_key(self):
+        """Layer 1: a config that already contains serverPublicKey is honored on construction
+        with no token and no programmatic params — the custom key is preserved in config."""
+        custom_key_b64 = keeper_public_keys['7']
+        config = InMemoryKeyValueStorage(MockConfig.make_json())
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY, custom_key_b64)
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, self.CUSTOM_KEY_ID)
+
+        SecretsManager(config=config)
+
+        # Construction must not clobber the pre-existing custom key or reset the unknown
+        # key_id back to the default 10
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), custom_key_b64)
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), self.CUSTOM_KEY_ID)
+
+    def test_layer_precedence_programmatic_beats_token_beats_config(self):
+        """Precedence: programmatic params > 4-segment token > pre-existing config values."""
+        config_key = keeper_public_keys['7']
+        token_key = keeper_public_keys['8']
+        programmatic_key = keeper_public_keys['9']
+
+        # Seed config with a Layer 1 value
+        config = InMemoryKeyValueStorage()
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY, config_key)
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, 'config-id')
+
+        # Layer 2 (token) and Layer 3 (programmatic) both supplied; programmatic must win
+        il5_token = 'IL5:fakeClientKey123456789012345:token-id:' + token_key
+
+        SecretsManager(
+            token=il5_token,
+            config=config,
+            server_public_key=programmatic_key,
+            server_public_key_id='programmatic-id',
+        )
+
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), programmatic_key)
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), 'programmatic-id')
+
+    def test_token_beats_config_when_no_programmatic_params(self):
+        """Token (Layer 2) overrides pre-existing config (Layer 1) when programmatic params absent."""
+        config_key = keeper_public_keys['7']
+        token_key = keeper_public_keys['8']
+
+        config = InMemoryKeyValueStorage()
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY, config_key)
+        config.set(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID, 'config-id')
+
+        il5_token = 'IL5:fakeClientKey123456789012345:token-id:' + token_key
+
+        SecretsManager(token=il5_token, config=config)
+
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY), token_key)
+        self.assertEqual(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), 'token-id')
+
+    # --- Parser hardening (KSM-932 follow-up) -----------------------------------
+
+    def test_malformed_il5_token_3_segments_raises(self):
+        """IL5 tokens with 3 segments must fail loud, not silently drop the third segment."""
+        with self.assertRaises(ValueError):
+            SecretsManager(token='IL5:fakeClientKey:' + self.CUSTOM_KEY_ID, config=InMemoryKeyValueStorage())
+
+    def test_malformed_il5_token_5_segments_raises(self):
+        """IL5 tokens with more than 4 segments must fail loud, not silently drop the extras."""
+        custom_key_b64 = keeper_public_keys['7']
+        token = 'IL5:fakeClientKey:' + self.CUSTOM_KEY_ID + ':' + custom_key_b64 + ':extra'
+        with self.assertRaises(ValueError):
+            SecretsManager(token=token, config=InMemoryKeyValueStorage())
+
+    def test_malformed_il5_token_empty_segments_raises(self):
+        """IL5 tokens with empty keyId or serverPublicKey segments must fail loud."""
+        custom_key_b64 = keeper_public_keys['7']
+        # Empty keyId
+        with self.assertRaises(ValueError):
+            SecretsManager(token='IL5:fakeClientKey::' + custom_key_b64, config=InMemoryKeyValueStorage())
+        # Empty serverPublicKey
+        with self.assertRaises(ValueError):
+            SecretsManager(token='IL5:fakeClientKey:' + self.CUSTOM_KEY_ID + ':', config=InMemoryKeyValueStorage())
+
+    def test_malformed_il5_token_invalid_base64_raises(self):
+        """IL5 tokens with a non-base64 serverPublicKey segment must fail at construction, not deeper in the stack."""
+        with self.assertRaises(ValueError):
+            SecretsManager(
+                token='IL5:fakeClientKey:' + self.CUSTOM_KEY_ID + ':not!valid@base64',
+                config=InMemoryKeyValueStorage(),
+            )
+
+    def test_non_il5_token_with_extra_segments_is_unchanged(self):
+        """A non-IL5 prefix with extra segments must not trigger the IL5 parser path —
+        commercial/standard tokens stay backwards-compatible."""
+        config = InMemoryKeyValueStorage()
+        # US prefix with extra segments — historically these were silently dropped; preserving that.
+        SecretsManager(token='US:fakeClientKey123456789012345:extra:more', config=config)
+        # No custom key should have been written
+        self.assertIsNone(config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY))
 
 
 if __name__ == '__main__':

--- a/sdk/python/helper/LICENSE
+++ b/sdk/python/helper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Keeper Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/python/storage/keeper_secrets_manager_storages/LICENSE
+++ b/sdk/python/storage/keeper_secrets_manager_storages/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Keeper Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Follow-up to PR #1008 (KSM-932 IL5 dynamic key, already merged into the v17.2.2 release branch). Addresses P0 / P1 items from two independent CTO reviews of the release branch ahead of QA week of 2026-05-18.

## Changes

### New Features
- **Custom server public key (KSM-932) — parser hardening**: the 4-segment IL5 one-time token parser now raises `ValueError` on wrong segment count (3 or 5+), empty `keyId` or `serverPublicKey` segments, and invalid base64 in the public-key segment. Previously these silently degraded to default-key behavior — wrong fail-mode for a credential-handling code path.

### Bug Fixes
- **Populate empty LICENSE files** across 4 packages (`sdk/python/core/LICENSE.txt`, `sdk/python/helper/LICENSE`, `integration/keeper_secrets_manager_cli/LICENSE`, `sdk/python/storage/keeper_secrets_manager_storages/LICENSE`). All four shipped as 0-byte files declaring MIT in `setup.py` — legal/compliance gap that would publish to PyPI as license-claim-without-text.
- **Runtime Python version guard mismatch**: `core.py` runtime check raised on `< 3.6` while `setup.py` `python_requires` and classifiers required `>= 3.9` (announced in v17.2.0). Updated guard to match.

### Maintenance
- **Docstrings on new public API**: `SecretsManager.__init__`'s new `server_public_key` / `server_public_key_id` params and `generate_transmission_key`'s new `custom_public_key_b64` arg. Documents precedence between provisioning paths (programmatic > one-time token > pre-existing config). Generic framing for isolated deployments.
- **Tests added** (8 new, 72/72 passing): Layer 1 config-file supplies custom key; layer precedence (programmatic > token > config); token > config when programmatic absent; 4 parser-negative cases; non-IL5 prefix with extra segments stays backwards-compatible.
- **README: Custom Server Public Key (Isolated Deployments)** section pointing at the new constructor params and OTT format. Generic language; deployment-specific details deferred to the official docs link.

### Breaking Changes
None. New runtime errors only fire on inputs that previously silently degraded — no caller relying on the documented v17.2.1 behavior is affected. Default behavior is unchanged for all standard deployments.

## Related Issues
- Builds on #1008 (KSM-932 dynamic server public key, already merged into this release branch)
- Jira: [KSM-932](https://keeper.atlassian.net/browse/KSM-932)

[KSM-932]: https://keeper.atlassian.net/browse/KSM-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ