### PR TITLE
KSM-977: fix AwsSecretStorage.__load_config() silently swallowing AWS errors

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_storage/storage_aws_secret.py
+++ b/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_storage/storage_aws_secret.py
@@ -473,7 +473,8 @@ class AwsSecretStorage(KeyValueStorage):
             else:
                 err = f"Failed to load/parse config JSON from AWS secret '{self.provider.key_name}' - the value must be a valid JSON object, value='{contents}'"
         except Exception as e:
-            logger.error(f"Failed to load config JSON from AWS secret '{self.provider.key_name}', Error: {str(e)}")
+            err = f"Failed to load config JSON from AWS secret '{self.provider.key_name}', Error: {str(e)}"
+            logger.error(err)
 
         if err:
             raise ValueError(err)

--- a/sdk/python/storage/keeper_secrets_manager_storages/tests/test_ksm977_load_config_exception_propagation.py
+++ b/sdk/python/storage/keeper_secrets_manager_storages/tests/test_ksm977_load_config_exception_propagation.py
@@ -1,0 +1,100 @@
+"""KSM-977: AwsSecretStorage.__load_config() must propagate exceptions from
+AwsConfigProvider.read_config() rather than swallowing them. Affected entry points:
+default constructor, from_default_config, from_profile_config, from_ec2instance_config,
+from_custom_config."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+_AWS_ERROR = Exception("Failed to read config from AWS secret 'my-secret': AccessDeniedException")
+
+
+class TestKsm977LoadConfigExceptionPropagation(unittest.TestCase):
+    def test_default_constructor_raises_when_read_config_raises(self):
+        """KSM-977: AwsSecretStorage() must raise when read_config raises, not return silently."""
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        with patch.object(AwsConfigProvider, 'from_ec2instance_config'), \
+             patch.object(AwsConfigProvider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError,
+                                   msg='AwsSecretStorage() must raise ValueError when read_config raises'):
+                AwsSecretStorage('my-secret')
+
+    def test_default_constructor_error_contains_secret_name(self):
+        """KSM-977: raised ValueError must identify the secret name."""
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        with patch.object(AwsConfigProvider, 'from_ec2instance_config'), \
+             patch.object(AwsConfigProvider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError) as ctx:
+                AwsSecretStorage('my-secret')
+
+        self.assertIn('my-secret', str(ctx.exception))
+
+    def test_from_default_config_raises_when_read_config_raises(self):
+        """KSM-977: from_default_config must raise when read_config raises."""
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        storage = AwsSecretStorage.__new__(AwsSecretStorage)
+        storage.provider = AwsConfigProvider('my-secret')
+        storage.config = {}
+        storage.last_saved_config_hash = ""
+
+        with patch.object(storage.provider, 'from_default_config'), \
+             patch.object(storage.provider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError,
+                                   msg='from_default_config must raise ValueError when read_config raises'):
+                storage.from_default_config('my-secret')
+
+    def test_from_profile_config_raises_when_read_config_raises(self):
+        """KSM-977: from_profile_config must raise when read_config raises."""
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        storage = AwsSecretStorage.__new__(AwsSecretStorage)
+        storage.provider = AwsConfigProvider('my-secret')
+        storage.config = {}
+        storage.last_saved_config_hash = ""
+
+        with patch.object(storage.provider, 'from_profile_config'), \
+             patch.object(storage.provider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError,
+                                   msg='from_profile_config must raise ValueError when read_config raises'):
+                storage.from_profile_config('my-secret', 'my-profile')
+
+    def test_from_ec2instance_config_raises_when_read_config_raises(self):
+        """KSM-977: from_ec2instance_config must raise when read_config raises.
+
+        Uses class-level patches because from_ec2instance_config creates a new
+        AwsConfigProvider instance internally — instance-level patches on the old
+        provider are irrelevant after the swap.
+        """
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        storage = AwsSecretStorage.__new__(AwsSecretStorage)
+        storage.provider = AwsConfigProvider('my-secret')
+        storage.config = {}
+        storage.last_saved_config_hash = ""
+
+        with patch.object(AwsConfigProvider, 'from_ec2instance_config'), \
+             patch.object(AwsConfigProvider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError,
+                                   msg='from_ec2instance_config must raise ValueError when read_config raises'):
+                storage.from_ec2instance_config('my-secret')
+
+    def test_from_custom_config_raises_when_read_config_raises(self):
+        """KSM-977: from_custom_config must raise when read_config raises."""
+        from keeper_secrets_manager_storage.storage_aws_secret import AwsSecretStorage, AwsConfigProvider
+
+        with patch.object(AwsConfigProvider, 'from_ec2instance_config'), \
+             patch.object(AwsConfigProvider, 'read_config', return_value='{"clientId": "init"}'):
+            storage = AwsSecretStorage('my-secret')
+
+        with patch.object(storage.provider, 'from_custom_config'), \
+             patch.object(storage.provider, 'read_config', side_effect=_AWS_ERROR):
+            with self.assertRaises(ValueError,
+                                   msg='from_custom_config must raise ValueError when read_config raises'):
+                storage.from_custom_config('my-secret', 'key-id', 'secret-key', 'us-east-1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

`AwsSecretStorage.__load_config()` had a broad `except Exception` block that logged errors from `AwsConfigProvider.read_config()` but never raised — leaving `self.config = {}` and returning silently. This defeated two prior fixes: KSM-966 (made `read_config` raise on AWS errors) and KSM-967 (made `__init__` eagerly call `__load_config`). All five entry points were affected.

## Why it was missed

KSM-966 tests call `provider.read_config()` directly. KSM-967 tests mock `read_config` to return a valid string. Neither exercised the path where `read_config` raises and `__load_config` catches it. Found during REL-5069 pre-release audit.

## Change

One logical change: populate `err` inside the `except` block instead of only logging, so the existing single raise-site at the bottom of `__load_config` fires.

```python
# Before
except Exception as e:
    logger.error(f"Failed to load config JSON from AWS secret '{self.provider.key_name}', Error: {str(e)}")

# After
except Exception as e:
    err = f"Failed to load config JSON from AWS secret '{self.provider.key_name}', Error: {str(e)}"
    logger.error(err)
```

## Tests

Added `test_ksm977_load_config_exception_propagation.py` with 6 tests — one per entry point plus message content check. All 6 fail before the fix, all pass after. Full suite: 43/43 pass.

## Related Issues

KSM-977 | KSM-966 | KSM-967 | REL-5069

## Breaking Changes

None.