### PR TITLE
feat(dotnet): KSM-879 throttle retry with exponential backoff

### DIFF
--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Keeper Secrets Manager .NET SDK will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- KSM-879 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleException` is thrown once retries are exhausted. `KeeperHttpResponse` now carries the HTTP `StatusCode` so the retry is gated on 403. Existing key-rotation retry behavior is unchanged.
+
 ## [17.1.2]
 
 ### Fixed

--- a/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
@@ -29,7 +29,7 @@ namespace SecretsManager.Test
             Task<KeeperHttpResponse> TestPostFunction(string s, TransmissionKey transmissionKey, EncryptedPayload encryptedPayload, string proxyUrl = null)
             {
                 var response = testResponses[responseNo++];
-                return Task.FromResult(new KeeperHttpResponse(CryptoUtils.Base64ToBytes(response.data), response.statusCode != 200));
+                return Task.FromResult(new KeeperHttpResponse(CryptoUtils.Base64ToBytes(response.data), response.statusCode != 200, response.statusCode));
             }
 
             var storage = new LocalConfigStorage();

--- a/sdk/dotNet/SecretsManager.Test.Core/Throttle.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/Throttle.Test.cs
@@ -1,0 +1,147 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SecretsManager.Test
+{
+    using QueryFunction = Func<string, TransmissionKey, EncryptedPayload, string, Task<KeeperHttpResponse>>;
+
+    // Throttle retry with exponential backoff (KSM-876 / KSM-879). Unit tests target the internal
+    // helpers (visible via InternalsVisibleTo); e2e tests drive GetSecrets with a mocked
+    // QueryFunction and a recording ThrottleSleep so retries never actually wait.
+    public class ThrottleTests
+    {
+        private const string FakeToken = "YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c";
+
+        private static KeeperHttpResponse Throttle403(double? retryAfter = null)
+        {
+            var json = retryAfter.HasValue
+                ? $"{{\"error\":\"throttled\",\"message\":\"throttled\",\"retry_after\":{retryAfter.Value}}}"
+                : "{\"error\":\"throttled\",\"message\":\"throttled\"}";
+            return new KeeperHttpResponse(CryptoUtils.StringToBytes(json), true, 403);
+        }
+
+        // --- unit: ThrottleDelayMs ---
+
+        [Test]
+        public void ThrottleDelay_ExponentialSequence_NoJitter()
+        {
+            var expected = new[] { 11000, 22000, 44000, 88000, 176000 };
+            for (var attempt = 0; attempt < expected.Length; attempt++)
+                Assert.That(SecretsManagerClient.ThrottleDelayMs(attempt, 0, 0), Is.EqualTo(expected[attempt]));
+        }
+
+        [Test]
+        public void ThrottleDelay_RetryAfterPrecedence_And_NonPositiveIgnored()
+        {
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(3, 7, 0), Is.EqualTo(7000));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, 0), Is.EqualTo(11000));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(1, -5, 0), Is.EqualTo(22000));
+        }
+
+        [Test]
+        public void ThrottleDelay_JitterBounds()
+        {
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, -0.25), Is.EqualTo(8250));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, 0.25), Is.EqualTo(13750));
+        }
+
+        // --- unit: ParseThrottle ---
+
+        [Test]
+        public void ParseThrottle_Table()
+        {
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\"}")), Is.EqualTo(0));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"result_code\":\"throttled\",\"retry_after\":5}")), Is.EqualTo(5));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\",\"retry_after\":\"3\"}")), Is.EqualTo(3));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\",\"retry_after\":-2}")), Is.EqualTo(0));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"key\"}")), Is.Null);
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("not json")), Is.Null);
+            Assert.That(SecretsManagerClient.ParseThrottle(Array.Empty<byte>()), Is.Null);
+        }
+
+        // --- e2e via GetSecrets ---
+
+        private static (SecretsManagerOptions options, List<int> sleeps) MakeOptions(QueryFunction queryFunction)
+        {
+            SecretsManagerClient.TransmissionKeyStub = null; // avoid static leakage from other tests
+            var storage = new InMemoryStorage();
+            SecretsManagerClient.InitializeStorage(storage, FakeToken, "fake.keepersecurity.com");
+            // Seed an app key so the (non-bound) empty success response decrypts without error; the
+            // key itself is unused because the mocked responses carry no records.
+            storage.SaveBytes("appKey", new byte[32]);
+            var sleeps = new List<int>();
+            var options = new SecretsManagerOptions(storage, queryFunction,
+                throttleSleep: ms => { sleeps.Add(ms); return Task.CompletedTask; });
+            return (options, sleeps);
+        }
+
+        [Test]
+        public async Task RetriesThenSucceeds()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+            {
+                if (call++ == 0) return Task.FromResult(Throttle403());
+                var data = CryptoUtils.Encrypt(CryptoUtils.StringToBytes("{}"), tk.Key);
+                return Task.FromResult(new KeeperHttpResponse(data, false, 200));
+            });
+
+            var secrets = await SecretsManagerClient.GetSecrets(options);
+            Assert.That(secrets.Records, Is.Empty);
+            Assert.That(sleeps.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Exhaustion_ThrowsKeeperThrottleException()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+            {
+                call++;
+                return Task.FromResult(Throttle403());
+            });
+
+            Assert.ThrowsAsync<KeeperThrottleException>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(5));
+            Assert.That(call, Is.EqualTo(6)); // 5 retries + the final throttled response
+        }
+
+        [Test]
+        public void RetryAfter_IsHonored()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(call++ == 0 ? Throttle403(3) : Throttle403()));
+
+            Assert.ThrowsAsync<KeeperThrottleException>(async () => await SecretsManagerClient.GetSecrets(options));
+            // retry_after = 3s with +/-25% jitter -> [2.25s, 3.75s] => [2250ms, 3750ms]
+            Assert.That(sleeps[0], Is.InRange(2250, 3750));
+        }
+
+        [Test]
+        public void NonThrottle403_NotRetried()
+        {
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(new KeeperHttpResponse(
+                    CryptoUtils.StringToBytes("{\"error\":\"access_denied\",\"message\":\"nope\"}"), true, 403)));
+
+            // Exactly System.Exception (not the derived KeeperThrottleException) and no retries.
+            Assert.ThrowsAsync<Exception>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Non403ThrottleBody_NotRetried()
+        {
+            // A 502 carrying a {"error":"throttled"} body must NOT be retried (403 gate).
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(new KeeperHttpResponse(
+                    CryptoUtils.StringToBytes("{\"error\":\"throttled\"}"), true, 502)));
+
+            Assert.ThrowsAsync<Exception>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -567,10 +567,12 @@ namespace SecretsManager
         // request, so the counter only clears after 10s of silence).
         private const int MaxThrottleRetries = 5;
         private const int BaseThrottleDelaySec = 11; // 1s safety margin over the backend's 10s memcached TTL
+        private const int MaxThrottleDelaySec = 176; // cap on server-supplied retry_after (baseThrottleDelaySec * 2^4)
         private static readonly Random ThrottleRng = new Random();
 
-        // Jitter multiplier in [-0.25, 0.25). A settable seam so unit tests can pin it.
-        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.5 - 0.25;
+        // Jitter multiplier in [0, 0.25). One-sided so delay is always >= floor, preventing a retry
+        // before the backend's 10s memcached window expires. A settable seam so unit tests can pin it.
+        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.25;
 
         private const string ClientIdHashTag = "KEEPER_SECRETS_MANAGER_CLIENT_ID"; // Tag for hashing the client key to client id
 
@@ -1615,11 +1617,12 @@ namespace SecretsManager
         /// <summary>
         /// Computes the backoff delay (milliseconds) for a 0-based attempt: retry_after seconds when
         /// provided (&gt; 0), otherwise exponential backoff (BaseThrottleDelaySec * 2**attempt -> 11,
-        /// 22, 44, 88, 176s). The jitter fraction (random in [-0.25, 0.25) unless pinned) is applied.
+        /// 22, 44, 88, 176s), capped at MaxThrottleDelaySec. A 0 to +25% jitter is then applied.
         /// </summary>
         internal static int ThrottleDelayMs(int attempt, double retryAfter, double? jitter = null)
         {
             var baseSec = retryAfter > 0 ? retryAfter : BaseThrottleDelaySec * Math.Pow(2, attempt);
+            if (baseSec > MaxThrottleDelaySec) baseSec = MaxThrottleDelaySec;
             var sec = baseSec + baseSec * (jitter ?? ThrottleJitter());
             return (int)(Math.Max(sec, 0) * 1000);
         }

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -9,6 +9,8 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SecretsManager.Test.Core")]
+
 namespace SecretsManager
 {
     using GetRandomBytesFunction = Func<int, byte[]>;
@@ -29,12 +31,17 @@ namespace SecretsManager
         public IKeyValueStorage Storage { get; }
         public QueryFunction QueryFunction { get; }
         public string ProxyUrl { get; }
-        public SecretsManagerOptions(IKeyValueStorage storage, QueryFunction queryFunction = null, bool allowUnverifiedCertificate = false, string proxyUrl = null)
+
+        // Override the sleep between throttle retries (primarily for tests). Defaults to Task.Delay.
+        public Func<int, Task> ThrottleSleep { get; }
+
+        public SecretsManagerOptions(IKeyValueStorage storage, QueryFunction queryFunction = null, bool allowUnverifiedCertificate = false, string proxyUrl = null, Func<int, Task> throttleSleep = null)
         {
             Storage = storage;
             QueryFunction = queryFunction;
             AllowUnverifiedCertificate = allowUnverifiedCertificate;
             ProxyUrl = proxyUrl;
+            ThrottleSleep = throttleSleep;
         }
     }
 
@@ -82,12 +89,23 @@ namespace SecretsManager
     {
         public byte[] Data { get; }
         public bool IsError { get; }
+        public int StatusCode { get; }
 
-        public KeeperHttpResponse(byte[] data, bool isError)
+        public KeeperHttpResponse(byte[] data, bool isError, int statusCode = 0)
         {
             Data = data;
             IsError = isError;
+            StatusCode = statusCode;
         }
+    }
+
+    /// <summary>
+    /// Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the
+    /// SDK has exhausted its automatic retries (see throttle constants in SecretsManagerClient).
+    /// </summary>
+    public class KeeperThrottleException : Exception
+    {
+        public KeeperThrottleException(string message) : base(message) { }
     }
 
     public class EncryptedPayload
@@ -543,6 +561,16 @@ namespace SecretsManager
         private const string KeyAppKey = "appKey"; // The application key with which all secrets are encrypted
         private const string KeyOwnerPublicKey = "appOwnerPublicKey"; // The application owner public key, to create records
         private const string KeyPrivateKey = "privateKey"; // The client's private key
+
+        // Throttle retry (KSM-876 / KSM-879). The backend throttles HTTP 403 {"error":"throttled"}
+        // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+        // request, so the counter only clears after 10s of silence).
+        private const int MaxThrottleRetries = 5;
+        private const int BaseThrottleDelaySec = 11; // 1s safety margin over the backend's 10s memcached TTL
+        private static readonly Random ThrottleRng = new Random();
+
+        // Jitter multiplier in [-0.25, 0.25). A settable seam so unit tests can pin it.
+        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.5 - 0.25;
 
         private const string ClientIdHashTag = "KEEPER_SECRETS_MANAGER_CLIENT_ID"; // Tag for hashing the client key to client id
 
@@ -1498,7 +1526,7 @@ namespace SecretsManager
                 var cachedTransmissionKey = cachedData.Take(32).ToArray();
                 transmissionKey.Key = cachedTransmissionKey;
                 var data = cachedData.Skip(32).ToArray();
-                return new KeeperHttpResponse(data, false);
+                return new KeeperHttpResponse(data, false, 200);
             }
         }
 
@@ -1544,11 +1572,56 @@ namespace SecretsManager
                     throw new InvalidOperationException("Response was expected but not received");
                 }
 
-                return new KeeperHttpResponse(StreamToBytes(errorResponseStream), true);
+                return new KeeperHttpResponse(StreamToBytes(errorResponseStream), true, (int)((HttpWebResponse)e.Response).StatusCode);
             }
 
             using var responseStream = response.GetResponseStream();
-            return new KeeperHttpResponse(StreamToBytes(responseStream), false);
+            return new KeeperHttpResponse(StreamToBytes(responseStream), false, (int)response.StatusCode);
+        }
+
+        /// <summary>
+        /// If <paramref name="data"/> is a backend throttle error (result_code/error == "throttled")
+        /// returns its retry_after in seconds (>= 0); otherwise null so the caller falls through to
+        /// normal error handling. Non-JSON / non-object bodies return null.
+        /// </summary>
+        internal static double? ParseThrottle(byte[] data)
+        {
+            if (data == null || data.Length == 0) return null;
+            try
+            {
+                using var doc = JsonDocument.Parse(data);
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) return null;
+                string resultCode = null;
+                if (root.TryGetProperty("result_code", out var rcEl) && rcEl.ValueKind == JsonValueKind.String)
+                    resultCode = rcEl.GetString();
+                else if (root.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String)
+                    resultCode = errEl.GetString();
+                if (resultCode != "throttled") return null;
+                double retryAfter = 0;
+                if (root.TryGetProperty("retry_after", out var raEl))
+                {
+                    if (raEl.ValueKind == JsonValueKind.Number) retryAfter = raEl.GetDouble();
+                    else if (raEl.ValueKind == JsonValueKind.String && double.TryParse(raEl.GetString(), out var parsed)) retryAfter = parsed;
+                }
+                return Math.Max(retryAfter, 0);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Computes the backoff delay (milliseconds) for a 0-based attempt: retry_after seconds when
+        /// provided (&gt; 0), otherwise exponential backoff (BaseThrottleDelaySec * 2**attempt -> 11,
+        /// 22, 44, 88, 176s). The jitter fraction (random in [-0.25, 0.25) unless pinned) is applied.
+        /// </summary>
+        internal static int ThrottleDelayMs(int attempt, double retryAfter, double? jitter = null)
+        {
+            var baseSec = retryAfter > 0 ? retryAfter : BaseThrottleDelaySec * Math.Pow(2, attempt);
+            var sec = baseSec + baseSec * (jitter ?? ThrottleJitter());
+            return (int)(Math.Max(sec, 0) * 1000);
         }
 
         private static async Task<byte[]> PostQuery<T>(SecretsManagerOptions options, string path, T payload)
@@ -1560,6 +1633,8 @@ namespace SecretsManager
             }
 
             var url = $"https://{hostName}/api/rest/sm/v1/{path}";
+            var throttleSleep = options.ThrottleSleep ?? (ms => Task.Delay(ms));
+            var throttleAttempt = 0;
             while (true)
             {
                 var transmissionKey = GenerateTransmissionKey(options.Storage);
@@ -1569,6 +1644,26 @@ namespace SecretsManager
                     : await options.QueryFunction(url, transmissionKey, encryptedPayload, options.ProxyUrl);
                 if (response.IsError)
                 {
+                    // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-879). Checked
+                    // before key rotation so that path is untouched, and gated on the 403 status so a
+                    // non-403 response carrying a {"error":"throttled"} body is not retried.
+                    if (response.StatusCode == 403)
+                    {
+                        var retryAfter = ParseThrottle(response.Data);
+                        if (retryAfter.HasValue)
+                        {
+                            if (throttleAttempt >= MaxThrottleRetries)
+                            {
+                                throw new KeeperThrottleException($"Request throttled by Keeper backend; exhausted {MaxThrottleRetries} retries");
+                            }
+                            var delayMs = ThrottleDelayMs(throttleAttempt, retryAfter.Value);
+                            Console.Error.WriteLine($"WARNING: Request throttled (attempt {throttleAttempt + 1}/{MaxThrottleRetries}); retrying in {delayMs / 1000.0:F1}s");
+                            await throttleSleep(delayMs);
+                            throttleAttempt++;
+                            continue;
+                        }
+                    }
+
                     try
                     {
                         var error = JsonSerializer.Deserialize<KeeperError>(response.Data);


### PR DESCRIPTION
## Summary

Implements automatic **throttle retry with exponential backoff** for the .NET/C# SDK, part of epic **KSM-876** — ticket **KSM-879**. Ports the algorithm already shipped in the Python (KSM-877) and Go (KSM-881) SDKs.

The Keeper backend throttles per `{endpoint}+{clientId}` (100 req / 10s window) and returns **HTTP 403** with body `{"error":"throttled"}`. Previously the SDK surfaced this as an immediate `Exception`; now `PostQuery` retries transparently.

## Algorithm

- Constants `MaxThrottleRetries = 5`, `BaseThrottleDelaySec = 11` (1s margin over the backend's 10s memcached TTL).
- On a **403** whose body is `result_code`/`error` == `"throttled"` (detected **before** the key-rotation handler so that path is untouched, and **gated on 403** so a 500/502 carrying a throttled body is not retried):
  - if retries are exhausted → throw new `KeeperThrottleException`;
  - otherwise log a warning, await `retry_after` (if > 0) else `11 * 2^attempt` (11/22/44/88/176s) with ±25% jitter, then retry.

## Changes

- `SecretsManager/SecretsManagerClient.cs`:
  - `KeeperHttpResponse` now carries `int StatusCode` (backward-compatible optional ctor arg), populated by `PostFunction` for both success and `WebException` paths — enables the 403 gate.
  - `ParseThrottle` / `ThrottleDelayMs` helpers (internal, with a pinnable `ThrottleJitter` seam) + retry logic in `PostQuery`.
  - new public `KeeperThrottleException`; optional `throttleSleep` seam on `SecretsManagerOptions` (defaults to `Task.Delay`).
  - `InternalsVisibleTo("SecretsManager.Test.Core")` so the helpers are unit-testable.
- `CHANGELOG.md` — `## [Unreleased]` entry. No version bump.
- `SecretsManager.Test.Core/` — new `Throttle.Test.cs`; existing mock now threads `statusCode`.

## Tests (NUnit)

- Unit: exponential sequence `[11,22,44,88,176]s`, `retry_after` precedence, jitter bounds; `ParseThrottle` table.
- E2E (via `GetSecrets` with a mocked `QueryFunction` + recording `throttleSleep`): retry-then-success, exhaustion → `KeeperThrottleException`, `retry_after` honored, non-throttle 403 not retried, 502-with-throttled-body not retried.
- Full suite (excluding network proxy tests): **44 passed**.

---

## Addendum (jitter hardening, KSM-1030)

Jitter corrected from symmetric ±25% to one-sided 0–+25%:

- **Bug**: `floor × (1 - 0.25) = 8.25s` — a retry could fire before the backend's 10s memcached window expires, wasting the attempt and resetting the throttle counter.
- **Fix**: `ThrottleJitter` now returns `[0, 0.25)` so the delay is always ≥ the floor.
- Added `MaxThrottleDelaySec = 176` constant and applied as a cap in `ThrottleDelayMs` so a server-supplied `retry_after` above 176s is clamped rather than honored blindly.