### PR TITLE
fix(ci): prevent shell injection in ServiceNow publish workflow

### DIFF
--- a/.github/workflows/publish.servicenow.plugin.yml
+++ b/.github/workflows/publish.servicenow.plugin.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tagname }}
         run: |
-          TAG="${{ github.event.inputs.tagname }}"
           GRADLE_CFG=./build.gradle.kts
           BUILD_NAME=`fgrep archivesName $GRADLE_CFG | sed -r 's/^\s*archivesName\s*=\s*//g' | sed 's/"//g'`
           BUILD_VERSION=`fgrep version $GRADLE_CFG | sed -r 's/^version\s+//g' | sed 's/"//g'`


### PR DESCRIPTION
## Summary

- Moves `github.event.inputs.tagname` from an inline `${{ }}` expression in the `run:` block to an intermediate `env:` variable, consistent with every other step in this workflow (lines 30, 37, 45 all already use this pattern).
- Eliminates the shell injection vector reported in VM-111: GitHub Actions evaluates `${{ }}` before the shell sees the command, so a malicious tag input could have broken out of the intended command and executed arbitrary code with `GITHUB_TOKEN` permissions.

## Security context

- **Vulnerability**: Bugcrowd VM-111 (P4/Low) — expression injection via `workflow_dispatch` input
- **Existing mitigation**: `environment: prod` approval gate limits exposure to write-access insiders, but does not eliminate the injection path
- **Fix**: Intermediate `env:` variable — value is stored in process memory and never participates in script generation

## Breaking Changes

None — purely a workflow hardening change with no behavioral difference under normal inputs.