### PR TITLE
KSM-978: raise on empty __decrypt_buffer result in HsmNfast and AwsKms

### DIFF
--- a/sdk/python/storage/keeper_secrets_manager_storages/README.md
+++ b/sdk/python/storage/keeper_secrets_manager_storages/README.md
@@ -21,6 +21,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - `AwsSecretStorage.__init__` now eagerly loads the config on construction, matching all other backends
 - `AwsSecretStorage.__load_config()` now raises when the underlying AWS Secrets Manager call fails — previously the exception from `read_config` was logged but not propagated, leaving `config = {}` with no error
 - Non-UTF8 bytes that are not a valid encrypted blob now raise a clear `"is not a valid encrypted config file"` exception across all encrypted backends (nfast, AWS KMS, Azure KeyVault)
+- HsmNfast and AwsKms now raise `"is not a valid encrypted config file"` when decryption produces empty output — previously HsmNfast leaked a bare `JSONDecodeError` and AwsKms logged silently without raising, unlike Azure
 
 ## 1.0.2
 

--- a/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_hsm/storage_aws_kms.py
+++ b/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_hsm/storage_aws_kms.py
@@ -147,8 +147,8 @@ class AwsKmsKeyValueStorage(KeyValueStorage):
                     config_json = self.__decrypt_buffer(contents)
                 except UnicodeDecodeError:
                     raise Exception("{} is not a valid encrypted config file".format(self.default_config_file_location))
-                if len(config_json) == 0:
-                    logging.getLogger(logger_name).error("Failed to decrypt config file " + self.default_config_file_location)
+                if not config_json:
+                    raise Exception("{} is not a valid encrypted config file".format(self.default_config_file_location))
                 else:
                     try:
                         config = json.loads(config_json)

--- a/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_hsm/storage_hsm_nfast.py
+++ b/sdk/python/storage/keeper_secrets_manager_storages/keeper_secrets_manager_hsm/storage_hsm_nfast.py
@@ -257,6 +257,8 @@ class HsmNfastKeyValueStorage(KeyValueStorage):
                     logging.getLogger(logger_name).warning("Empty config file " + self.default_config_file_location)
 
                 config_json = self.__decrypt_buffer(ciphertext)
+                if not config_json:
+                    raise Exception("{} is not a valid encrypted config file".format(self.default_config_file_location))
                 try:
                     config = json.loads(config_json)
                     self.config = config

--- a/sdk/python/storage/keeper_secrets_manager_storages/tests/test_ksm978_decrypt_path_consistency.py
+++ b/sdk/python/storage/keeper_secrets_manager_storages/tests/test_ksm978_decrypt_path_consistency.py
@@ -1,0 +1,108 @@
+"""KSM-978: All three encrypted backends must raise the KSM-972 friendly exception
+("is not a valid encrypted config file") when __decrypt_buffer returns empty.
+
+- HsmNfast: valid \xff\xff header + malformed body → __decrypt_buffer returns "" →
+  json.loads("") raises bare JSONDecodeError (bypasses KSM-972 wrapper). Fix: guard before json.loads.
+- AwsKms: KMS returns empty bytes → config_json == "" → only logger.error, no raise (unlike Azure).
+  Fix: raise instead of log-only.
+
+Azure already handles this correctly and serves as the reference implementation.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# b'\xff\xff' + malformed body:
+# - header matches HSM_BLOB_HEADER → is_blob=True, decrypt path entered
+# - mech_len = 0xDEAD = 57005 but only 4 bytes follow → success=False → __decrypt_buffer returns ""
+MALFORMED_BLOB = b'\xff\xff' + b'\xde\xad\xbe\xef\xca\xfe'
+
+# Any non-JSON binary bytes — causes is_json() to return False → AwsKms decrypt path entered
+BINARY_BYTES = b'\xff\xfe\xfd\xfc'
+
+
+# ---------------------------------------------------------------------------
+# nfast (stub nfpython/nfkm at import time — no hardware required)
+# Mirrors the setup in test_ksm972_corrupt_config.py
+# ---------------------------------------------------------------------------
+
+_nfpython_stub = MagicMock()
+_nfkm_stub = MagicMock()
+_conn_stub = MagicMock()
+_conn_stub.transact.return_value.status = 'OK'
+_nfpython_stub.connection.return_value = _conn_stub
+
+if 'nfpython' not in sys.modules:
+    sys.modules['nfpython'] = _nfpython_stub
+if 'nfkm' not in sys.modules:
+    sys.modules['nfkm'] = _nfkm_stub
+
+
+class TestKsm978NfastMalformedBody(unittest.TestCase):
+    """HsmNfast: valid header + malformed body must raise the KSM-972 wrapper, not JSONDecodeError."""
+
+    def setUp(self):
+        self._d = tempfile.TemporaryDirectory()
+        self.config_path = os.path.join(self._d.name, 'cfg.json')
+        with open(self.config_path, 'wb') as fh:
+            fh.write(MALFORMED_BLOB)
+
+    def tearDown(self):
+        self._d.cleanup()
+
+    def test_malformed_body_raises_typed_exception(self):
+        """KSM-978: HsmNfast must raise a clear config-format Exception when __decrypt_buffer
+        returns "" for a valid-header/malformed-body blob, not a bare JSONDecodeError."""
+        from keeper_secrets_manager_hsm.storage_hsm_nfast import HsmNfastKeyValueStorage
+        from json import JSONDecodeError
+
+        with self.assertRaises(Exception) as ctx:
+            HsmNfastKeyValueStorage('app', 'ksm', self.config_path)
+
+        msg = str(ctx.exception)
+        self.assertIn('not a valid encrypted config file', msg,
+                      'Exception must identify the file as an invalid encrypted config')
+        self.assertNotIsInstance(ctx.exception, JSONDecodeError,
+                                 'Exception must not be a bare JSONDecodeError')
+
+
+# ---------------------------------------------------------------------------
+# AWS KMS (mock KMS client to return empty plaintext)
+# ---------------------------------------------------------------------------
+
+class TestKsm978AwsKmsEmptyPlaintext(unittest.TestCase):
+    """AwsKms: empty __decrypt_buffer result must raise, not silently log. Parity with Azure."""
+
+    def setUp(self):
+        self._d = tempfile.TemporaryDirectory()
+        self.config_path = os.path.join(self._d.name, 'cfg.json')
+        with open(self.config_path, 'wb') as fh:
+            fh.write(BINARY_BYTES)
+
+    def tearDown(self):
+        self._d.cleanup()
+
+    def _build_storage(self):
+        from keeper_secrets_manager_hsm.storage_aws_kms import AwsKmsKeyValueStorage
+        mk = MagicMock()
+        # KMS returns empty plaintext — the empty-decrypt path (lines 150-151 pre-fix)
+        mk.decrypt.return_value = {'Plaintext': b''}
+        with patch('keeper_secrets_manager_hsm.storage_aws_kms.boto3') as mb:
+            mb.client.return_value = mk
+            return AwsKmsKeyValueStorage('alias/test', self.config_path)
+
+    def test_empty_decrypt_raises_typed_exception(self):
+        """KSM-978: AwsKmsKeyValueStorage must raise when KMS decrypts to empty bytes,
+        matching Azure's behavior at the equivalent site."""
+        with self.assertRaises(Exception) as ctx:
+            self._build_storage()
+
+        msg = str(ctx.exception)
+        self.assertIn('not a valid encrypted config file', msg,
+                      'Exception must identify the file as an invalid encrypted config')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Two pre-existing inconsistencies in the encrypted-backend decrypt path where `__decrypt_buffer` returns empty string — found during the REL-5069 Gallego sweep.

- **HsmNfast**: valid `\xff\xff` header + malformed body causes `__decrypt_buffer` to return `""`. The call site passed that directly to `json.loads("")`, raising a bare `JSONDecodeError` with no file path and no KSM-972 wrapper message.
- **AwsKms**: the `if len(config_json) == 0:` check only called `logger.error` with no `raise`. Azure's equivalent site raises. All three encrypted backends now behave identically.

## Fix

Add the same guard Azure already has — `if not config_json: raise Exception("{path} is not a valid encrypted config file")` — immediately after the `__decrypt_buffer` call in both backends.

**HsmNfast** (`storage_hsm_nfast.py`): inserted between `__decrypt_buffer` return and `json.loads`.

**AwsKms** (`storage_aws_kms.py`): replaced `logger.error` (no raise) with `raise Exception(...)`.

## Tests

Added `test_ksm978_decrypt_path_consistency.py` with 2 tests:
- HsmNfast: `b'\xff\xff' + malformed_body` → before fix raises `JSONDecodeError`; after fix raises `Exception("...is not a valid encrypted config file...")`
- AwsKms: KMS mock returning `b''` → before fix no exception; after fix raises same

Full suite: 45/45 pass. KSM-972 tests (`test_ksm972_corrupt_config.py`) remain green — the fixes are complementary.

## Related Issues
- KSM-978 | KSM-972 | REL-5069

## Breaking Changes
None.