### PR TITLE
feat(java): KSM-878 throttle retry with exponential backoff

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1730,10 +1730,12 @@ private inline fun <reified T> postQuery(
                         throw KeeperThrottleException("Request throttled by Keeper backend; exhausted $MAX_THROTTLE_RETRIES retries")
                     }
                     val delayMs = throttleDelayMillis(throttleAttempt, retryAfter, throttleJitter())
-                    System.err.println(
-                        "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
-                            "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
-                    )
+                    if (options.loggingEnabled) {
+                        System.err.println(
+                            "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
+                                "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
+                        )
+                    }
                     throttleSleep(delayMs)
                     throttleAttempt++
                     continue

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1700,6 +1700,7 @@ internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Doubl
 // throttleDelayMillis with a pinned jitter instead.
 internal fun throttleJitter(): Double = Random.nextDouble(-0.25, 0.25)
 
+@ExperimentalSerializationApi
 private inline fun <reified T> postQuery(
     options: SecretsManagerOptions,
     path: String,

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URI
 import java.security.KeyManagementException
@@ -17,9 +18,16 @@ import java.security.cert.X509Certificate
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.*
+import kotlin.random.Random
 import javax.net.ssl.*
 
 const val KEEPER_CLIENT_VERSION = "mj17.2.1"
+
+// Throttle retry (KSM-876 / KSM-878). The backend throttles HTTP 403 {"error":"throttled"}
+// per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+// request, so the counter only clears after 10s of silence).
+const val MAX_THROTTLE_RETRIES = 5
+const val BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
@@ -47,7 +55,9 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val allowUnverifiedCertificate: Boolean = false,
     val loggingEnabled: Boolean = true,
     val serverPublicKey: String? = null,
-    val serverPublicKeyId: String? = null
+    val serverPublicKeyId: String? = null,
+    // Override the sleep between throttle retries (primarily for tests). Defaults to Thread.sleep.
+    val throttleSleepMillis: ((Long) -> Unit)? = null
 ) {
     init {
         testSecureRandom()
@@ -1662,6 +1672,34 @@ private inline fun <reified T> encryptAndSignPayload(
 }
 
 @ExperimentalSerializationApi
+// Returns the throttle retry_after (>= 0) when [body] is a backend throttle error
+// (result_code/error == "throttled"), otherwise null so the caller falls through to normal
+// error handling. Non-JSON / non-object bodies return null. (KSM-876 / KSM-878)
+internal fun parseThrottle(body: String): Double? {
+    val obj = try {
+        nonStrictJson.parseToJsonElement(body).jsonObject
+    } catch (e: Exception) {
+        return null
+    }
+    val resultCode = ((obj["result_code"] ?: obj["error"]) as? JsonPrimitive)?.content
+    if (resultCode != "throttled") return null
+    val retryAfter = (obj["retry_after"] as? JsonPrimitive)?.content?.toDoubleOrNull() ?: 0.0
+    return if (retryAfter < 0.0) 0.0 else retryAfter
+}
+
+// Backoff delay (milliseconds) for a 0-based [attempt]: retryAfter when > 0, otherwise
+// exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22, 44, 88, 176s). The
+// [jitter] fraction (typically in [-0.25, 0.25)) is then applied.
+internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Double): Long {
+    val baseSec = if (retryAfter > 0.0) retryAfter else BASE_THROTTLE_DELAY_SEC.toDouble() * (1L shl attempt)
+    val sec = baseSec + baseSec * jitter
+    return (maxOf(sec, 0.0) * 1000).toLong()
+}
+
+// Random jitter multiplier in [-0.25, 0.25). Kept separate so unit tests exercise
+// throttleDelayMillis with a pinned jitter instead.
+internal fun throttleJitter(): Double = Random.nextDouble(-0.25, 0.25)
+
 private inline fun <reified T> postQuery(
     options: SecretsManagerOptions,
     path: String,
@@ -1669,6 +1707,8 @@ private inline fun <reified T> postQuery(
 ): ByteArray {
     val hostName = options.storage.getString(KEY_HOSTNAME) ?: throw Exception("hostname is missing from the storage")
     val url = "https://${hostName}/api/rest/sm/v1/${path}"
+    val throttleSleep = options.throttleSleepMillis ?: { ms -> Thread.sleep(ms) }
+    var throttleAttempt = 0
     while (true) {
         val transmissionKey = generateTransmissionKey(options.storage)
         val encryptedPayload = encryptAndSignPayload(options.storage, transmissionKey, payload)
@@ -1679,6 +1719,26 @@ private inline fun <reified T> postQuery(
         }
         if (response.statusCode != HTTP_OK) {
             val errorMessage = String(response.data)
+            // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-878). Checked before
+            // key-rotation so that path (incl. the IL5 custom-key suppression) is untouched, and
+            // gated on the 403 status so a non-403 response carrying a {"error":"throttled"} body
+            // is not mistaken for a throttle and retried.
+            if (response.statusCode == HTTP_FORBIDDEN) {
+                val retryAfter = parseThrottle(errorMessage)
+                if (retryAfter != null) {
+                    if (throttleAttempt >= MAX_THROTTLE_RETRIES) {
+                        throw KeeperThrottleException("Request throttled by Keeper backend; exhausted $MAX_THROTTLE_RETRIES retries")
+                    }
+                    val delayMs = throttleDelayMillis(throttleAttempt, retryAfter, throttleJitter())
+                    System.err.println(
+                        "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
+                            "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
+                    )
+                    throttleSleep(delayMs)
+                    throttleAttempt++
+                    continue
+                }
+            }
             try {
                 val error = nonStrictJson.decodeFromString<KeeperError>(errorMessage)
                 if (error.error == "key") {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
@@ -6,3 +6,10 @@ internal open class SecretsManagerException(message: String): Exception(message)
 
 internal class SecureRandomException(message: String): SecretsManagerException(message)
 internal class SecureRandomSlowGenerationException(message: String): SecretsManagerException(message)
+
+/**
+ * Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the SDK
+ * has exhausted its automatic retries (see MAX_THROTTLE_RETRIES). Public so callers can catch
+ * throttling specifically; extends Exception so existing `catch (e: Exception)` handlers still work.
+ */
+class KeeperThrottleException(message: String): Exception(message)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -154,4 +154,53 @@ internal class ThrottleTest {
         assertFailsWith<Exception> { getSecrets(options) }
         assertEquals(0, sleeps.size)
     }
+
+    // --- logging gate (PR #1043 review): the throttle warning must respect options.loggingEnabled ---
+
+    // Runs one throttle-then-success getSecrets with the given flag, returning whatever the SDK
+    // wrote to stderr. Tests run sequentially here (shared TestStubs, no parallel config), so
+    // temporarily swapping System.err is safe.
+    private fun captureThrottleStderr(loggingEnabled: Boolean): String {
+        var calls = 0
+        val mock: QueryFunction = { _, transmissionKey, _ ->
+            calls++
+            if (calls == 1) {
+                KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+            } else {
+                val body = """{"records":[],"folders":[],"encryptedAppKey":null}""".toByteArray()
+                KeeperHttpResponse(HTTP_OK, encrypt(body, transmissionKey.key))
+            }
+        }
+        val options = SecretsManagerOptions(
+            buildStorage(), mock, loggingEnabled = loggingEnabled, throttleSleepMillis = { }
+        )
+        val original = System.err
+        val buf = java.io.ByteArrayOutputStream()
+        System.setErr(java.io.PrintStream(buf, true))
+        try {
+            getSecrets(options)
+        } finally {
+            System.setErr(original)
+        }
+        return buf.toString()
+    }
+
+    @Test
+    fun throttleWarning_suppressedWhenLoggingDisabled() {
+        val err = captureThrottleStderr(loggingEnabled = false)
+        assertFalse(
+            err.contains("throttled", ignoreCase = true),
+            "no throttle warning should reach stderr when loggingEnabled=false, got: $err"
+        )
+    }
+
+    @Test
+    fun throttleWarning_emittedWhenLoggingEnabled() {
+        val err = captureThrottleStderr(loggingEnabled = true)
+        assertTrue(err.contains("throttled", ignoreCase = true), "expected a throttle warning on stderr")
+        assertTrue(
+            Regex("attempt 1/$MAX_THROTTLE_RETRIES").containsMatchIn(err),
+            "expected attempt counter in warning, got: $err"
+        )
+    }
 }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -1,0 +1,157 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_OK
+import kotlin.test.*
+
+// Throttle retry with exponential backoff (KSM-876 / KSM-878). Unit tests exercise the internal
+// helpers; e2e tests drive getSecrets through postQuery with a mocked queryFunction returning
+// HTTP 403 {"error":"throttled"} responses and a recording throttleSleepMillis so retries never
+// actually wait.
+@ExperimentalSerializationApi
+internal class ThrottleTest {
+
+    private val fakeToken = "YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c"
+
+    @BeforeTest
+    fun setUp() {
+        // A deterministic, valid 32-byte transmission key. Also avoids leakage from getSecretsE2E,
+        // whose stub closes over its own (by now out-of-range) response index.
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+    }
+
+    private fun throttleBody(retryAfter: Double? = null): ByteArray {
+        val json = if (retryAfter == null) {
+            """{"error":"throttled","message":"throttled"}"""
+        } else {
+            """{"error":"throttled","message":"throttled","retry_after":$retryAfter}"""
+        }
+        return json.toByteArray()
+    }
+
+    // --- unit: throttleDelayMillis ---
+
+    @Test
+    fun throttleDelay_exponentialSequence_noJitter() {
+        val expected = listOf(11000L, 22000L, 44000L, 88000L, 176000L)
+        expected.forEachIndexed { attempt, want ->
+            assertEquals(want, throttleDelayMillis(attempt, 0.0, 0.0))
+        }
+    }
+
+    @Test
+    fun throttleDelay_retryAfterPrecedence_andNonPositiveIgnored() {
+        assertEquals(7000L, throttleDelayMillis(3, 7.0, 0.0))
+        assertEquals(11000L, throttleDelayMillis(0, 0.0, 0.0))
+        assertEquals(22000L, throttleDelayMillis(1, -5.0, 0.0))
+    }
+
+    @Test
+    fun throttleDelay_jitterBounds() {
+        assertEquals(8250L, throttleDelayMillis(0, 0.0, -0.25))
+        assertEquals(13750L, throttleDelayMillis(0, 0.0, 0.25))
+    }
+
+    // --- unit: parseThrottle ---
+
+    @Test
+    fun parseThrottle_table() {
+        assertEquals(0.0, parseThrottle("""{"error":"throttled"}"""))
+        assertEquals(5.0, parseThrottle("""{"result_code":"throttled","retry_after":5}"""))
+        assertEquals(3.0, parseThrottle("""{"error":"throttled","retry_after":"3"}"""))
+        assertEquals(0.0, parseThrottle("""{"error":"throttled","retry_after":-2}"""))
+        assertNull(parseThrottle("""{"error":"key"}"""))
+        assertNull(parseThrottle("not json"))
+        assertNull(parseThrottle(""))
+    }
+
+    // --- e2e via getSecrets ---
+
+    private fun buildStorage(): KeyValueStorage {
+        val storage = InMemoryStorage()
+        initializeStorage(storage, fakeToken, "fake.keepersecurity.com")
+        // Seed an app key so the (non-bound) empty success response decrypts without error; the
+        // key itself is unused because the mocked responses carry no records.
+        storage.saveBytes(KEY_APP_KEY, ByteArray(32))
+        return storage
+    }
+
+    @Test
+    fun retriesThenSucceeds() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, transmissionKey, _ ->
+            calls++
+            if (calls == 1) {
+                KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+            } else {
+                val body = """{"records":[],"folders":[],"encryptedAppKey":null}""".toByteArray()
+                KeeperHttpResponse(HTTP_OK, encrypt(body, transmissionKey.key))
+            }
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        val secrets = getSecrets(options)
+        assertTrue(secrets.records.isEmpty())
+        assertEquals(1, sleeps.size)
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun exhaustionThrowsKeeperThrottleException() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            calls++
+            KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<KeeperThrottleException> { getSecrets(options) }
+        assertEquals(5, sleeps.size) // five backoff sleeps before giving up
+        assertEquals(6, calls) // 5 retries + the final throttled response
+    }
+
+    @Test
+    fun retryAfterIsHonored() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            calls++
+            if (calls == 1) KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody(3.0))
+            else KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<KeeperThrottleException> { getSecrets(options) }
+        // retry_after = 3s with +/-25% jitter -> [2250ms, 3750ms]
+        assertTrue(sleeps[0] in 2250L..3750L, "first delay was ${sleeps[0]}ms")
+    }
+
+    @Test
+    fun nonThrottle403NotRetried() {
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            KeeperHttpResponse(HTTP_FORBIDDEN, """{"error":"access_denied","message":"nope"}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        val e = assertFailsWith<Exception> { getSecrets(options) }
+        assertFalse(e is KeeperThrottleException, "a non-throttle 403 must not become a throttle error")
+        assertEquals(0, sleeps.size)
+    }
+
+    @Test
+    fun non403ThrottleBodyNotRetried() {
+        // A 502 carrying a {"error":"throttled"} body must NOT be retried (403 gate).
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            KeeperHttpResponse(502, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<Exception> { getSecrets(options) }
+        assertEquals(0, sleeps.size)
+    }
+}


### PR DESCRIPTION
## Summary

Implements automatic **throttle retry with exponential backoff** for the Java/Kotlin SDK, part of epic **KSM-876** — ticket **KSM-878**. Ports the algorithm already shipped in the Python (KSM-877) and Go (KSM-881) SDKs.

The Keeper backend throttles per `{endpoint}+{clientId}` (100 req / 10s window) and returns **HTTP 403** with body `{"error":"throttled"}`. Previously the SDK surfaced this as an immediate `Exception`; now `postQuery` retries transparently.

## Algorithm

- Constants `MAX_THROTTLE_RETRIES = 5`, `BASE_THROTTLE_DELAY_SEC = 11` (1s margin over the backend's 10s memcached TTL).
- On a **403** whose body is `result_code`/`error` == `"throttled"` (detected **before** the key-rotation handler so that path — including the IL5 custom-key suppression — is untouched, and **gated on 403** so a 500/502 carrying a throttled body is not retried):
  - if retries are exhausted → throw the new `KeeperThrottleException`;
  - otherwise log a warning, sleep `retry_after` (if > 0) else `11 * 2^attempt` (11/22/44/88/176s) with **±25% jitter**, then retry.

## Changes

- `SecretsManager.kt` — `MAX_THROTTLE_RETRIES` / `BASE_THROTTLE_DELAY_SEC` constants; `parseThrottle` / `throttleDelayMillis` / `throttleJitter` helpers (internal, for unit tests); retry logic in `postQuery`; optional `throttleSleepMillis` seam on `SecretsManagerOptions` (defaults to `Thread.sleep`).
- `SecretsManagerExceptions.kt` — new public `KeeperThrottleException`.
- `ThrottleTest.kt` — new test class. No version bump; the Java SDK keeps no CHANGELOG.

## Tests (kotlin.test / JUnit)

- Unit: exponential sequence `[11,22,44,88,176]s` with pinned jitter, `retry_after` precedence, jitter bounds; `parseThrottle` table.
- E2E (via `getSecrets` with a mocked `queryFunction` + recording `throttleSleepMillis`): retry-then-success, exhaustion → `KeeperThrottleException`, `retry_after` honored, non-throttle 403 not retried, 502-with-throttled-body not retried.
- `ThrottleTest`: **9 tests pass**; full module suite: **38 tests, 0 failures** (existing `getSecretsE2E` unaffected).

Base branch: `release/sdk/java/core/v17.2.1` (can be retargeted once a dedicated release branch is cut).
