### PR TITLE
feat(rust): KSM-882 throttle retry with exponential backoff

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **KSM-882**: Automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `post_query` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; returns the new `KSMRError::Throttled` once retries are exhausted. Existing key-rotation retry behavior is unchanged.
 - **KSM-904**: IL5 dynamic server public key injection — three-layer mechanism for isolated deployments (e.g. IL5 region) that use a non-standard server key not present in the hardcoded key map:
   - **Layer 1 (core)**: `generate_transmission_key()` accepts an optional `custom_public_key_b64` parameter; `post_query()` reads `serverPublicKey` from config and passes it automatically
   - **Layer 2 (OTT)**: 4-segment IL5 token format `IL5:clientKey:keyId:serverPublicKeyBase64` — key material is written to config at `SecretsManager::new()` time so Layer 1 picks it up without additional steps. Invalid base64 in the public key segment is rejected with a clear error.

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -55,7 +55,7 @@ use serde_json::Value;
 
 /// Custom post function type for HTTP request injection (used for testing and mocking).
 ///
-/// Changed in v17.2.0 (KSM-931) from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>` to allow
+/// Changed in v17.2.0 from `fn(...)` to `Arc<dyn Fn(...) + Send + Sync>` to allow
 /// closures that capture state (e.g. a shared `reqwest::blocking::Client`). Existing call
 /// sites using `options.set_custom_post_function(my_fn)` continue to compile unchanged
 /// because bare `fn` pointers implement `Fn + Send + Sync + 'static`.
@@ -994,7 +994,7 @@ impl SecretsManager {
         Ok(proxy)
     }
 
-    /// `_verify_ssl_certificates` is accepted for API compatibility but ignored since KSM-926;
+    /// `_verify_ssl_certificates` is accepted for API compatibility but ignored;
     /// TLS verification is controlled by `verify_ssl_certs` set in `SecretsManager::new()`.
     pub fn post_function(
         self,
@@ -1399,7 +1399,7 @@ impl SecretsManager {
                 return Ok(keeper_result);
             }
 
-            // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-882). Detected
+            // Throttle retry with exponential backoff + jitter. Detected
             // before handle_http_error so the existing key-rotation retry path is untouched.
             // Gated on the 403 status so a non-403 response carrying a {"error":"throttled"}
             // body is not mistaken for a throttle and retried.
@@ -4168,7 +4168,7 @@ mod key_rotation_regression {
 mod throttle_unit {
     use super::{parse_throttle, throttle_delay};
 
-    // throttle_delay with zero jitter yields the exact exponential sequence (KSM-876).
+    // throttle_delay with zero jitter yields the exact exponential sequence.
     #[test]
     fn delay_exponential_sequence_no_jitter() {
         let expected = [11.0, 22.0, 44.0, 88.0, 176.0];

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -12,6 +12,7 @@
 
 use std::env;
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::cache::{self, KSMCache};
 use crate::dto::dtos::{KeeperFileUpload, KeeperFolder, RecordCreate};
@@ -43,7 +44,9 @@ use crate::dto::{
     TransmissionKey, UpdateFolderPayload, UpdatePayload, UpdateTransactionType,
 };
 use crate::helpers::get_servers;
-use crate::keeper_globals::KEEPER_SECRETS_MANAGER_SDK_CLIENT_ID;
+use crate::keeper_globals::{
+    BASE_THROTTLE_DELAY_SEC, KEEPER_SECRETS_MANAGER_SDK_CLIENT_ID, MAX_THROTTLE_RETRIES,
+};
 use crate::utils::{base64_to_bytes, bytes_to_base64, json_to_dict, string_to_bytes};
 use log::{debug, error, info, warn};
 use regex::Regex;
@@ -61,6 +64,51 @@ pub type CustomPostFunction = std::sync::Arc<
         + Send
         + Sync,
 >;
+
+/// Optional sleep override used between throttle retries (primarily for testing/mocking).
+/// When unset, `std::thread::sleep` is used. Mirrors [`CustomPostFunction`].
+pub type CustomSleepFunction = std::sync::Arc<dyn Fn(Duration) + Send + Sync>;
+
+/// Returns a jitter multiplier in `[-0.25, 0.25)`. Kept separate so concurrent clients
+/// desynchronize their retries; unit tests exercise [`throttle_delay`] with a pinned jitter.
+fn throttle_jitter() -> f64 {
+    use rand::Rng;
+    rand::thread_rng().gen_range(-0.25..0.25)
+}
+
+/// Reports whether `body` is a backend throttle error (`result_code`/`error` == "throttled")
+/// and, if so, returns its optional `retry_after` (seconds, `>= 0`). Returns `None` for any
+/// non-throttle response (including non-JSON or empty bodies) so the caller falls through to
+/// normal error handling.
+fn parse_throttle(body: Option<&str>) -> Option<f64> {
+    let dict = json_to_dict(body?)?;
+    let rc = dict
+        .get("result_code")
+        .or_else(|| dict.get("error"))
+        .and_then(|v| v.as_str())?;
+    if rc != "throttled" {
+        return None;
+    }
+    let retry_after = match dict.get("retry_after") {
+        Some(Value::Number(n)) => n.as_f64().unwrap_or(0.0),
+        Some(Value::String(s)) => s.parse::<f64>().unwrap_or(0.0),
+        _ => 0.0,
+    };
+    Some(retry_after.max(0.0))
+}
+
+/// Computes the backoff delay for a 0-based `attempt`: `retry_after` when provided (`> 0`),
+/// otherwise exponential backoff (`BASE_THROTTLE_DELAY_SEC * 2**attempt` -> 11, 22, 44, 88,
+/// 176s). The `jitter` fraction (typically in `[-0.25, 0.25)`) is then applied.
+fn throttle_delay(attempt: u32, retry_after: f64, jitter: f64) -> Duration {
+    let base = if retry_after > 0.0 {
+        retry_after
+    } else {
+        (BASE_THROTTLE_DELAY_SEC as f64) * 2f64.powi(attempt as i32)
+    };
+    let secs = (base + base * jitter).max(0.0);
+    Duration::from_secs_f64(secs)
+}
 
 pub struct ClientOptions {
     pub token: String,
@@ -310,6 +358,9 @@ pub struct SecretsManager {
     pub cache: KSMCache,
     pub proxy_url: Option<String>,
     custom_post_function: Option<CustomPostFunction>,
+    /// Optional sleep override for throttle backoff (defaults to `std::thread::sleep`); tests
+    /// inject a no-op/recording sleeper via [`SecretsManager::set_custom_sleep_function`].
+    custom_sleep_function: Option<CustomSleepFunction>,
     /// Pre-built HTTP client shared across all operations (API calls + file downloads).
     /// Built once during init to avoid constructing reqwest::blocking::Client inside
     /// tokio::spawn_blocking, which fails due to nested runtime conflicts.
@@ -328,6 +379,7 @@ impl Clone for SecretsManager {
             cache: self.cache.clone(),
             proxy_url: self.proxy_url.clone(),
             custom_post_function: self.custom_post_function.clone(),
+            custom_sleep_function: self.custom_sleep_function.clone(),
             http_client: self.http_client.clone(),
         }
     }
@@ -397,6 +449,7 @@ impl SecretsManager {
             cache: KSMCache::None,
             proxy_url: client_options.proxy_url.clone(),
             custom_post_function: client_options.custom_post_function,
+            custom_sleep_function: None,
             http_client: None, // built after SSL/proxy config is resolved
         };
 
@@ -1270,6 +1323,15 @@ impl SecretsManager {
         Ok(ksp)
     }
 
+    /// Override the sleep used between throttle retries (primarily for tests/mocking). When
+    /// unset, `std::thread::sleep` is used. Accepts any `Fn(Duration) + Send + Sync + 'static`.
+    pub fn set_custom_sleep_function<F>(&mut self, f: F)
+    where
+        F: Fn(Duration) + Send + Sync + 'static,
+    {
+        self.custom_sleep_function = Some(std::sync::Arc::new(f));
+    }
+
     fn post_query(&mut self, path: String, payload: &dyn Payload) -> Result<Vec<u8>, KSMRError> {
         let keeper_server = get_servers(self.hostname.clone(), self.config.clone())
             .map_err(|e| KSMRError::StorageError(e.to_string()))?;
@@ -1278,6 +1340,10 @@ impl SecretsManager {
         let mut keeper_response: KsmHttpResponse;
         let mut transmission_key: TransmissionKey;
         let mut retry = true;
+        // Cloned once so the throttle sleeper can be invoked without borrowing `self` across
+        // the later `&mut self` call to `handle_http_error`.
+        let throttle_sleeper = self.custom_sleep_function.clone();
+        let mut throttle_attempt: u32 = 0;
         while retry {
             let transmission_key_id = self
                 .config
@@ -1331,6 +1397,35 @@ impl SecretsManager {
                     CryptoUtils::decrypt_aes(&keeper_response.data, &transmission_key.key)?
                 };
                 return Ok(keeper_result);
+            }
+
+            // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-882). Detected
+            // before handle_http_error so the existing key-rotation retry path is untouched.
+            // Gated on the 403 status so a non-403 response carrying a {"error":"throttled"}
+            // body is not mistaken for a throttle and retried.
+            if keeper_response.status_code == 403 {
+                if let Some(retry_after) = parse_throttle(keeper_response.http_response.as_deref()) {
+                    if throttle_attempt >= MAX_THROTTLE_RETRIES {
+                        error!("Request throttled; exhausted {} retries", MAX_THROTTLE_RETRIES);
+                        return Err(KSMRError::Throttled(format!(
+                            "Request throttled by Keeper backend; exhausted {} retries",
+                            MAX_THROTTLE_RETRIES
+                        )));
+                    }
+                    let delay = throttle_delay(throttle_attempt, retry_after, throttle_jitter());
+                    warn!(
+                        "Request throttled (attempt {}/{}); retrying in {:.1}s",
+                        throttle_attempt + 1,
+                        MAX_THROTTLE_RETRIES,
+                        delay.as_secs_f64()
+                    );
+                    match &throttle_sleeper {
+                        Some(sleeper) => sleeper(delay),
+                        None => std::thread::sleep(delay),
+                    }
+                    throttle_attempt += 1;
+                    continue;
+                }
             }
 
             // Handle the error. Handling will throw an exception if it doesn't want us to retry.
@@ -4066,5 +4161,71 @@ mod key_rotation_regression {
             result.is_err(),
             "a non-key error should surface as an error, not a retry"
         );
+    }
+}
+
+#[cfg(test)]
+mod throttle_unit {
+    use super::{parse_throttle, throttle_delay};
+
+    // throttle_delay with zero jitter yields the exact exponential sequence (KSM-876).
+    #[test]
+    fn delay_exponential_sequence_no_jitter() {
+        let expected = [11.0, 22.0, 44.0, 88.0, 176.0];
+        for (attempt, want) in expected.iter().enumerate() {
+            let got = throttle_delay(attempt as u32, 0.0, 0.0).as_secs_f64();
+            assert!(
+                (got - want).abs() < 1e-9,
+                "attempt {attempt}: got {got}, want {want}"
+            );
+        }
+    }
+
+    // retry_after (> 0) takes precedence over the exponential backoff.
+    #[test]
+    fn delay_retry_after_precedence() {
+        assert!((throttle_delay(3, 7.0, 0.0).as_secs_f64() - 7.0).abs() < 1e-9);
+    }
+
+    // A non-positive retry_after is ignored in favor of exponential backoff.
+    #[test]
+    fn delay_non_positive_retry_after_ignored() {
+        assert!((throttle_delay(0, 0.0, 0.0).as_secs_f64() - 11.0).abs() < 1e-9);
+        assert!((throttle_delay(1, -5.0, 0.0).as_secs_f64() - 22.0).abs() < 1e-9);
+    }
+
+    // +/-25% jitter keeps the first delay within [8.25, 13.75] (still > the 10s TTL at +0%).
+    #[test]
+    fn delay_jitter_bounds() {
+        assert!((throttle_delay(0, 0.0, -0.25).as_secs_f64() - 8.25).abs() < 1e-9);
+        assert!((throttle_delay(0, 0.0, 0.25).as_secs_f64() - 13.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_throttle_table() {
+        // throttled via "error"
+        assert_eq!(parse_throttle(Some(r#"{"error":"throttled"}"#)), Some(0.0));
+        // throttled via "result_code" with numeric retry_after
+        assert_eq!(
+            parse_throttle(Some(r#"{"result_code":"throttled","retry_after":5}"#)),
+            Some(5.0)
+        );
+        // string retry_after is parsed
+        assert_eq!(
+            parse_throttle(Some(r#"{"error":"throttled","retry_after":"3"}"#)),
+            Some(3.0)
+        );
+        // negative retry_after is clamped to 0
+        assert_eq!(
+            parse_throttle(Some(r#"{"error":"throttled","retry_after":-2}"#)),
+            Some(0.0)
+        );
+        // other error -> not throttled
+        assert_eq!(parse_throttle(Some(r#"{"error":"key"}"#)), None);
+        // non-JSON -> not throttled
+        assert_eq!(parse_throttle(Some("not json")), None);
+        // empty / none -> not throttled
+        assert_eq!(parse_throttle(Some("")), None);
+        assert_eq!(parse_throttle(None), None);
     }
 }

--- a/sdk/rust/src/custom_error.rs
+++ b/sdk/rust/src/custom_error.rs
@@ -88,6 +88,8 @@ pub enum KSMRError {
     TransactionError(String), // Transaction operation failures (commit/rollback)
     #[error("Configuration error: {0}")]
     ConfigurationError(String), // Configuration validation errors
+    #[error("Request throttled by Keeper backend: {0}")]
+    Throttled(String), // HTTP 403 {"error":"throttled"} — automatic retries exhausted
 }
 
 impl PartialEq for KSMRError {
@@ -161,6 +163,7 @@ impl PartialEq for KSMRError {
             (KSMRError::ConfigurationError(msg1), KSMRError::ConfigurationError(msg2)) => {
                 msg1 == msg2
             }
+            (KSMRError::Throttled(msg1), KSMRError::Throttled(msg2)) => msg1 == msg2,
             _ => false,
         }
     }

--- a/sdk/rust/src/keeper_globals.rs
+++ b/sdk/rust/src/keeper_globals.rs
@@ -22,3 +22,9 @@ pub fn get_client_version(_hardcode: bool) -> String {
 static CLIENT_VERSION: LazyLock<String> = LazyLock::new(|| get_client_version(false));
 pub static KEEPER_SECRETS_MANAGER_SDK_CLIENT_ID: LazyLock<String> =
     LazyLock::new(|| format!("{}{}", RUST_VERSION_PREFIX, CLIENT_VERSION.clone()));
+
+// Throttle retry (KSM-876 / KSM-882). The backend throttles HTTP 403 {"error":"throttled"}
+// per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+// request, so the counter only clears after 10s of silence).
+pub const MAX_THROTTLE_RETRIES: u32 = 5;
+pub const BASE_THROTTLE_DELAY_SEC: u64 = 11; // 1s safety margin over the backend's 10s memcached TTL

--- a/sdk/rust/src/keeper_globals.rs
+++ b/sdk/rust/src/keeper_globals.rs
@@ -23,7 +23,7 @@ static CLIENT_VERSION: LazyLock<String> = LazyLock::new(|| get_client_version(fa
 pub static KEEPER_SECRETS_MANAGER_SDK_CLIENT_ID: LazyLock<String> =
     LazyLock::new(|| format!("{}{}", RUST_VERSION_PREFIX, CLIENT_VERSION.clone()));
 
-// Throttle retry (KSM-876 / KSM-882). The backend throttles HTTP 403 {"error":"throttled"}
+// Throttle retry. The backend throttles HTTP 403 {"error":"throttled"}
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
 // request, so the counter only clears after 10s of silence).
 pub const MAX_THROTTLE_RETRIES: u32 = 5;

--- a/sdk/rust/tests/throttle_tests.rs
+++ b/sdk/rust/tests/throttle_tests.rs
@@ -1,0 +1,294 @@
+// -*- coding: utf-8 -*-
+//  _  __
+// | |/ /___ ___ _ __  ___ _ _ (R)
+// | ' </ -_) -_) '_ \/ -_) '_|
+// |_|\_\___\___| .__/\___|_|
+//              |_|
+//
+// Keeper Secrets Manager
+// Copyright 2024 Keeper Security Inc.
+// Contact: sm@keepersecurity.com
+//
+
+//! End-to-end tests for throttle retry with exponential backoff (KSM-876 / KSM-882).
+//!
+//! Each test drives a real `update_secret` round-trip through `post_query` with a mocked
+//! post function (returning HTTP 403 `{"error":"throttled"}` responses) and a recording
+//! sleeper injected via `set_custom_sleep_function`, so no real time is spent sleeping.
+
+#[cfg(test)]
+mod throttle_tests {
+    use keeper_secrets_manager_core::config_keys::ConfigKeys;
+    use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+    use keeper_secrets_manager_core::crypto::CryptoUtils;
+    use keeper_secrets_manager_core::custom_error::KSMRError;
+    use keeper_secrets_manager_core::dto::{
+        EncryptedPayload, KsmHttpResponse, Record, TransmissionKey,
+    };
+    use keeper_secrets_manager_core::enums::KvStoreType;
+    use keeper_secrets_manager_core::storage::{InMemoryKeyValueStorage, KeyValueStorage};
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /// Minimal "already bound" in-memory config sufficient for `post_query` to build a
+    /// transmission key, sign, and (on 200) decrypt the response.
+    fn create_mock_storage() -> KvStoreType {
+        let storage = InMemoryKeyValueStorage::new(None).unwrap();
+        let mut kv = KvStoreType::InMemory(storage);
+
+        let private_key = CryptoUtils::generate_private_key_ecc().unwrap();
+        let private_key_der = CryptoUtils::generate_private_key_der().unwrap();
+        let private_key_base64 =
+            keeper_secrets_manager_core::utils::bytes_to_base64(&private_key_der);
+        let public_key_bytes = CryptoUtils::public_key_ecc(&private_key);
+        let public_key_base64 =
+            keeper_secrets_manager_core::utils::bytes_to_base64(&public_key_bytes);
+
+        kv.set(ConfigKeys::KeyClientId, "TEST_CLIENT_ID".to_string())
+            .unwrap();
+        kv.set(
+            ConfigKeys::KeyAppKey,
+            "dGVzdF9hcHBfa2V5X2Jhc2U2NF9lbmNvZGVkX3ZhbHVlAAAAAAAAAAAA".to_string(),
+        )
+        .unwrap();
+        kv.set(ConfigKeys::KeyServerPublicKeyId, "10".to_string())
+            .unwrap();
+        kv.set(
+            ConfigKeys::KeyHostname,
+            "fake.keepersecurity.com".to_string(),
+        )
+        .unwrap();
+        kv.set(ConfigKeys::KeyPrivateKey, private_key_base64).unwrap();
+        kv.set(ConfigKeys::KeyOwnerPublicKey, public_key_base64)
+            .unwrap();
+        kv
+    }
+
+    fn make_record() -> Record {
+        let mut record_dict = std::collections::HashMap::new();
+        record_dict.insert("title".to_string(), json!("Throttle Test"));
+        record_dict.insert("type".to_string(), json!("login"));
+        record_dict.insert("fields".to_string(), json!([]));
+
+        Record {
+            uid: "throttle-test-uid".to_string(),
+            title: "Throttle Test".to_string(),
+            record_type: "login".to_string(),
+            files: vec![],
+            raw_json: serde_json::to_string(&record_dict).unwrap(),
+            record_dict,
+            password: None,
+            revision: Some(1),
+            is_editable: true,
+            folder_uid: "folder-uid".to_string(),
+            inner_folder_uid: None,
+            record_key_bytes: vec![0; 32],
+            folder_key_bytes: None,
+            links: vec![],
+        }
+    }
+
+    /// A 200 response carrying an encrypted `{"status":"success"}` body (decryptable with the
+    /// transmission key the SDK generated for that call) — makes `update_secret` succeed.
+    fn encrypted_success(tk: &TransmissionKey) -> Result<KsmHttpResponse, KSMRError> {
+        let data = CryptoUtils::encrypt_aes_gcm(
+            &json!({"status":"success"}).to_string().into_bytes(),
+            &tk.key,
+            None,
+        )?;
+        Ok(KsmHttpResponse {
+            status_code: 200,
+            data,
+            http_response: None,
+        })
+    }
+
+    /// An HTTP 403 throttle response, optionally carrying a `retry_after` (seconds).
+    fn throttle_403(retry_after: Option<i64>) -> KsmHttpResponse {
+        let body = match retry_after {
+            Some(ra) => json!({"error":"throttled","message":"throttled","retry_after":ra}),
+            None => json!({"error":"throttled","message":"throttled"}),
+        };
+        KsmHttpResponse {
+            status_code: 403,
+            data: vec![],
+            http_response: Some(body.to_string()),
+        }
+    }
+
+    /// Build a `SecretsManager` with the given mock post function and a recording sleeper.
+    fn sm_with<F>(mock: F) -> (SecretsManager, Arc<Mutex<Vec<Duration>>>)
+    where
+        F: Fn(String, TransmissionKey, EncryptedPayload) -> Result<KsmHttpResponse, KSMRError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let mut opts = ClientOptions::new_client_options(create_mock_storage());
+        opts.set_custom_post_function(mock);
+        let mut sm = SecretsManager::new(opts).expect("SecretsManager::new");
+
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let recorder = sleeps.clone();
+        sm.set_custom_sleep_function(move |d| recorder.lock().unwrap().push(d));
+        (sm, sleeps)
+    }
+
+    #[test]
+    fn throttle_then_success() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, tk, _p| {
+            if c.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(throttle_403(None))
+            } else {
+                encrypted_success(&tk)
+            }
+        });
+
+        let res = sm.update_secret(make_record());
+        assert!(res.is_ok(), "should succeed after one throttle: {:?}", res);
+        assert_eq!(sleeps.lock().unwrap().len(), 1, "exactly one backoff sleep");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn throttle_exhaustion_returns_throttled_error() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, _tk, _p| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok(throttle_403(None))
+        });
+
+        let res = sm.update_secret(make_record());
+        assert!(
+            matches!(res, Err(KSMRError::Throttled(_))),
+            "exhaustion must surface KSMRError::Throttled, got {:?}",
+            res
+        );
+        assert_eq!(
+            sleeps.lock().unwrap().len(),
+            5,
+            "five backoff sleeps before giving up"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            6,
+            "5 retries plus the final throttled response"
+        );
+    }
+
+    #[test]
+    fn retry_after_is_honored() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, tk, _p| {
+            if c.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(throttle_403(Some(3)))
+            } else {
+                encrypted_success(&tk)
+            }
+        });
+
+        assert!(sm.update_secret(make_record()).is_ok());
+        let recorded = sleeps.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        // retry_after = 3s with +/-25% jitter -> [2.25, 3.75]; well below the exponential 11s base.
+        let secs = recorded[0].as_secs_f64();
+        assert!(
+            (2.25..=3.75).contains(&secs),
+            "retry_after should drive the delay, got {secs}s"
+        );
+    }
+
+    #[test]
+    fn non_throttle_403_not_retried() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, _tk, _p| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok(KsmHttpResponse {
+                status_code: 403,
+                data: vec![],
+                http_response: Some(json!({"error":"access_denied","message":"nope"}).to_string()),
+            })
+        });
+
+        let res = sm.update_secret(make_record());
+        assert!(res.is_err());
+        assert!(
+            !matches!(res, Err(KSMRError::Throttled(_))),
+            "a non-throttle 403 must not become a throttle error"
+        );
+        assert_eq!(sleeps.lock().unwrap().len(), 0, "no retry for non-throttle");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn non_403_throttle_body_not_retried() {
+        // A 502 that happens to carry a {"error":"throttled"} body must NOT be retried (403 gate).
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, _tk, _p| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok(KsmHttpResponse {
+                status_code: 502,
+                data: vec![],
+                http_response: Some(json!({"error":"throttled"}).to_string()),
+            })
+        });
+
+        let res = sm.update_secret(make_record());
+        assert!(res.is_err());
+        assert_eq!(
+            sleeps.lock().unwrap().len(),
+            0,
+            "a 502 with a throttled body must not be retried"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn throttle_then_key_rotation_compose() {
+        // 403 throttle -> 401 key rotation (key_id 9) -> 200 success.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let (mut sm, sleeps) = sm_with(move |_url, tk, _p| {
+            match c.fetch_add(1, Ordering::SeqCst) {
+                0 => Ok(throttle_403(None)),
+                1 => Ok(KsmHttpResponse {
+                    status_code: 401,
+                    data: vec![],
+                    http_response: Some(
+                        json!({"key_id":9,"error":"key","message":"invalid key id"}).to_string(),
+                    ),
+                }),
+                _ => encrypted_success(&tk),
+            }
+        });
+
+        let res = sm.update_secret(make_record());
+        assert!(
+            res.is_ok(),
+            "throttle and key-rotation retries should compose: {:?}",
+            res
+        );
+        assert_eq!(
+            sleeps.lock().unwrap().len(),
+            1,
+            "only the throttle sleeps; key rotation retries immediately"
+        );
+        assert_eq!(
+            sm.config
+                .get(ConfigKeys::KeyServerPublicKeyId)
+                .unwrap()
+                .as_deref(),
+            Some("9"),
+            "key rotation must still persist the rotated key id"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+}

--- a/sdk/rust/tests/throttle_tests.rs
+++ b/sdk/rust/tests/throttle_tests.rs
@@ -10,7 +10,7 @@
 // Contact: sm@keepersecurity.com
 //
 
-//! End-to-end tests for throttle retry with exponential backoff (KSM-876 / KSM-882).
+//! End-to-end tests for throttle retry with exponential backoff.
 //!
 //! Each test drives a real `update_secret` round-trip through `post_query` with a mocked
 //! post function (returning HTTP 403 `{"error":"throttled"}` responses) and a recording


### PR DESCRIPTION
## Summary

Implements automatic **throttle retry with exponential backoff** for the Rust SDK.

The Keeper backend throttles per `{endpoint}+{clientId}` (100 req / 10s window) and returns **HTTP 403** with body `{"error":"throttled"}`. Previously the Rust SDK surfaced this as an immediate error. Now `post_query` retries transparently.

## Algorithm

- Constants `MAX_THROTTLE_RETRIES = 5`, `BASE_THROTTLE_DELAY_SEC = 11` (1s margin over the backend's 10s memcached TTL).
- On a **403** whose body is `result_code`/`error` == `"throttled"` (detected **before** `handle_http_error`, so key-rotation retry is untouched, and **gated on 403** so a 500/502 carrying a throttled body is not retried):
  - if retries are exhausted → return new `KSMRError::Throttled`;
  - otherwise log a warning, sleep `retry_after` (if > 0) else `11 * 2^attempt` (11/22/44/88/176s) with **±25% jitter**, then retry.

## Changes

- `src/keeper_globals.rs` — throttle constants.
- `src/custom_error.rs` — new `KSMRError::Throttled` variant (with `PartialEq`).
- `src/core/core.rs` — `parse_throttle` / `throttle_delay` helpers + retry logic in `post_query`; `SecretsManager::set_custom_sleep_function` test seam.
- `CHANGELOG.md` — entry under `17.3.0`. No version bump.

## Tests

- Unit (`throttle_unit`): exponential sequence `[11,22,44,88,176]`, `retry_after` precedence, jitter bounds, `parse_throttle` table.
- E2E (`tests/throttle_tests.rs`): retry-then-success, exhaustion → `Throttled`, `retry_after` honored, non-throttle 403 not retried, 502-with-throttled-body not retried, throttle + key-rotation compose.
- Full lib suite: **226 passed**. Existing key-rotation regression unaffected.
