### PR TITLE
feat(javascript): KSM-880 throttle retry with exponential backoff

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 17.4.1
+- KSM-880 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `postQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` is thrown once retries are exhausted. Existing key-rotation retry behavior is unchanged.
 - KSM-901 - Add IL5 (DoD Impact Level 5) support: region mapping (`IL5` → `il5.keepersecurity.us`) and custom server public key injection via three layers — OTS token (`IL5:TOKEN:keyId:publicKey`), `ClientConfiguration` fields (`serverPublicKey` / `serverPublicKeyId`), and `initialize()` options parameter. When a custom key is configured, server-side key rotation hints are suppressed so the client stays pinned to the IL5 key.
 - KSM-758 - Replace deprecated `rollup-plugin-sourcemaps@0.6.3` with `rollup-plugin-sourcemaps2@0.5.6` — resolves peer dependency warnings with Rollup 4.x; bumped to 0.5.6 to resolve transitive `picomatch` HIGH vulnerability (dev dependency only, no production impact)
 - Security: Bump `rollup` devDependency from `^4.52.3` to `^4.60.1` — fixes HIGH severity arbitrary file write via path traversal (CVE affects 4.0.0–4.58.0)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -13,6 +13,12 @@ const KEY_CLIENT_KEY = 'clientKey' // The key that is used to identify the clien
 const KEY_APP_KEY = 'appKey' // The application key with which all secrets are encrypted
 const KEY_OWNER_PUBLIC_KEY = 'appOwnerPublicKey' // The application owner public key, to create records
 const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
+
+// Throttle retry (KSM-876 / KSM-880). The backend throttles HTTP 403 {"error":"throttled"}
+// per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+// request, so the counter only clears after 10s of silence).
+const MAX_THROTTLE_RETRIES = 5
+const BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
 const CLIENT_ID_HASH_TAG = 'KEEPER_SECRETS_MANAGER_CLIENT_ID' // Tag for hashing the client key to client id
 
 let keeperPublicKeys: Record<number, Uint8Array>
@@ -47,6 +53,61 @@ export type SecretManagerOptions = {
     allowUnverifiedCertificate?: boolean
     serverPublicKey?: string
     serverPublicKeyId?: string
+    // Override the sleep between throttle retries (primarily for tests). Defaults to setTimeout.
+    throttleSleep?: (milliseconds: number) => Promise<void>
+}
+
+/**
+ * Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the
+ * SDK has exhausted its automatic retries (MAX_THROTTLE_RETRIES). Extends Error so existing
+ * `catch` handlers keep working; callers that want to react specifically to throttling can
+ * check `instanceof KeeperThrottleError`.
+ */
+export class KeeperThrottleError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'KeeperThrottleError'
+        // Restore the prototype chain so `instanceof` works across transpilation targets.
+        Object.setPrototypeOf(this, KeeperThrottleError.prototype)
+    }
+}
+
+// Returns a jitter multiplier in [-0.25, 0.25). Kept separate so concurrent clients
+// desynchronize their retries; unit tests exercise throttleDelay with a pinned jitter.
+export const throttleJitter = (): number => Math.random() * 0.5 - 0.25
+
+/**
+ * If `body` is a backend throttle error (`result_code`/`error` === "throttled") returns its
+ * `retry_after` in seconds (>= 0); otherwise returns `null` so the caller falls through to
+ * normal error handling. Non-JSON / non-object bodies return `null`.
+ */
+export const parseThrottle = (body: string): number | null => {
+    let obj: any
+    try {
+        obj = JSON.parse(body)
+    } catch {
+        return null
+    }
+    if (!obj || typeof obj !== 'object') {
+        return null
+    }
+    const resultCode = obj.result_code ?? obj.error
+    if (resultCode !== 'throttled') {
+        return null
+    }
+    const retryAfter = Number(obj.retry_after)
+    return Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 0
+}
+
+/**
+ * Computes the backoff delay (milliseconds) for a 0-based `attempt`: `retryAfter` seconds when
+ * provided (> 0), otherwise exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22,
+ * 44, 88, 176s). The `jitter` fraction (typically in [-0.25, 0.25)) is then applied.
+ */
+export const throttleDelay = (attempt: number, retryAfter: number, jitter: number = throttleJitter()): number => {
+    const baseSec = retryAfter > 0 ? retryAfter : BASE_THROTTLE_DELAY_SEC * Math.pow(2, attempt)
+    const sec = baseSec + baseSec * jitter
+    return Math.max(sec, 0) * 1000
 }
 
 export type QueryOptions = {
@@ -544,6 +605,8 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
         throw new Error('hostname is missing from the configuration')
     }
     const url = `https://${hostName}/api/rest/sm/v1/${path}`
+    const sleep = options.throttleSleep || ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+    let throttleAttempt = 0
     while (true) {
         const transmissionKey = await generateTransmissionKey(options.storage)
         const encryptedPayload = await encryptAndSignPayload(options.storage, transmissionKey, payload)
@@ -552,6 +615,22 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
             let errorMessage
             if (response.data) {
                 errorMessage = platform.bytesToString(response.data.slice(0, 1000))
+                // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-880). Checked
+                // before key-rotation so that path is untouched, and gated on the 403 status so a
+                // non-403 response carrying a {"error":"throttled"} body is not retried.
+                if (response.statusCode === 403) {
+                    const retryAfter = parseThrottle(errorMessage)
+                    if (retryAfter !== null) {
+                        if (throttleAttempt >= MAX_THROTTLE_RETRIES) {
+                            throw new KeeperThrottleError(`Request throttled by Keeper backend; exhausted ${MAX_THROTTLE_RETRIES} retries`)
+                        }
+                        const delay = throttleDelay(throttleAttempt, retryAfter)
+                        console.error(`WARNING: Request throttled (attempt ${throttleAttempt + 1}/${MAX_THROTTLE_RETRIES}); retrying in ${(delay / 1000).toFixed(1)}s`)
+                        await sleep(delay)
+                        throttleAttempt++
+                        continue
+                    }
+                }
                 try {
                     const errorObj: KeeperError = JSON.parse(errorMessage)
                     if (errorObj.error === 'key') {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -14,7 +14,7 @@ const KEY_APP_KEY = 'appKey' // The application key with which all secrets are e
 const KEY_OWNER_PUBLIC_KEY = 'appOwnerPublicKey' // The application owner public key, to create records
 const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
 
-// Throttle retry (KSM-876 / KSM-880). The backend throttles HTTP 403 {"error":"throttled"}
+// Throttle retry. The backend throttles HTTP 403 {"error":"throttled"}
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
 // request, so the counter only clears after 10s of silence).
 const MAX_THROTTLE_RETRIES = 5
@@ -615,7 +615,7 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
             let errorMessage
             if (response.data) {
                 errorMessage = platform.bytesToString(response.data.slice(0, 1000))
-                // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-880). Checked
+                // Throttle retry with exponential backoff + jitter. Checked
                 // before key-rotation so that path is untouched, and gated on the 403 status so a
                 // non-403 response carrying a {"error":"throttled"} body is not retried.
                 if (response.statusCode === 403) {

--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -1,0 +1,134 @@
+import {
+    getSecrets,
+    initializeStorage,
+    inMemoryStorage,
+    platform,
+    SecretManagerOptions,
+    KeeperHttpResponse,
+    KeeperThrottleError,
+    parseThrottle,
+    throttleDelay,
+} from '../'
+
+// A valid one-time token (same fixture the e2e suite uses) so initializeStorage produces a
+// real client key pair; throttle behaviour is exercised purely through the mocked queryFunction.
+const FAKE_TOKEN = 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c'
+const enc = new TextEncoder()
+
+const throttle403 = (retryAfter?: number): KeeperHttpResponse => ({
+    statusCode: 403,
+    data: enc.encode(
+        JSON.stringify(
+            retryAfter === undefined
+                ? { error: 'throttled', message: 'throttled' }
+                : { error: 'throttled', message: 'throttled', retry_after: retryAfter }
+        )
+    ),
+    headers: [],
+})
+
+// Build options backed by a freshly initialized in-memory storage, plus a recording sleeper
+// (so retries never actually wait).
+const makeOptions = async (
+    queryFunction: SecretManagerOptions['queryFunction']
+): Promise<{ options: SecretManagerOptions; sleeps: number[] }> => {
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, FAKE_TOKEN, 'fake.keepersecurity.com')
+    const sleeps: number[] = []
+    const options: SecretManagerOptions = {
+        storage,
+        queryFunction,
+        throttleSleep: async (ms: number) => {
+            sleeps.push(ms)
+        },
+    }
+    return { options, sleeps }
+}
+
+describe('throttleDelay (unit)', () => {
+    test('exponential sequence with zero jitter', () => {
+        expect([0, 1, 2, 3, 4].map((a) => throttleDelay(a, 0, 0))).toEqual([
+            11000, 22000, 44000, 88000, 176000,
+        ])
+    })
+    test('retry_after takes precedence', () => {
+        expect(throttleDelay(3, 7, 0)).toBe(7000)
+    })
+    test('non-positive retry_after is ignored', () => {
+        expect(throttleDelay(0, 0, 0)).toBe(11000)
+        expect(throttleDelay(1, -5, 0)).toBe(22000)
+    })
+    test('jitter bounds keep the first delay in [8.25s, 13.75s]', () => {
+        expect(throttleDelay(0, 0, -0.25)).toBe(8250)
+        expect(throttleDelay(0, 0, 0.25)).toBe(13750)
+    })
+})
+
+describe('parseThrottle (unit)', () => {
+    test('throttled via error / result_code with retry_after variants', () => {
+        expect(parseThrottle('{"error":"throttled"}')).toBe(0)
+        expect(parseThrottle('{"result_code":"throttled","retry_after":5}')).toBe(5)
+        expect(parseThrottle('{"error":"throttled","retry_after":"3"}')).toBe(3)
+        expect(parseThrottle('{"error":"throttled","retry_after":-2}')).toBe(0)
+    })
+    test('non-throttle / non-JSON / empty -> null', () => {
+        expect(parseThrottle('{"error":"key"}')).toBeNull()
+        expect(parseThrottle('not json')).toBeNull()
+        expect(parseThrottle('')).toBeNull()
+    })
+})
+
+describe('throttle retry (e2e via getSecrets)', () => {
+    test('retries then succeeds', async () => {
+        let call = 0
+        const { options, sleeps } = await makeOptions(async (_url, tk) => {
+            if (call++ === 0) return throttle403()
+            return { statusCode: 200, data: await platform.encryptWithKey(enc.encode('{}'), tk.key), headers: [] }
+        })
+        const secrets = await getSecrets(options)
+        expect(secrets.records).toEqual([])
+        expect(sleeps.length).toBe(1)
+    })
+
+    test('exhaustion throws KeeperThrottleError after 5 retries', async () => {
+        let call = 0
+        const { options, sleeps } = await makeOptions(async () => {
+            call++
+            return throttle403()
+        })
+        await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
+        expect(sleeps.length).toBe(5)
+        expect(call).toBe(6) // 5 retries + the final throttled response
+    })
+
+    test('honors retry_after from the response body', async () => {
+        let call = 0
+        const { options, sleeps } = await makeOptions(async () =>
+            call++ === 0 ? throttle403(3) : throttle403()
+        )
+        await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
+        // retry_after = 3s with +/-25% jitter -> [2.25s, 3.75s]
+        expect(sleeps[0]).toBeGreaterThanOrEqual(2250)
+        expect(sleeps[0]).toBeLessThanOrEqual(3750)
+    })
+
+    test('non-throttle 403 is not retried', async () => {
+        const { options, sleeps } = await makeOptions(async () => ({
+            statusCode: 403,
+            data: enc.encode(JSON.stringify({ error: 'access_denied', message: 'nope' })),
+            headers: [],
+        }))
+        await expect(getSecrets(options)).rejects.not.toBeInstanceOf(KeeperThrottleError)
+        expect(sleeps.length).toBe(0)
+    })
+
+    test('a 502 carrying a throttled body is not retried (403 gate)', async () => {
+        const { options, sleeps } = await makeOptions(async () => ({
+            statusCode: 502,
+            data: enc.encode(JSON.stringify({ error: 'throttled' })),
+            headers: [],
+        }))
+        await expect(getSecrets(options)).rejects.toThrow()
+        expect(sleeps.length).toBe(0)
+    })
+})


### PR DESCRIPTION
## Summary

Implements automatic **throttle retry with exponential backoff** for the JavaScript/TypeScript SDK, part of epic **KSM-876** — ticket **KSM-880**. Ports the algorithm already shipped in the Python (KSM-877) and Go (KSM-881) SDKs.

The Keeper backend throttles per `{endpoint}+{clientId}` (100 req / 10s window) and returns **HTTP 403** with body `{"error":"throttled"}`. Previously the SDK surfaced this as an immediate error; now `postQuery` retries transparently.

## Algorithm

- Constants `MAX_THROTTLE_RETRIES = 5`, `BASE_THROTTLE_DELAY_SEC = 11` (1s margin over the backend's 10s memcached TTL).
- On a **403** whose body is `result_code`/`error` == `"throttled"` (detected **before** the key-rotation handler so that path — including the IL5 custom-key suppression — is untouched, and **gated on 403** so a 500/502 carrying a throttled body is not retried):
  - if retries are exhausted → throw new `KeeperThrottleError`;
  - otherwise log a warning, await `retry_after` (if > 0) else `11 * 2^attempt` (11/22/44/88/176s) with **±25% jitter**, then retry.

## Changes

- `src/keeper.ts` — `MAX_THROTTLE_RETRIES` / `BASE_THROTTLE_DELAY_SEC` constants; exported `KeeperThrottleError`, `parseThrottle`, `throttleDelay`, `throttleJitter`; retry logic in `postQuery`; optional `throttleSleep` seam on `SecretManagerOptions` (defaults to `setTimeout`).
- `CHANGELOG.md` — entry under `17.4.1`. No version bump.
- `test/throttle.test.ts` — new Jest suite.

## Tests

- Unit: exponential sequence `[11,22,44,88,176]s`, `retry_after` precedence, jitter bounds; `parseThrottle` table.
- E2E (via `getSecrets` with a mocked `queryFunction` + recording `throttleSleep`): retry-then-success, exhaustion → `KeeperThrottleError`, `retry_after` honored, non-throttle 403 not retried, 502-with-throttled-body not retried.
- `throttle.test.ts` + existing `keeper.test.ts`: **25 passed**.

Base branch: `release/sdk/javascript/core/v17.4.1` (can be retargeted once a dedicated release branch is cut).
