### PR TITLE
fix(cli): context-aware keyring warning for binary vs pip installs (KSM-975)

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/profile.py
@@ -305,7 +305,15 @@ class Profile:
         if not use_keyring and not use_config_file and ini_file is None:
             logger.debug("Keyring not available, falling back to INI file storage")
             print(Fore.YELLOW + "Warning: Keyring not available, using keeper.ini file instead" + Style.RESET_ALL, file=sys.stderr)
-            print(Fore.YELLOW + "Warning: For better security, install: pip install keeper-secrets-manager-cli[keyring]" + Style.RESET_ALL, file=sys.stderr)
+            if getattr(sys, 'frozen', False):
+                # Running from a standalone binary install — pip is not applicable.
+                # Two binaries are published: with and without keyring support.
+                print(Fore.YELLOW + "Warning: For keychain support, download the '-keyring' version of the binary:" + Style.RESET_ALL, file=sys.stderr)
+                print(Fore.YELLOW + "  https://github.com/Keeper-Security/secrets-manager/releases" + Style.RESET_ALL, file=sys.stderr)
+            else:
+                # Running from pip install — quote the package name for zsh compatibility
+                # (unquoted [] is a glob pattern in zsh and causes "no matches found").
+                print(Fore.YELLOW + "Warning: For better security, install: pip install 'keeper-secrets-manager-cli[keyring]'" + Style.RESET_ALL, file=sys.stderr)
             use_config_file = True
             ini_file = Config.get_default_ini_file(launched_from_app)
 

--- a/integration/keeper_secrets_manager_cli/tests/profile_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/profile_test.py
@@ -1003,5 +1003,138 @@ color = True
                       "expected profile not found in --ini-file output")
 
 
+class KeyringWarningMessageTest(unittest.TestCase):
+    """KSM-975: keyring fallback warning must give context-appropriate advice.
+
+    When keyring is unavailable the warning should:
+    - Direct *pip* users to install with quoted brackets (zsh-safe).
+    - Direct *binary* users (sys.frozen=True) to the releases page, not pip.
+    """
+
+    def setUp(self):
+        self.orig_dir = os.getcwd()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.temp_dir.name)
+        os.environ.pop("KSM_CONFIG", None)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        self.temp_dir.cleanup()
+        os.environ.pop("KSM_CONFIG", None)
+
+    def _run_profile_init(self, runner, frozen=False):
+        """Invoke 'profile init' with keyring disabled and optional sys.frozen mock."""
+        res_queue = {}
+
+        def do_run():
+            patches = [
+                patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                      return_value=False),
+                patch('keeper_secrets_manager_cli.profile.Profile._mock_client',
+                      create=True),
+            ]
+            if frozen:
+                patches.append(patch('sys.frozen', True, create=True))
+
+            # Patch the network call so init doesn't actually hit the server
+            from keeper_secrets_manager_core import mock as ksm_mock
+            res = ksm_mock.Response()
+            res.flags = 0
+            queue = ksm_mock.ResponseQueue(client=None)
+            queue.add_response(res)
+
+            with patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                       return_value=False):
+                if frozen:
+                    with patch.object(__builtins__ if isinstance(__builtins__, dict)
+                                      else __import__('builtins'), '__dict__', {}):
+                        pass  # just need sys.frozen below
+                import sys as _sys
+                had_frozen = hasattr(_sys, 'frozen')
+                try:
+                    if frozen:
+                        _sys.frozen = True
+                    result = runner.invoke(
+                        cli,
+                        ['profile', 'init', '-t', 'US:FAKE_TOKEN_FOR_WARNING_TEST'],
+                        catch_exceptions=True,
+                    )
+                    res_queue['result'] = result
+                finally:
+                    if frozen:
+                        if had_frozen:
+                            pass
+                        else:
+                            del _sys.frozen
+
+        do_run()
+        return res_queue.get('result')
+
+    def test_pip_warning_uses_quoted_brackets(self):
+        """KSM-975: pip path warning must quote brackets — unquoted [] fails on zsh."""
+        runner = CliRunner()
+        with patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                   return_value=False):
+            import sys as _sys
+            had_frozen = hasattr(_sys, 'frozen')
+            try:
+                if had_frozen:
+                    del _sys.frozen  # ensure we're in pip path
+                result = runner.invoke(
+                    cli,
+                    ['profile', 'init', '-t', 'US:FAKE_TOKEN_KSM975'],
+                    catch_exceptions=True,
+                )
+            finally:
+                pass  # frozen was not set, nothing to restore
+
+        # The warning must use quoted brackets: 'keeper-secrets-manager-cli[keyring]'
+        combined = (result.output or '') + (result.stderr if hasattr(result, 'stderr') else '')
+        self.assertIn(
+            "pip install 'keeper-secrets-manager-cli[keyring]'",
+            combined,
+            "pip warning must use single-quoted package name for zsh compatibility"
+        )
+        # Must NOT contain the unquoted form as the install suggestion
+        self.assertNotIn(
+            "pip install keeper-secrets-manager-cli[keyring]\n",
+            combined,
+            "unquoted pip command found — will fail on zsh"
+        )
+
+    def test_binary_warning_points_to_releases_not_pip(self):
+        """KSM-975: binary path (sys.frozen=True) must direct users to releases page, not pip."""
+        runner = CliRunner()
+        import sys as _sys
+        had_frozen = hasattr(_sys, 'frozen')
+        try:
+            _sys.frozen = True
+            with patch('keeper_secrets_manager_cli.keyring_config.KeyringConfigStorage.is_available',
+                       return_value=False):
+                result = runner.invoke(
+                    cli,
+                    ['profile', 'init', '-t', 'US:FAKE_TOKEN_KSM975_BINARY'],
+                    catch_exceptions=True,
+                )
+        finally:
+            if not had_frozen:
+                del _sys.frozen
+
+        combined = (result.output or '') + (result.stderr if hasattr(result, 'stderr') else '')
+
+        # Must point to the releases page
+        self.assertIn(
+            'github.com/Keeper-Security/secrets-manager/releases',
+            combined,
+            "binary warning must link to the releases page for the -keyring binary"
+        )
+        # Must NOT tell binary users to run pip install
+        self.assertNotIn(
+            'pip install',
+            combined,
+            "binary users should not be told to use pip install"
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

When keyring is unavailable, the fallback warning in `profile.py` now gives context-appropriate advice depending on how the CLI was installed.

**Before:** both binary and pip users were told to run `pip install keeper-secrets-manager-cli[keyring]` — wrong advice for binary users, and broken syntax on zsh.

**After:**
- **Binary install** (`sys.frozen=True`): directs user to download the `-keyring` version of the binary from the GitHub releases page
- **Pip install**: corrects the command to use single-quoted brackets — `pip install 'keeper-secrets-manager-cli[keyring]'` — so it works on zsh (macOS default shell since Catalina, where unquoted `[]` is a glob pattern)

## Context

Two binaries are published per platform in each release (e.g. `keeper-secrets-manager-cli-macos-1.3.0.pkg` and `keeper-secrets-manager-cli-macos-1.3.0-keyring.pkg`). A user who installs the non-keyring binary and hits the warning has no use for a pip command. Confirmed via hands-on testing with the actual 1.3.0 Linux release binaries in Docker (linux/amd64) and native macOS testing.

## Testing

- Two new unit tests added to `profile_test.py::KeyringWarningMessageTest`
  - `test_pip_warning_uses_quoted_brackets` — asserts single-quoted form in pip path
  - `test_binary_warning_points_to_releases_not_pip` — asserts releases URL and no pip mention in binary path
- Both tests pass in Docker (Python 3.11)

Jira: KSM-975