### PR TITLE
fix(sdk/rust): persist server key rotation instead of mutating a clone

### DIFF
--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -879,7 +879,7 @@ impl SecretsManager {
     }
 
     fn handle_http_error(
-        mut self,
+        &mut self,
         status_code: u16,
         response: Option<String>,
     ) -> Result<bool, KSMRError> {
@@ -1120,9 +1120,12 @@ impl SecretsManager {
             }
 
             // Handle the error. Handling will throw an exception if it doesn't want us to retry.
-            let handle_error_result: bool = self
-                .clone()
-                .handle_http_error(keeper_response.status_code, keeper_response.http_response)?;
+            // Must borrow &mut self (not self.clone()) so a server-requested key
+            // rotation (`result_code: "key"`) persists KeyServerPublicKeyId on the
+            // real config; cloning here discarded the update and looped forever
+            // against any data center whose active key != DEFAULT_KEY_ID.
+            let handle_error_result: bool =
+                self.handle_http_error(keeper_response.status_code, keeper_response.http_response)?;
             retry = handle_error_result
         }
         Err(KSMRError::SecretManagerCreationError(
@@ -3773,5 +3776,75 @@ impl NotationSection {
             index1: None,
             index2: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod key_rotation_regression {
+    use super::*;
+    use crate::config_keys::ConfigKeys;
+    use crate::enums::KvStoreType;
+    use crate::storage::{InMemoryKeyValueStorage, KeyValueStorage};
+
+    /// Build a minimally "already bound" SecretsManager without any network
+    /// or live keypair: a non-empty `clientId` plus an empty token makes
+    /// `_init` take the already-bound early-return path. Enough to exercise
+    /// `handle_http_error`, which needs only the config.
+    fn bound_sm(server_key_id: &str) -> SecretsManager {
+        let json =
+            format!(r#"{{"clientId":"dGVzdENsaWVudElk","serverPublicKeyId":"{server_key_id}"}}"#);
+        let storage = InMemoryKeyValueStorage::new(Some(json)).unwrap();
+        let opts = ClientOptions::new_client_options(KvStoreType::InMemory(storage));
+        SecretsManager::new(opts).unwrap()
+    }
+
+    /// Regression: a server key-rotation response (`error: "key"`) must
+    /// persist the server-requested `serverPublicKeyId` on the live config.
+    ///
+    /// Previously `post_query` invoked `self.clone().handle_http_error(...)`,
+    /// so the rotation was written to a discarded clone. `post_query`'s
+    /// `while retry` loop then re-read the original (default) key id every
+    /// iteration and looped forever against any data center whose active
+    /// transmission key id != DEFAULT_KEY_ID (e.g. a token whose region
+    /// expects key 9 while the default is 10).
+    #[test]
+    fn key_rotation_persists_on_live_config() {
+        let mut sm = bound_sm("10");
+        assert_eq!(
+            sm.config
+                .get(ConfigKeys::KeyServerPublicKeyId)
+                .unwrap()
+                .as_deref(),
+            Some("10"),
+            "precondition: starts on the default key id"
+        );
+
+        let body = r#"{"key_id":9,"error":"key","message":"invalid key id"}"#.to_string();
+        let retry = sm
+            .handle_http_error(401, Some(body))
+            .expect("a key-rotation response should request a retry");
+
+        assert!(retry, "server key error must request a retry");
+        assert_eq!(
+            sm.config
+                .get(ConfigKeys::KeyServerPublicKeyId)
+                .unwrap()
+                .as_deref(),
+            Some("9"),
+            "rotated key id must persist on the live config (not a clone)"
+        );
+    }
+
+    /// A non-rotation error must NOT request a retry (guards against turning
+    /// every error into a retry loop).
+    #[test]
+    fn non_key_error_does_not_retry() {
+        let mut sm = bound_sm("10");
+        let body = r#"{"error":"access_denied","message":"nope"}"#.to_string();
+        let result = sm.handle_http_error(403, Some(body));
+        assert!(
+            result.is_err(),
+            "a non-key error should surface as an error, not a retry"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The Rust KSM SDK loops forever during the initial bind / `get_secrets` against any data center whose **active server transmission key id is not the default (`DEFAULT_KEY_ID = 10`)**. Production happens to use key 10, so this was masked there; environments on a different active key (observed against a `qa.keepersecurity.com` one-time token, active key **9**) never bind — the client spins on `401 {"key_id":9,"error":"key","message":"invalid key id"}` at roughly one request per RTT, indefinitely.

## Root cause

`core.rs::post_query` handles HTTP errors via:

```rust
let handle_error_result: bool = self
    .clone()                       // <- deep copy of SecretsManager
    .handle_http_error(...)?;      // fn handle_http_error(mut self, ...)
```

On a key-rotation response (`result_code: "key"`), `handle_http_error` calls
`self.config.set(KeyServerPublicKeyId, requested_id)` — but on the **discarded clone**.
`InMemoryKeyValueStorage` is `{ config: HashMap<..> }` with `#[derive(Clone)]` (deep copy, no interior sharing), so the update never reaches the real `self.config`. The `while retry` loop in `post_query` then re-reads the original (default) key id every iteration, re-encrypts the transmission key with the wrong key, the server again asks for the rotated key, and it loops forever.

The `.clone()` only existed to satisfy the borrow checker (`post_query` holds `&mut self`; `handle_http_error` consumed `self` by value).

## Fix

- `handle_http_error(mut self, …)` → `handle_http_error(&mut self, …)`
- Drop the `.clone()` at the call site.

Now the rotated `serverPublicKeyId` persists on the live config; the next loop iteration encrypts with the server-requested key → `200` → bind succeeds in a single rotation. Production (already on key 10) is unaffected.

## Tests

Added `key_rotation_regression` unit tests in `core.rs`:
- `key_rotation_persists_on_live_config` — a `key` response persists the rotated id on the **live** config and requests a retry.
- `non_key_error_does_not_retry` — a non-key error surfaces as an error rather than triggering a retry.

Both pass. Confirmed they do **not compile** against the pre-fix code (`E0507` "cannot move out of `*self`" / `E0382`), which is exactly why the original `.clone()` was there — demonstrating the fix is what removes the loop.

Verified end-to-end: a real `qa.keepersecurity.com` one-time token (active key 9) now binds successfully (one rotation → `Successfully Made API call`), where it previously looped forever.

## Scope / compatibility

- Single file (`sdk/rust/src/core/core.rs`); no public API change (`handle_http_error` is private).
- `cargo fmt` clean.
- Behavior for the common path (default key) is unchanged.