### PR TITLE
docs(sdk/rust): clarify SecretsManager::new() deferred bind lifecycle (KSM-973)

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -224,27 +224,31 @@ impl Clone for SecretsManager {
 }
 
 impl SecretsManager {
-    /// Creates a new `SecretsManager` instance and initializes it with the provided configuration.
+    /// Creates a new `SecretsManager` instance and initialises it with the provided configuration.
     ///
-    /// This method performs token binding (if using a one-time token), sets up storage,
-    /// and validates the configuration. The SDK never panics - all errors are returned as `Result`.
+    /// # ⚠️ Deferred bind — this constructor makes NO network calls
     ///
-    /// # Arguments
+    /// `new()` only sets up local state: it generates the key-pair, stores the token and
+    /// hostname in the configured storage backend, and builds the HTTP client. The
+    /// one-time token is **not** redeemed here.
     ///
-    /// * `client_options` - Configuration options including token, storage backend, hostname, and cache settings
+    /// The token is redeemed on the **first method call that contacts Keeper Cloud**
+    /// (typically `get_secrets`). Until that call completes successfully the configured
+    /// storage is **unbound**: it contains `clientId`, `privateKey`, `hostname`, and
+    /// `serverPublicKeyId`, but is **missing `appKey` and `appOwnerPublicKey`**. An
+    /// unbound config cannot be loaded into a new `SecretsManager` on a future run.
     ///
-    /// # Returns
-    ///
-    /// * `Result<Self, KSMRError>` - Initialized `SecretsManager` instance or an error
-    ///
-    /// # Errors
-    ///
-    /// * `SecretManagerCreationError` - If initialization fails (invalid token, storage error, missing config)
-    ///
-    /// # Example
+    /// **If you intend to persist the config to an external store** (OS keychain,
+    /// AWS Secrets Manager, HashiCorp Vault, …), call `get_secrets(vec![])` immediately
+    /// after `new()` to force the bind, then export from the storage backend:
     ///
     /// ```no_run
-    /// use keeper_secrets_manager_core::{core::{ClientOptions, SecretsManager}, enums::KvStoreType, storage::FileKeyValueStorage, custom_error::KSMRError};
+    /// use keeper_secrets_manager_core::{
+    ///     core::{ClientOptions, SecretsManager},
+    ///     enums::KvStoreType,
+    ///     storage::FileKeyValueStorage,
+    ///     custom_error::KSMRError,
+    /// };
     ///
     /// fn example() -> Result<(), KSMRError> {
     ///     let storage = FileKeyValueStorage::new(Some("config.json".to_string()))?;
@@ -252,9 +256,27 @@ impl SecretsManager {
     ///     let token = "US:YOUR_TOKEN".to_string();
     ///     let options = ClientOptions::new_client_options_with_token(token, config);
     ///     let mut secrets_manager = SecretsManager::new(options)?;
+    ///
+    ///     // IMPORTANT: the one-time token is redeemed on the FIRST network call.
+    ///     // After this line the storage is fully bound (appKey + appOwnerPublicKey
+    ///     // are written) and safe to persist to an external store.
+    ///     secrets_manager.get_secrets(vec![])?;
+    ///
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `client_options` - Configuration options including token, storage backend, hostname, and cache settings
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, KSMRError>` - Initialised `SecretsManager` instance or an error
+    ///
+    /// # Errors
+    ///
+    /// * `SecretManagerCreationError` - If initialisation fails (invalid token, storage error, missing config)
     pub fn new(client_options: ClientOptions) -> Result<Self, KSMRError> {
         let mut secrets_manager = SecretsManager {
             token: String::new(),

--- a/sdk/rust/tests/bind_lifecycle_tests.rs
+++ b/sdk/rust/tests/bind_lifecycle_tests.rs
@@ -1,0 +1,174 @@
+// KSM-973: Tests for the SecretsManager bind lifecycle.
+//
+// SecretsManager::new() makes NO network calls. The one-time token is redeemed
+// on the first get_secrets() call. Until that call completes the config storage
+// is "unbound" — it is missing appKey and appOwnerPublicKey and cannot be used
+// to construct a new SecretsManager on a later run.
+
+#[cfg(test)]
+mod bind_lifecycle_tests {
+    use keeper_secrets_manager_core::config_keys::ConfigKeys;
+    use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+    use keeper_secrets_manager_core::crypto::CryptoUtils;
+    use keeper_secrets_manager_core::custom_error::KSMRError;
+    use keeper_secrets_manager_core::dto::{EncryptedPayload, KsmHttpResponse, TransmissionKey};
+    use keeper_secrets_manager_core::enums::KvStoreType;
+    use keeper_secrets_manager_core::storage::{InMemoryKeyValueStorage, KeyValueStorage};
+
+    // A fake one-time token whose base64 part (after "US:") has a length that is
+    // a multiple of 4 — required for the SDK's internal base64 decoder.
+    // Value is meaningless; it will never be sent to a server in these tests.
+    const MOCK_TOKEN: &str = "US:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    // ─── helpers ────────────────────────────────────────────────────────────
+
+    /// Build a fully-bound storage (appKey + appOwnerPublicKey present) that
+    /// SecretsManager::new() accepts without a token — simulates a persisted
+    /// config loaded from a keychain / secrets-manager on a subsequent run.
+    fn bound_storage() -> Result<KvStoreType, KSMRError> {
+        let storage = InMemoryKeyValueStorage::new(None)?;
+        let mut kv = KvStoreType::InMemory(storage);
+
+        let priv_der = CryptoUtils::generate_private_key_der()?;
+        let priv_b64 = keeper_secrets_manager_core::utils::bytes_to_base64(&priv_der);
+        let priv_key = CryptoUtils::generate_private_key_ecc()?;
+        let pub_b64 = keeper_secrets_manager_core::utils::bytes_to_base64(
+            &CryptoUtils::public_key_ecc(&priv_key),
+        );
+
+        kv.set(ConfigKeys::KeyClientId, "TEST_CLIENT_ID".to_string())?;
+        kv.set(
+            ConfigKeys::KeyAppKey,
+            "dGVzdF9hcHBfa2V5X2Jhc2U2NF9lbmNvZGVkX3ZhbHVlAAAAAAAAAAAA".to_string(),
+        )?;
+        kv.set(ConfigKeys::KeyOwnerPublicKey, pub_b64)?;
+        kv.set(ConfigKeys::KeyPrivateKey, priv_b64)?;
+        kv.set(ConfigKeys::KeyServerPublicKeyId, "10".to_string())?;
+        kv.set(
+            ConfigKeys::KeyHostname,
+            "fake.keepersecurity.com".to_string(),
+        )?;
+
+        Ok(kv)
+    }
+
+    /// Mock HTTP handler that always returns an error — used in tests that must
+    /// not reach the network.
+    fn mock_no_network(
+        _url: String,
+        _tk: TransmissionKey,
+        _ep: EncryptedPayload,
+    ) -> Result<KsmHttpResponse, KSMRError> {
+        Err(KSMRError::HTTPError(
+            "KSM-973 test: unexpected network call".to_string(),
+        ))
+    }
+
+    // ─── tests ──────────────────────────────────────────────────────────────
+
+    /// new() must NOT touch the network. We inject a mock that panics if called
+    /// — if the test passes, new() never attempted a network request.
+    #[test]
+    fn test_new_does_not_perform_network_call() -> Result<(), KSMRError> {
+        let storage = InMemoryKeyValueStorage::new(None)?;
+        let kv = KvStoreType::InMemory(storage);
+
+        let mut options = ClientOptions::new_client_options_with_token(MOCK_TOKEN.to_string(), kv);
+        options.set_custom_post_function(|_url, _tk, _ep| {
+            panic!(
+                "KSM-973: SecretsManager::new() must not make a network call. \
+                 The token must only be redeemed on the first get_secrets() call."
+            );
+        });
+
+        // If this panics, new() hit the network — the test will fail.
+        let _sm = SecretsManager::new(options)?;
+        Ok(())
+    }
+
+    /// Immediately after new() (before any get_secrets call) the storage must
+    /// NOT contain appKey or appOwnerPublicKey — i.e. it is unbound.
+    /// Persisting an unbound config produces a non-reloadable credential store.
+    #[test]
+    fn test_storage_is_unbound_after_new() -> Result<(), KSMRError> {
+        let storage = InMemoryKeyValueStorage::new(None)?;
+        let kv = KvStoreType::InMemory(storage);
+
+        let mut options = ClientOptions::new_client_options_with_token(MOCK_TOKEN.to_string(), kv);
+        options.set_custom_post_function(mock_no_network);
+
+        let sm = SecretsManager::new(options)?;
+
+        let has_app_key = match &sm.config {
+            KvStoreType::InMemory(s) => s.contains(ConfigKeys::KeyAppKey).unwrap_or(false),
+            KvStoreType::File(s) => s.contains(ConfigKeys::KeyAppKey).unwrap_or(false),
+            _ => false,
+        };
+        assert!(
+            !has_app_key,
+            "KSM-973: appKey must NOT be present before the first get_secrets() call. \
+             Persisting config at this point produces an unbound (non-reloadable) config."
+        );
+
+        let has_owner_key = match &sm.config {
+            KvStoreType::InMemory(s) => s.contains(ConfigKeys::KeyOwnerPublicKey).unwrap_or(false),
+            KvStoreType::File(s) => s.contains(ConfigKeys::KeyOwnerPublicKey).unwrap_or(false),
+            _ => false,
+        };
+        assert!(
+            !has_owner_key,
+            "KSM-973: appOwnerPublicKey must NOT be present before bind completes."
+        );
+
+        Ok(())
+    }
+
+    /// A fully-bound storage (appKey + appOwnerPublicKey present) must allow
+    /// constructing a SecretsManager without a token. This is the "reload from
+    /// persisted config" path that integrators use on every run after the first.
+    #[test]
+    fn test_bound_config_can_be_reloaded_without_token() -> Result<(), KSMRError> {
+        let bound_kv = bound_storage()?;
+        let mut options = ClientOptions::new_client_options(bound_kv);
+        options.set_custom_post_function(mock_no_network);
+
+        SecretsManager::new(options)
+            .expect("KSM-973: a bound config must be reloadable without a token");
+
+        Ok(())
+    }
+
+    /// The pre-bind keys written locally by new() (clientId, privateKey,
+    /// hostname) must be present in storage after construction — these do not
+    /// require a network call.
+    #[test]
+    fn test_pre_bind_keys_present_after_new() -> Result<(), KSMRError> {
+        let storage = InMemoryKeyValueStorage::new(None)?;
+        let kv = KvStoreType::InMemory(storage);
+
+        let mut options = ClientOptions::new_client_options_with_token(MOCK_TOKEN.to_string(), kv);
+        options.set_custom_post_function(mock_no_network);
+
+        let sm = SecretsManager::new(options)?;
+
+        for key in &[
+            ConfigKeys::KeyClientId,
+            ConfigKeys::KeyPrivateKey,
+            ConfigKeys::KeyHostname,
+        ] {
+            let present = match &sm.config {
+                KvStoreType::InMemory(s) => s.contains(key.clone()).unwrap_or(false),
+                KvStoreType::File(s) => s.contains(key.clone()).unwrap_or(false),
+                _ => false,
+            };
+            assert!(
+                present,
+                "KSM-973: {:?} must be present in storage after new() — \
+                 it is written locally without any network call.",
+                key
+            );
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

`SecretsManager::new()` does not make any network calls — the one-time token is redeemed on the **first** `get_secrets()` call. This contract was previously undocumented and caused real integration bugs (most recently while integrating the Rust SDK into KeeperDB).

## What changes

**Doc only — no public API change.**

- Expanded the doc comment on `SecretsManager::new()` to make the deferred-bind contract explicit, explain when the storage is "unbound" (missing `appKey` and `appOwnerPublicKey`), and warn against persisting the config before the first network call.
- Updated the inline example to call `secrets_manager.get_secrets(vec![])?` immediately after `new()` with an explanatory comment.

## Why it matters

If an integrator reads from the SDK's storage and persists it (to OS keychain, AWS Secrets Manager, HashiCorp Vault, …) **between** `new()` and the first network call, the saved blob is missing `appKey` + `appOwnerPublicKey`. On the next run, loading that blob produces a `SecretsManager` that cannot fetch secrets. The fix is to force the bind by calling `get_secrets(vec![])` first — but until now nothing in the public surface signalled this.

## Tests

New test file `sdk/rust/tests/bind_lifecycle_tests.rs` with four tests covering the bind lifecycle contract:

| Test | Asserts |
|------|---------|
| `test_new_does_not_perform_network_call` | `new()` never invokes the HTTP layer — verified by injecting a panicking `custom_post_function` |
| `test_storage_is_unbound_after_new` | `appKey` and `appOwnerPublicKey` are absent immediately after `new()` |
| `test_pre_bind_keys_present_after_new` | `clientId`, `privateKey`, `hostname` ARE present after `new()` (written locally, no network) |
| `test_bound_config_can_be_reloaded_without_token` | A persisted bound config can be loaded by a fresh `SecretsManager` with no token (the second-run path) |

All four pass locally: `cargo test --test bind_lifecycle_tests` → `4 passed; 0 failed`.

## Follow-ups (not in this PR)

- KSM-974 covers mirroring this lifecycle documentation across the other SDK pages (Python, JS, Java, .NET, Go) on docs.keeper.io.
- A future change could add explicit `bind()` and `is_bound()` convenience methods, but that needs to be done consistently across all SDKs — out of scope here.

Jira: KSM-973