### PR TITLE
fix(cli): ksm shell crash from update-checker 1.0.0 keyword-only check() (KSM-1005)

### DIFF
--- a/integration/keeper_secrets_manager_cli/README.md
+++ b/integration/keeper_secrets_manager_cli/README.md
@@ -11,6 +11,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - **Fix**: KSM-980 - Binary install created `keeper.ini` in the current working directory instead of the user's home directory. Now detects `sys.frozen` in `Config.get_default_ini_file()` and uses `$HOME`/`%USERPROFILE%` for binary installs, matching the existing `launched_from_app` behaviour.
 - **Fix**: KSM-981 - `ksm secret get` did not surface linked records (PAM credential records were invisible). Now passes `request_links=True` to the server so linked record UIDs are returned, includes a `links` array in JSON output, and shows a Links table in text output.
 - **Fix**: KSM-1003 - Binary install wrote `ksm_cache.bin` to the current working directory when caching was enabled (sibling to KSM-980). The CLI now sets `KSM_CACHE_DIR` to the same directory it resolves for `keeper.ini` before loading the SDK core, so the cache co-locates with the ini in `$HOME`/`%USERPROFILE%` for binary installs; pip/source installs are unchanged.
+- **Fix**: KSM-1005 - `ksm shell` crashed on launch (`UpdateChecker.check() takes 1 positional argument but 3 were given`) on any fresh install after the `update-checker` 1.0.0 release made `check()` keyword-only. The CLI now calls it with keyword arguments (compatible with both 0.18.0 and 1.0.0, no version pin needed), and the `shell` startup update check is wrapped in try/except so a failed update check can never block the shell from starting.
 
 ## 1.3.0
 - **Feature**: KSM-800 - OS-native keyring storage for CLI configuration

--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -197,7 +197,7 @@ def update_available(module, versions=None):
 
     if versions is None:
         versions = get_versions()
-    return UpdateChecker().check(module, versions[module])
+    return UpdateChecker().check(package_name=module, package_version=versions[module])
 
 
 def base_command_help(f):
@@ -1433,9 +1433,13 @@ def shell_command(app):
     versions = get_versions()
 
     print(Fore.CYAN + "Current Version: " + Fore.GREEN + versions.get("keeper-secrets-manager-cli", "") + Style.RESET_ALL)
-    update = update_available("keeper-secrets-manager-cli", versions)
-    if update is not None:
-        print(Fore.YELLOW + "Version {} is available.".format(update.available_version) + Style.RESET_ALL)
+    try:
+        update = update_available("keeper-secrets-manager-cli", versions)
+        if update is not None:
+            print(Fore.YELLOW + "Version {} is available.".format(update.available_version) + Style.RESET_ALL)
+    except (Exception,):
+        # A failed update check must never block the shell from starting.
+        pass
 
     print("\nRunning in shell mode. Type 'quit' to exit.\n")
 

--- a/integration/keeper_secrets_manager_cli/tests/update_check_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/update_check_test.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch
+
+from conftest import CliRunner
+from keeper_secrets_manager_cli import __main__
+
+
+class UpdateCheckTest(unittest.TestCase):
+
+    def test_update_available_calls_check_with_keywords(self):
+        """KSM-1005 regression: update_available() must call UpdateChecker.check()
+        with keyword arguments.
+
+        update_checker 1.0.0 (published to PyPI 2026-06-08, first release since
+        0.18.0) made UpdateChecker.check() keyword-only:
+
+            check(self, *, package_name, package_version)
+
+        The CLI previously called it positionally (__main__.py:200), so every
+        fresh install resolving 1.0.0 crashed `ksm shell` on launch with:
+
+            UpdateChecker.check() takes 1 positional argument but 3 were given
+
+        The StubUpdateChecker below mirrors the 1.0.0 keyword-only signature. A
+        positional call binds against it as TypeError (this test fails); the
+        keyword-argument fix passes. setup.py leaves update-checker unpinned, and
+        0.18.0 uses the same parameter names, so the keyword call is compatible
+        with both versions.
+
+        See: https://keeper.atlassian.net/browse/KSM-1005
+        """
+        captured = {}
+
+        class StubUpdateChecker:
+            # Mirrors update_checker 1.0.0's keyword-only check() signature.
+            def check(self, *, package_name, package_version):
+                captured["package_name"] = package_name
+                captured["package_version"] = package_version
+                return None
+
+        versions = {"keeper-secrets-manager-cli": "1.4.0"}
+        with patch.object(__main__, "UpdateChecker", StubUpdateChecker):
+            result = __main__.update_available("keeper-secrets-manager-cli", versions)
+
+        self.assertIsNone(result)
+        self.assertEqual(captured["package_name"], "keeper-secrets-manager-cli")
+        self.assertEqual(captured["package_version"], "1.4.0")
+
+    def test_shell_start_survives_update_check_failure(self):
+        """KSM-1005 hardening: a failing update check must not stop `ksm shell`
+        from starting.
+
+        version_command (__main__.py:1393) and base_command_help (__main__.py:214)
+        already wrap their update check in try/except; shell_command (1436) called
+        it bare, so the KSM-1005 TypeError escaped to the top-level handler and the
+        CLI exited before the shell opened. This test forces the update check to
+        raise and asserts the shell still reaches the REPL.
+
+        See: https://keeper.atlassian.net/browse/KSM-1005
+        """
+        def boom(*args, **kwargs):
+            raise TypeError(
+                "UpdateChecker.check() takes 1 positional argument but 3 were given")
+
+        runner = CliRunner()
+        with patch.object(__main__, "update_available", side_effect=boom), \
+                patch.object(__main__, "Config"), \
+                patch.object(__main__, "repl") as mock_repl:
+            result = runner.invoke(__main__.cli, ["shell"])
+
+        self.assertEqual(
+            result.exit_code, 0,
+            msg="shell did not start after update-check failure "
+                f"(exit {result.exit_code}): {result.output}\n{result.exception}")
+        mock_repl.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

[KSM-1005](https://keeper.atlassian.net/browse/KSM-1005): `ksm shell` crashed on launch (`ksm had a problem: UpdateChecker.check() takes 1 positional argument but 3 were given`) on any fresh `pip install` performed on or after 2026-06-08.

The third-party `update-checker` package published **1.0.0** that day (its first release since 0.18.0 in 2020), making `UpdateChecker.check()` keyword-only: `check(self, *, package_name, package_version)`. `setup.py` declares `update-checker` unpinned, so every fresh environment now resolves 1.0.0, and the positional call in `update_available()` raised `TypeError`. `shell` was the visible casualty because its update check was the only one not wrapped in try/except (`version` and the base help text already swallow the failure).

## Changes

- Call `UpdateChecker().check()` with keyword arguments (`package_name=`, `package_version=`). 0.18.0 uses the same parameter names, so this works against both 0.18.0 and 1.0.0 — no version pin carried.
- Wrap the `shell` startup update check in try/except, matching `version_command` and `base_command_help`, so a failed update check can never block shell startup.

## Testing

- New regression tests in `tests/update_check_test.py`: one asserts `update_available()` invokes `check()` with keywords (stubbing the 1.0.0 keyword-only signature); one asserts `ksm shell` still reaches the REPL when the update check raises. Both fail before the fix, pass after.
- Full CLI suite: 146 passed, 5 skipped.
- Live app test: installed the branch into a venv with `update-checker==1.0.0` (the broken combo) and ran `ksm shell` and `ksm version` — both work, no crash.

## Breaking Changes

None.

[KSM-1005]: https://keeper.atlassian.net/browse/KSM-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ