### PR TITLE
fix(sdk/python/core): honor kms_cache_file_name override in KSMCache cache path (KSM-1019)

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/_version.py
+++ b/sdk/python/core/keeper_secrets_manager_core/_version.py
@@ -11,4 +11,4 @@
 
 # Single source of truth for package version
 # This file is imported by both setup.py and the package itself
-__version__ = "17.3.0"
+__version__ = "17.3.1"

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1904,14 +1904,20 @@ class SecretsManager:
 
 
 class KSMCache:
-    # Default cache file name, kept for backward compatibility. The directory is read
-    # lazily from KSM_CACHE_DIR at call time (see get_cache_file_path), so setting the
-    # env var after import is honored. If not set, the cache file is created in the
-    # current working directory.
+    # Default cache file name. The directory is read lazily from KSM_CACHE_DIR at call
+    # time (see get_cache_file_path), so setting the env var after import is honored. If
+    # not set, the cache file is created in the current working directory. Assigning
+    # kms_cache_file_name directly still overrides the full path (backward compatibility).
     kms_cache_file_name = os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
+    # Snapshot of the import-time default, used to detect an explicit override above.
+    _default_cache_file_name = kms_cache_file_name
 
     @classmethod
     def get_cache_file_path(cls):
+        # An explicit assignment to kms_cache_file_name takes precedence (backward compat)...
+        if cls.kms_cache_file_name != cls._default_cache_file_name:
+            return cls.kms_cache_file_name
+        # ...otherwise resolve the directory from KSM_CACHE_DIR at call time.
         return os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
 
     @staticmethod

--- a/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
+++ b/sdk/python/core/keeper_secrets_manager_core/keeper_globals.py
@@ -32,7 +32,7 @@ def get_client_version(hardcode=False):
     # Default version for hardcode mode or when all detection methods fail
     version_major = "17"
     version_minor_default = "3"
-    version_revision_default = "0"
+    version_revision_default = "1"
     version = "{}.{}.{}".format(version_major, version_minor_default, version_revision_default)
 
     # Allow the default version to be hard coded

--- a/sdk/python/core/tests/cache_test.py
+++ b/sdk/python/core/tests/cache_test.py
@@ -39,6 +39,33 @@ class CacheTest(unittest.TestCase):
                 else:
                     os.environ["KSM_CACHE_DIR"] = original
 
+    def test_kms_cache_file_name_override_is_honored(self):
+        """Assigning KSMCache.kms_cache_file_name must override the cache path (backward compat).
+
+        Before the lazy-resolution change this override governed the cache location; cache
+        operations must continue to honor it when it is explicitly set.
+        """
+        original = KSMCache.kms_cache_file_name
+        with tempfile.TemporaryDirectory() as temp_dir:
+            custom_path = os.path.join(temp_dir, "custom_cache.bin")
+            KSMCache.kms_cache_file_name = custom_path
+            try:
+                payload = b"override-bytes"
+                KSMCache.save_cache(payload)
+                self.assertTrue(
+                    os.path.exists(custom_path),
+                    "cache file should be written to the overridden kms_cache_file_name",
+                )
+                self.assertEqual(payload, KSMCache.get_cached_data())
+
+                KSMCache.remove_cache_file()
+                self.assertFalse(
+                    os.path.exists(custom_path),
+                    "remove_cache_file should delete the overridden cache file",
+                )
+            finally:
+                KSMCache.kms_cache_file_name = original
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/core/tests/smoke_test.py
+++ b/sdk/python/core/tests/smoke_test.py
@@ -194,11 +194,11 @@ class SmokeTest(unittest.TestCase):
 
         # Test 1: Normal case - __version__ is available (primary path)
         client_version = get_client_version(hardcode=False)
-        self.assertEqual("17.3.0", client_version, "did not get correct version from __version__")
+        self.assertEqual("17.3.1", client_version, "did not get correct version from __version__")
 
         # Test 2: Hardcode mode still works
         client_version = get_client_version(hardcode=True)
-        self.assertEqual("17.3.0", client_version, "did not get the correct client version for hardcoded")
+        self.assertEqual("17.3.1", client_version, "did not get the correct client version for hardcoded")
 
         # Test 3: Fallback to importlib.metadata when __version__ import fails
         # Mock the import to fail, then check fallback works
@@ -231,8 +231,8 @@ class SmokeTest(unittest.TestCase):
             mock_meta.return_value = "16.6.5"
             # But __version__ should take precedence with correct version
             client_version = get_client_version(hardcode=False)
-            # Should get 17.1.0 from __version__, NOT 16.6.5 from stale metadata
-            self.assertEqual("17.3.0", client_version,
+            # Should get 17.3.1 from __version__, NOT 16.6.5 from stale metadata
+            self.assertEqual("17.3.1", client_version,
                            "KSM-749: Should use __version__ not stale metadata (16.6.5)")
 
     def test_il5_region_mapping(self):


### PR DESCRIPTION
**Jira:** [KSM-1019](https://keeper.atlassian.net/browse/KSM-1019) · **Fixes** #1044

## Summary

PR #1034 (KSM-1004) rerouted `KSMCache.save_cache` / `get_cached_data` / `remove_cache_file` through a new `get_cache_file_path()` that re-derives the path from `KSM_CACHE_DIR` and no longer reads the `kms_cache_file_name` class attribute. As a result, assigning `KSMCache.kms_cache_file_name = "/custom/path.bin"` was **silently ignored** — a backward-incompatible change for consumers that set it (and it was the only way to customize the cache *filename*, since `KSM_CACHE_DIR` only controls the directory).

## Changes

- **`core.py`** — `get_cache_file_path()` returns an explicitly-overridden `kms_cache_file_name` (detected via an import-time default snapshot), otherwise resolves `KSM_CACHE_DIR` lazily at call time. #1034's lazy behavior is preserved; the three cache methods already route through this method, so no caller changes were needed.
- **`tests/cache_test.py`** — add `test_kms_cache_file_name_override_is_honored`.
- **Version bump 17.3.0 → 17.3.1** across the three coupled sources: `_version.py`, the `keeper_globals.py` hardcoded fallback (`version_revision_default`), and the `smoke_test.py` version assertions.

## Behavior (verified)

| Scenario | Result |
|---|---|
| Explicit `kms_cache_file_name` override | honored (regression fixed) |
| No override, no env var | `ksm_cache.bin` in CWD (unchanged) |
| `KSM_CACHE_DIR` set after import, attribute untouched | honored (KSM-1004 preserved) |

## Testing

`cd sdk/python/core && python -m pytest tests/` → **127 passed, 1 skipped** locally.

> Note: the `Test-Python` workflow only triggers on PRs targeting `master`, so it will not auto-run against this release branch — the suite was run locally instead.

## Target

Point release on the v17.3.x line; base branch `release/sdk/python/core/v17.3.1` (branched from the v17.3.0 release).


[KSM-1019]: https://keeper.atlassian.net/browse/KSM-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ