### PR TITLE
KSM-1004: resolve KSMCache path lazily so KSM_CACHE_DIR is honored after import

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1904,27 +1904,34 @@ class SecretsManager:
 
 
 class KSMCache:
-    # Allow the directory that will contain the cache to be set with environment variables. If not set, the
-    # cache file will be create in the current working directory.
+    # Default cache file name, kept for backward compatibility. The directory is read
+    # lazily from KSM_CACHE_DIR at call time (see get_cache_file_path), so setting the
+    # env var after import is honored. If not set, the cache file is created in the
+    # current working directory.
     kms_cache_file_name = os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
+
+    @classmethod
+    def get_cache_file_path(cls):
+        return os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
 
     @staticmethod
     def save_cache(data):
-        cache_file = open(KSMCache.kms_cache_file_name, 'wb')
+        cache_file = open(KSMCache.get_cache_file_path(), 'wb')
         cache_file.write(data)
         cache_file.close()
 
     @staticmethod
     def get_cached_data():
-        cache_file = open(KSMCache.kms_cache_file_name, 'rb')
+        cache_file = open(KSMCache.get_cache_file_path(), 'rb')
         cache_data = cache_file.read()
         cache_file.close()
         return cache_data
 
     @staticmethod
     def remove_cache_file():
-        if os.path.exists(KSMCache.kms_cache_file_name) is True:
-            os.unlink(KSMCache.kms_cache_file_name)
+        cache_file_path = KSMCache.get_cache_file_path()
+        if os.path.exists(cache_file_path) is True:
+            os.unlink(cache_file_path)
 
     @staticmethod
     def caching_post_function(url, transmission_key, encrypted_payload_and_signature, verify_ssl_certs=True, proxy_url=None):

--- a/sdk/python/core/tests/cache_test.py
+++ b/sdk/python/core/tests/cache_test.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+
+from keeper_secrets_manager_core.core import KSMCache
+
+
+class CacheTest(unittest.TestCase):
+
+    def test_ksm_cache_dir_honored_when_set_after_import(self):
+        """KSM_CACHE_DIR must be honored at call time, not only when set before import (KSM-1004).
+
+        The module is already imported by the time this test runs (the import at the
+        top of the file), with KSM_CACHE_DIR unset. Setting it now and then exercising
+        the cache must place the file under the new directory.
+        """
+        original = os.environ.get("KSM_CACHE_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["KSM_CACHE_DIR"] = temp_dir
+            try:
+                payload = b"cache-bytes"
+                KSMCache.save_cache(payload)
+
+                expected_path = os.path.join(temp_dir, "ksm_cache.bin")
+                self.assertTrue(
+                    os.path.exists(expected_path),
+                    "cache file should be written under KSM_CACHE_DIR set after import",
+                )
+                self.assertEqual(payload, KSMCache.get_cached_data())
+
+                KSMCache.remove_cache_file()
+                self.assertFalse(
+                    os.path.exists(expected_path),
+                    "remove_cache_file should delete the lazily-resolved cache file",
+                )
+            finally:
+                if original is None:
+                    os.environ.pop("KSM_CACHE_DIR", None)
+                else:
+                    os.environ["KSM_CACHE_DIR"] = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/core/tests/proxy_test.py
+++ b/sdk/python/core/tests/proxy_test.py
@@ -139,9 +139,8 @@ class ProxyTest(unittest.TestCase):
         with open(ksm_cache_path, "wb") as cache_file:
             cache_file.write(b"")
 
-        # Reload the KSMCache module to ensure KSM_CACHE_DIR is set
-        import importlib, keeper_secrets_manager_core.core
-        importlib.reload(keeper_secrets_manager_core.core)
+        # KSM_CACHE_DIR is resolved lazily at call time (KSM-1004), so setting it
+        # above is enough; no module reload is needed.
         from keeper_secrets_manager_core.core import KSMCache
 
         with patch("requests.post", mocked_post):


### PR DESCRIPTION
## Summary

`KSMCache` resolved its cache file path from `KSM_CACHE_DIR` once, at import time, via the class attribute `kms_cache_file_name`. Setting the env var programmatically after `keeper_secrets_manager_core.core` was imported had no effect. This resolves the path lazily at call time so the documented env var is honored whenever it is set.

## Changes

### Maintenance
- Add `KSMCache.get_cache_file_path()` classmethod that reads `KSM_CACHE_DIR` at call time; route `save_cache`, `get_cached_data`, and `remove_cache_file` through it (KSM-1004)
- Keep the `kms_cache_file_name` class attribute for backward compatibility (no longer governs behavior)
- Drop the `importlib.reload` workaround in `test_proxy_url_passed_to_custom_post_function` — unnecessary now that the path resolves lazily

Default behavior is unchanged: with `KSM_CACHE_DIR` unset, the cache file is still created CWD-relative. `sys.frozen`/HOME-defaulting is intentionally out of scope (library file-location policy belongs to the consumer; CLI frozen-binary handling is KSM-1003).

## Testing

```bash
cd sdk/python/core && python -m pytest tests/
# new regression test:
python -m pytest tests/cache_test.py -v
```

New `tests/cache_test.py` sets `KSM_CACHE_DIR` after import and asserts the cache file is written/read/removed under that directory. It fails before this change and passes after. Full core suite: 108 passed, 1 skipped.

## Breaking Changes

None.

## Related Issues

- Jira: KSM-1004