### PR TITLE
feat(python): KSM-877 throttle retry with exponential backoff

### DIFF
--- a/sdk/python/core/CHANGELOG.md
+++ b/sdk/python/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 17.2.2
+* KSM-877 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, requests are retried up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` (subclass of `KeeperError`) is raised once retries are exhausted. Existing key-rotation retry behavior is unchanged.
 * KSM-932 - IL5 custom server public key support — supports three provisioning paths: config field (`serverPublicKey`), OTS token extension (4-segment IL5 format), and programmatic parameter (`server_public_key` on `SecretsManager`)
 * KSM-808 - Config-decoding utilities (`base64_to_bytes`, `url_safe_str_to_bytes`, `base64_to_string`, `CryptoUtils.url_safe_str_to_bytes`) now raise `KeeperError` with actionable messages instead of cryptic `TypeError` when passed `None` from an incomplete config or empty server response field. Per-call-site guards in `core.py` name the specific missing `ConfigKey` (`appKey`, `clientKey`) and direct users to reinitialize with a fresh One-Time Token.
 

--- a/sdk/python/core/CHANGELOG.md
+++ b/sdk/python/core/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## 17.2.2
+## 17.3.0
 * KSM-877 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, requests are retried up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` (subclass of `KeeperError`) is raised once retries are exhausted. Existing key-rotation retry behavior is unchanged.
+
+## 17.2.2
 * KSM-932 - IL5 custom server public key support — supports three provisioning paths: config field (`serverPublicKey`), OTS token extension (4-segment IL5 format), and programmatic parameter (`server_public_key` on `SecretsManager`)
 * KSM-808 - Config-decoding utilities (`base64_to_bytes`, `url_safe_str_to_bytes`, `base64_to_string`, `CryptoUtils.url_safe_str_to_bytes`) now raise `KeeperError` with actionable messages instead of cryptic `TypeError` when passed `None` from an incomplete config or empty server response field. Per-call-site guards in `core.py` name the specific missing `ConfigKey` (`appKey`, `clientKey`) and direct users to reinitialize with a fresh One-Time Token.
 

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -13,9 +13,11 @@ import hmac
 import json
 import logging
 import os
+import random
 import re
 import requests
 import sys
+import time
 from base64 import urlsafe_b64decode
 from http import HTTPStatus
 from typing import List, Tuple, Optional
@@ -31,9 +33,10 @@ from keeper_secrets_manager_core.dto.payload import GetPayload, \
     EncryptedPayload, KSMHttpResponse, CreatePayload, FileUploadPayload, \
     DeletePayload, CreateFolderPayload, UpdateFolderPayload, \
     DeleteFolderPayload, CreateOptions, QueryOptions
-from keeper_secrets_manager_core.exceptions import KeeperError
+from keeper_secrets_manager_core.exceptions import KeeperError, KeeperThrottleError
 from keeper_secrets_manager_core.keeper_globals import keeper_public_keys, \
-    keeper_secrets_manager_sdk_client_id, logger_name, keeper_servers
+    keeper_secrets_manager_sdk_client_id, logger_name, keeper_servers, \
+    MAX_THROTTLE_RETRIES, BASE_THROTTLE_DELAY_SEC
 from keeper_secrets_manager_core.storage import FileKeyValueStorage, \
     KeyValueStorage, InMemoryKeyValueStorage
 from keeper_secrets_manager_core.utils import base64_to_bytes, dict_to_json, \
@@ -653,6 +656,8 @@ class SecretsManager:
         keeper_server = helpers.get_server(self.hostname, self.config)
         url = "https://%s/api/rest/sm/v1/%s" % (keeper_server, path)
 
+        throttle_attempt = 0
+
         while True:
 
             transmission_key_id = self.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID)
@@ -668,6 +673,23 @@ class SecretsManager:
             # If we are ok, then break out of the while loop
             if ksm_rs.status_code == 200:
                 break
+
+            # The backend throttles with HTTP 403 {"error":"throttled"}. Retry with exponential
+            # backoff + jitter before falling through to generic error handling. Checked before
+            # handler_http_error so the existing key-rotation retry path is left untouched.
+            retry_after = self._parse_throttle(ksm_rs.http_response)
+            if retry_after is not None:
+                if throttle_attempt >= MAX_THROTTLE_RETRIES:
+                    raise KeeperThrottleError(
+                        "Request throttled by Keeper backend; exhausted %d retries"
+                        % MAX_THROTTLE_RETRIES)
+                delay = self._throttle_delay(throttle_attempt, retry_after)
+                self.logger.warning(
+                    "Request throttled (attempt %d/%d); retrying in %.1fs"
+                    % (throttle_attempt + 1, MAX_THROTTLE_RETRIES, delay))
+                time.sleep(delay)
+                throttle_attempt += 1
+                continue
 
             # Handle the error. Handling will throw an exception if it doesn't want us to retry.
             self.handler_http_error(ksm_rs.http_response)
@@ -728,6 +750,42 @@ class SecretsManager:
         else:
             return None
 
+    @staticmethod
+    def _parse_throttle(http_response):
+        """If the response is a backend throttle error, return its retry_after (>= 0), else None.
+
+        Throttle responses are HTTP 403 with a JSON body {"error":"throttled", ...} and an
+        optional numeric "retry_after" field (seconds). Returns None for any non-throttle
+        response (including non-JSON bodies) so the caller falls through to normal error handling.
+        """
+        try:
+            response_dict = utils.json_to_dict(http_response.text)
+        except Exception:
+            return None
+        if not response_dict:
+            return None
+        if response_dict.get('result_code', response_dict.get('error')) != 'throttled':
+            return None
+        try:
+            retry_after = float(response_dict.get('retry_after', 0) or 0)
+        except (TypeError, ValueError):
+            retry_after = 0.0
+        return max(retry_after, 0.0)
+
+    @staticmethod
+    def _throttle_delay(attempt, retry_after=0.0):
+        """Compute the throttle backoff delay in seconds for a 0-based attempt number.
+
+        Uses retry_after when the server provides one (> 0), otherwise exponential backoff
+        (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11s, 22s, 44s, 88s, 176s). A +/- 25% jitter is
+        then applied to desynchronize concurrent clients retrying at the same time.
+        """
+        if retry_after and retry_after > 0:
+            delay = retry_after
+        else:
+            delay = BASE_THROTTLE_DELAY_SEC * (2 ** attempt)
+        delay += delay * random.uniform(-0.25, 0.25)
+        return delay
 
     def handler_http_error(self, rs):
 

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -677,19 +677,22 @@ class SecretsManager:
             # The backend throttles with HTTP 403 {"error":"throttled"}. Retry with exponential
             # backoff + jitter before falling through to generic error handling. Checked before
             # handler_http_error so the existing key-rotation retry path is left untouched.
-            retry_after = self._parse_throttle(ksm_rs.http_response)
-            if retry_after is not None:
-                if throttle_attempt >= MAX_THROTTLE_RETRIES:
-                    raise KeeperThrottleError(
-                        "Request throttled by Keeper backend; exhausted %d retries"
-                        % MAX_THROTTLE_RETRIES)
-                delay = self._throttle_delay(throttle_attempt, retry_after)
-                self.logger.warning(
-                    "Request throttled (attempt %d/%d); retrying in %.1fs"
-                    % (throttle_attempt + 1, MAX_THROTTLE_RETRIES, delay))
-                time.sleep(delay)
-                throttle_attempt += 1
-                continue
+            # Gated on the 403 status so a non-403 response (e.g. 500/502) that happens to carry
+            # a {"error":"throttled"} body is not mistaken for a throttle and retried.
+            if ksm_rs.status_code == 403:
+                retry_after = self._parse_throttle(ksm_rs.http_response)
+                if retry_after is not None:
+                    if throttle_attempt >= MAX_THROTTLE_RETRIES:
+                        raise KeeperThrottleError(
+                            "Request throttled by Keeper backend; exhausted %d retries"
+                            % MAX_THROTTLE_RETRIES)
+                    delay = self._throttle_delay(throttle_attempt, retry_after)
+                    self.logger.warning(
+                        "Request throttled (attempt %d/%d); retrying in %.1fs"
+                        % (throttle_attempt + 1, MAX_THROTTLE_RETRIES, delay))
+                    time.sleep(delay)
+                    throttle_attempt += 1
+                    continue
 
             # Handle the error. Handling will throw an exception if it doesn't want us to retry.
             self.handler_http_error(ksm_rs.http_response)

--- a/sdk/python/core/keeper_secrets_manager_core/exceptions.py
+++ b/sdk/python/core/keeper_secrets_manager_core/exceptions.py
@@ -25,3 +25,16 @@ class KeeperAccessDenied(Exception):
         self.message = message
 
         super().__init__(self.message)
+
+
+class KeeperThrottleError(KeeperError):
+
+    """Raised when the Keeper backend throttles requests and the SDK has
+    exhausted its automatic retries (see MAX_THROTTLE_RETRIES).
+
+    Subclasses KeeperError so existing ``except KeeperError`` handlers keep
+    working; callers that want to react specifically to throttling can catch
+    this type instead.
+    """
+
+    pass

--- a/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
+++ b/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
@@ -100,3 +100,9 @@ keeper_servers = {
     'CA': 'keepersecurity.ca',
     'IL5': 'il5.keepersecurity.us'
 }
+
+# Throttle retry (KSM-876 / KSM-877). The backend throttles HTTP 403 {"error":"throttled"}
+# per clientId+endpoint (100 requests / 10s window; memcached TTL is 10s and resets on every
+# request, so the counter only clears after 10s of silence).
+MAX_THROTTLE_RETRIES = 5
+BASE_THROTTLE_DELAY_SEC = 11  # 1s safety margin over the backend's 10s memcached TTL

--- a/sdk/python/core/tests/throttle_test.py
+++ b/sdk/python/core/tests/throttle_test.py
@@ -243,6 +243,19 @@ class ThrottleRetryIntegrationTest(unittest.TestCase):
         mock_sleep.assert_not_called()
 
     @patch(SLEEP)
+    def test_throttle_body_non_403_not_retried(self, mock_sleep):
+        # A non-403 response (e.g. 500) that happens to carry a {"error":"throttled"} body
+        # must NOT be treated as a throttle: it falls straight through to error handling.
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        body = {"error": "throttled", "message": "throttled"}
+        q.add_response(mock.Response(content=json.dumps(body).encode(), status_code=500))
+
+        with self.assertRaises(KeeperError):
+            sm.get_secrets()
+        mock_sleep.assert_not_called()
+
+    @patch(SLEEP)
     def test_counter_resets_per_call(self, mock_sleep):
         sm = make_sm()
         q = mock.ResponseQueue(client=sm)

--- a/sdk/python/core/tests/throttle_test.py
+++ b/sdk/python/core/tests/throttle_test.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ (R)
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2024 Keeper Security Inc.
+# Contact: sm@keepersecurity.com
+
+"""KSM-877 — throttle retry with exponential backoff.
+
+The backend throttles with HTTP 403 {"error":"throttled"}; the SDK retries inside the
+``_post_query`` loop with exponential backoff + jitter (see ``MAX_THROTTLE_RETRIES`` /
+``BASE_THROTTLE_DELAY_SEC``) and raises ``KeeperThrottleError`` once retries are exhausted.
+
+``time.sleep`` is patched in every test so the suite never actually waits, and
+``random.uniform`` is patched where a deterministic delay value is asserted.
+"""
+
+import json
+import logging
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from requests import HTTPError
+
+from keeper_secrets_manager_core import SecretsManager, mock
+from keeper_secrets_manager_core.configkeys import ConfigKeys
+from keeper_secrets_manager_core.exceptions import KeeperError, KeeperThrottleError
+from keeper_secrets_manager_core.keeper_globals import (
+    BASE_THROTTLE_DELAY_SEC,
+    MAX_THROTTLE_RETRIES,
+    logger_name,
+)
+from keeper_secrets_manager_core.mock import MockConfig
+from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
+
+# Patch targets — core.py does ``import random`` / ``import time``.
+SLEEP = "keeper_secrets_manager_core.core.time.sleep"
+UNIFORM = "keeper_secrets_manager_core.core.random.uniform"
+
+
+def make_sm():
+    return SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+
+
+def throttled_response(retry_after=None):
+    """A canned HTTP 403 throttle response (optionally carrying retry_after)."""
+    body = {"error": "throttled", "message": "throttled"}
+    if retry_after is not None:
+        body["retry_after"] = retry_after
+    return mock.Response(content=json.dumps(body).encode(), status_code=403)
+
+
+def record_response(title="My Record"):
+    """A normal 200 response containing a single record."""
+    res = mock.Response()
+    rec = res.add_record(title=title)
+    rec.field("login", "My Login")
+    rec.field("password", "My Password")
+    return res
+
+
+class ThrottleDelayUnitTest(unittest.TestCase):
+    """Pure-function coverage of the delay computation and throttle detection."""
+
+    def _delay_no_jitter(self, attempt, retry_after=0.0):
+        with patch(UNIFORM, return_value=0.0):
+            return SecretsManager._throttle_delay(attempt, retry_after)
+
+    def test_exponential_sequence(self):
+        delays = [self._delay_no_jitter(n, 0.0) for n in range(MAX_THROTTLE_RETRIES)]
+        self.assertEqual(delays, [11, 22, 44, 88, 176])
+
+    def test_retry_after_precedence(self):
+        # A positive retry_after wins over the exponential value (88 for attempt 3).
+        self.assertEqual(self._delay_no_jitter(3, 7.0), 7)
+
+    def test_retry_after_nonpositive_ignored(self):
+        self.assertEqual(self._delay_no_jitter(0, 0.0), 11)
+        self.assertEqual(self._delay_no_jitter(1, -5.0), 22)
+
+    def test_jitter_upper_bound(self):
+        with patch(UNIFORM, return_value=0.25):
+            self.assertAlmostEqual(SecretsManager._throttle_delay(0, 0.0), 13.75)
+
+    def test_jitter_lower_bound(self):
+        with patch(UNIFORM, return_value=-0.25):
+            self.assertAlmostEqual(SecretsManager._throttle_delay(0, 0.0), 8.25)
+
+    def test_jitter_within_bounds_real_random(self):
+        base = BASE_THROTTLE_DELAY_SEC * (2 ** 2)  # attempt 2 -> 44
+        for _ in range(1000):
+            delay = SecretsManager._throttle_delay(2, 0.0)
+            self.assertGreaterEqual(delay, base * 0.75)
+            self.assertLessEqual(delay, base * 1.25)
+
+    def test_parse_throttle_no_retry_after(self):
+        r = SimpleNamespace(text=json.dumps({"error": "throttled"}))
+        self.assertEqual(SecretsManager._parse_throttle(r), 0.0)
+
+    def test_parse_throttle_with_retry_after(self):
+        r = SimpleNamespace(text=json.dumps({"error": "throttled", "retry_after": 5}))
+        self.assertEqual(SecretsManager._parse_throttle(r), 5.0)
+
+    def test_parse_throttle_result_code_key(self):
+        # handler_http_error reads result_code before error; _parse_throttle mirrors that.
+        r = SimpleNamespace(text=json.dumps({"result_code": "throttled"}))
+        self.assertEqual(SecretsManager._parse_throttle(r), 0.0)
+
+    def test_parse_throttle_other_error_is_none(self):
+        r = SimpleNamespace(text=json.dumps({"error": "access_denied"}))
+        self.assertIsNone(SecretsManager._parse_throttle(r))
+
+    def test_parse_throttle_non_json_is_none(self):
+        self.assertIsNone(SecretsManager._parse_throttle(SimpleNamespace(text="Bad Gateway")))
+
+    def test_parse_throttle_empty_is_none(self):
+        self.assertIsNone(SecretsManager._parse_throttle(SimpleNamespace(text="")))
+        self.assertIsNone(SecretsManager._parse_throttle(SimpleNamespace(text=None)))
+
+    def test_parse_throttle_bad_retry_after(self):
+        r = SimpleNamespace(text=json.dumps({"error": "throttled", "retry_after": "soon"}))
+        self.assertEqual(SecretsManager._parse_throttle(r), 0.0)
+
+
+class ThrottleRetryIntegrationTest(unittest.TestCase):
+    """End-to-end coverage through the public API, driving the real _post_query loop."""
+
+    def setUp(self):
+        self.orig_working_dir = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self.orig_working_dir)
+
+    @patch(SLEEP)
+    def test_retry_then_success(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(throttled_response())
+        q.add_response(record_response())
+
+        records = sm.get_secrets()
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    @patch(UNIFORM, return_value=0.0)
+    @patch(SLEEP)
+    def test_multiple_throttles_then_success(self, mock_sleep, _uniform):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(throttled_response())
+        q.add_response(throttled_response())
+        q.add_response(record_response())
+
+        records = sm.get_secrets()
+
+        self.assertEqual(len(records), 1)
+        delays = [c.args[0] for c in mock_sleep.call_args_list]
+        self.assertEqual(delays, [11, 22])  # exponential, jitter pinned to 0
+
+    @patch(SLEEP)
+    def test_retry_exhausted_raises(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        for _ in range(MAX_THROTTLE_RETRIES + 1):
+            q.add_response(throttled_response())
+
+        with self.assertRaises(KeeperThrottleError) as ctx:
+            sm.get_secrets()
+
+        # Subclasses KeeperError, so legacy handlers still catch it.
+        self.assertIsInstance(ctx.exception, KeeperError)
+        self.assertEqual(mock_sleep.call_count, MAX_THROTTLE_RETRIES)
+
+    @patch(UNIFORM, return_value=0.0)
+    @patch(SLEEP)
+    def test_retry_after_honored(self, mock_sleep, _uniform):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(throttled_response(retry_after=2))
+        q.add_response(record_response())
+
+        records = sm.get_secrets()
+
+        self.assertEqual(len(records), 1)
+        mock_sleep.assert_called_once_with(2)
+
+    @patch(SLEEP)
+    def test_retry_on_write_path(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(record_response())  # initial get to obtain a record
+        record = sm.get_secrets()[0]
+
+        q.add_response(throttled_response())       # save() throttled once
+        q.add_response(mock.Response(content=""))  # then succeeds
+        sm.save(record)
+
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    @patch(SLEEP)
+    def test_throttle_and_key_rotation_compose(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(throttled_response())
+        q.add_response(mock.Response(
+            content=json.dumps({"error": "key", "key_id": "2"}).encode(), status_code=403))
+        q.add_response(record_response())
+
+        records = sm.get_secrets()
+
+        self.assertEqual(len(records), 1)
+        # Key rotation still applied (unaffected by the throttle path)...
+        self.assertEqual(sm.config.get(ConfigKeys.KEY_SERVER_PUBLIC_KEY_ID), "2")
+        # ...and only the throttle slept; key rotation does not consume throttle budget.
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    @patch(SLEEP)
+    def test_non_throttle_403_not_retried(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        err = {"error": "access_denied", "message": "Signature is invalid"}
+        q.add_response(mock.Response(content=json.dumps(err).encode(), status_code=403))
+
+        with self.assertRaises(KeeperError):
+            sm.get_secrets()
+        mock_sleep.assert_not_called()
+
+    @patch(SLEEP)
+    def test_non_json_502_not_retried(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(mock.Response(content=b"Bad Gateway", status_code=502))
+
+        with self.assertRaises(HTTPError):
+            sm.get_secrets()
+        mock_sleep.assert_not_called()
+
+    @patch(SLEEP)
+    def test_counter_resets_per_call(self, mock_sleep):
+        sm = make_sm()
+        q = mock.ResponseQueue(client=sm)
+        # Two independent calls, each throttled once then served.
+        q.add_response(throttled_response())
+        q.add_response(record_response())
+        q.add_response(throttled_response())
+        q.add_response(record_response())
+
+        self.assertEqual(len(sm.get_secrets()), 1)
+        self.assertEqual(len(sm.get_secrets()), 1)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+
+class ThrottleLoggingTest(unittest.TestCase):
+    """The retry path logs a WARNING with the attempt number and the delay."""
+
+    @patch(SLEEP)
+    def test_logs_warning_on_throttle(self, _mock_sleep):
+        sm = SecretsManager(
+            config=InMemoryKeyValueStorage(MockConfig.make_config()), log_level="WARNING")
+        logging.getLogger(logger_name).disabled = False  # defensive (singleton logger)
+
+        q = mock.ResponseQueue(client=sm)
+        q.add_response(throttled_response())
+        q.add_response(record_response())
+
+        with self.assertLogs(logger_name, level="WARNING") as cm:
+            records = sm.get_secrets()
+
+        self.assertEqual(len(records), 1)
+        output = "\n".join(cm.output)
+        self.assertIn("throttled", output.lower())
+        self.assertRegex(output, r"attempt 1/%d" % MAX_THROTTLE_RETRIES)
+
+
+class ThrottleLiveIntegrationTest(unittest.TestCase):
+    """Optional live-backend smoke test (skipped unless KSM_INTEGRATION_CONFIG is set).
+
+    A real throttle (HTTP 403 throttled) cannot be reliably forced in CI without abusively
+    hammering the backend (>100 req/10s) or lowering the server-side ServerSettingDAO limit, so
+    this only confirms the modified _post_query still works end-to-end against a live server.
+    Provide a base64 KSM config via KSM_INTEGRATION_CONFIG to run it as a manual QA step.
+    """
+
+    @unittest.skipUnless(
+        os.environ.get("KSM_INTEGRATION_CONFIG"),
+        "set KSM_INTEGRATION_CONFIG (base64 KSM config) to run the live test")
+    def test_live_get_secrets(self):
+        sm = SecretsManager(
+            config=InMemoryKeyValueStorage(os.environ["KSM_INTEGRATION_CONFIG"]))
+        records = sm.get_secrets()
+        self.assertIsInstance(records, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Supersedes #1031**, which was auto-closed when its base branch `release/sdk/python/core/v17.2.2` was deleted. Same change, retargeted to `release/sdk/python/core/v17.3.0` with the CHANGELOG entry moved under `## 17.3.0`.

## Summary
Implements throttle retry with exponential backoff for the Python SDK (epic KSM-876, task KSM-877). The Keeper backend throttles with **HTTP 403 `{"error":"throttled"}`**; previously the SDK raised `KeeperError` on the first throttle. Now `_post_query` retries transparently, so every `SecretsManager` operation gains throttle resilience with no caller changes.

## What changed
- **`core.py`** — in the `_post_query` loop, detect throttle responses *before* `handler_http_error` and retry with exponential backoff + jitter; raise `KeeperThrottleError` once retries are exhausted. Two static helpers added: `_parse_throttle` (detection / `retry_after`) and `_throttle_delay` (backoff + jitter).
- **`keeper_globals.py`** — `MAX_THROTTLE_RETRIES = 5`, `BASE_THROTTLE_DELAY_SEC = 11` (1s margin over the backend's 10s memcached TTL). No new config keys or env vars.
- **`exceptions.py`** — new `KeeperThrottleError(KeeperError)`; subclassing keeps existing `except KeeperError` handlers working.
- **`CHANGELOG.md`** — entry under `## 17.3.0` (matching the v17.3.0 release branch; `_version.py` is already `17.3.0` on this branch).

## Algorithm
Delays `11s, 22s, 44s, 88s, 176s` (each ±25% jitter) → ~341s worst case over 5 retries. A `retry_after` in the response body takes precedence when present. `handler_http_error` is left untouched, so **key-rotation retry is unaffected**.

## Tests
New `tests/throttle_test.py` — 23 unit + end-to-end cases (`time.sleep` / `random.uniform` patched) covering delay computation, throttle detection, retry-then-success, multi-throttle delay verification, exhaustion → `KeeperThrottleError`, `retry_after` honored, write-path (`save`) retry, throttle + key-rotation compose, non-throttle 403/502 not retried, per-call counter reset, and WARNING logging; plus an optional env-gated live-backend test.

```
$ python -m pytest tests/ -q
102 passed, 1 skipped, 2 warnings
```

Jira: [KSM-877](https://keeper.atlassian.net/browse/KSM-877)


[KSM-877]: https://keeper.atlassian.net/browse/KSM-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
