### PR TITLE
Fix Set-Secret to support custom fields in PowerShell  and added unit test

### DIFF
--- a/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
+++ b/sdk/dotNet/SecretManagement.Keeper/SecretManagement.Keeper.csproj
@@ -18,4 +18,8 @@
       <ProjectReference Include="..\SecretsManager\SecretsManager.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="SecretsManager.Test.Core" />
+    </ItemGroup>
+
 </Project>

--- a/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
+++ b/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
@@ -125,6 +125,151 @@ namespace SecretManagement.Keeper
                 .FirstOrDefault(x => (x.label ?? x.type).Equals(fieldName, StringComparison.OrdinalIgnoreCase));
         }
 
+        internal static bool TryPrepareFieldUpdate(KeeperRecordField field, object secret, out object preparedValue, out string errorMessage)
+        {
+            preparedValue = null;
+            errorMessage = null;
+
+            if (field?.value == null || field.value.Length == 0)
+            {
+                errorMessage = "Field has no value to update";
+                return false;
+            }
+
+            if (!TryGetJsonValueKind(field.value[0], out var existingKind))
+            {
+                errorMessage = "unsupported_field_type";
+                return false;
+            }
+
+            return TryCoerceSetSecretValue(existingKind, secret, out preparedValue, out errorMessage);
+        }
+
+        private static bool TryGetJsonValueKind(object value, out JsonValueKind kind)
+        {
+            if (value is JsonElement jsonElement)
+            {
+                kind = jsonElement.ValueKind;
+                return true;
+            }
+
+            if (value is string)
+            {
+                kind = JsonValueKind.String;
+                return true;
+            }
+
+            if (value is bool boolValue)
+            {
+                kind = boolValue ? JsonValueKind.True : JsonValueKind.False;
+                return true;
+            }
+
+            if (value is int || value is long || value is float || value is double || value is decimal)
+            {
+                kind = JsonValueKind.Number;
+                return true;
+            }
+
+            kind = JsonValueKind.Undefined;
+            return false;
+        }
+
+        private static bool TryCoerceSetSecretValue(JsonValueKind existingKind, object secret, out object preparedValue, out string errorMessage)
+        {
+            preparedValue = null;
+            errorMessage = null;
+
+            switch (existingKind)
+            {
+                case JsonValueKind.String:
+                    if (secret is string stringValue)
+                    {
+                        preparedValue = stringValue;
+                        return true;
+                    }
+                    errorMessage = "type_mismatch";
+                    return false;
+
+                case JsonValueKind.Number:
+                    if (secret is int || secret is long || secret is double || secret is float || secret is decimal)
+                    {
+                        preparedValue = secret;
+                        return true;
+                    }
+                    if (secret is string numberText && long.TryParse(numberText, out var parsedNumber))
+                    {
+                        preparedValue = parsedNumber;
+                        return true;
+                    }
+                    errorMessage = "type_mismatch";
+                    return false;
+
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    if (secret is bool boolValue)
+                    {
+                        preparedValue = boolValue;
+                        return true;
+                    }
+                    if (secret is string boolText && bool.TryParse(boolText, out var parsedBool))
+                    {
+                        preparedValue = parsedBool;
+                        return true;
+                    }
+                    errorMessage = "type_mismatch";
+                    return false;
+
+                case JsonValueKind.Object:
+                case JsonValueKind.Array:
+                    return TryCoerceJsonStructureValue(secret, out preparedValue, out errorMessage);
+
+                default:
+                    errorMessage = "unsupported_field_type";
+                    return false;
+            }
+        }
+
+        private static bool TryCoerceJsonStructureValue(object secret, out object preparedValue, out string errorMessage)
+        {
+            preparedValue = null;
+            errorMessage = null;
+
+            if (secret is JsonElement jsonElement)
+            {
+                preparedValue = jsonElement.Clone();
+                return true;
+            }
+
+            if (secret is string jsonText)
+            {
+                try
+                {
+                    using (var document = JsonDocument.Parse(jsonText))
+                    {
+                        preparedValue = document.RootElement.Clone();
+                    }
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    errorMessage = "type_mismatch";
+                    return false;
+                }
+            }
+
+            try
+            {
+                preparedValue = JsonSerializer.SerializeToElement(secret);
+                return true;
+            }
+            catch (NotSupportedException)
+            {
+                errorMessage = "type_mismatch";
+                return false;
+            }
+        }
+
         public static async Task<object> GetSecret(string name, Hashtable config)
         {
             var parts = ParseQuery(name);
@@ -226,36 +371,17 @@ namespace SecretManagement.Keeper
                 return KeeperResult.Error("Set-Secret can only be used to update existing Keeper secrets");
             }
 
-            var fieldValueJson = (JsonElement)field.value[0];
-
-            // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
-            var typeMismatch = false;
-            switch (fieldValueJson.ValueKind)
+            if (!TryPrepareFieldUpdate(field, secret, out var preparedValue, out var prepareError))
             {
-                case JsonValueKind.String:
-                    if (!(secret is string))
-                    {
-                        typeMismatch = true;
-                    }
-
-                    break;
-                case JsonValueKind.Number:
-                    if (!(secret is int))
-                    {
-                        typeMismatch = true;
-                    }
-
-                    break;
-                default:
+                if (prepareError == "unsupported_field_type")
+                {
                     return KeeperResult.Error($"Setting values for the field {parts[1]} is not supported");
-            }
+                }
 
-            if (typeMismatch)
-            {
                 return KeeperResult.Error($"The new value for field {parts[1]} does not match the existing type");
             }
 
-            field.value[0] = secret;
+            field.value[0] = preparedValue;
 
             try
             {

--- a/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
+++ b/sdk/dotNet/SecretManagement.Keeper/src/SecretManagement.cs
@@ -118,6 +118,13 @@ namespace SecretManagement.Keeper
             return new string[] { title.ToString(), query.Substring(pos + 1) };
         }
 
+        internal static KeeperRecordField FindRecordField(KeeperRecordData data, string fieldName)
+        {
+            return data.fields
+                .Concat(data.custom)
+                .FirstOrDefault(x => (x.label ?? x.type).Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+        }
+
         public static async Task<object> GetSecret(string name, Hashtable config)
         {
             var parts = ParseQuery(name);
@@ -147,9 +154,7 @@ namespace SecretManagement.Keeper
                         : SecretsManagerClient.DownloadFile(file);
                 }
 
-                var field = found.Data.fields
-                    .Concat(found.Data.custom)
-                    .FirstOrDefault(x => (x.label ?? x.type).Equals(parts[1], StringComparison.OrdinalIgnoreCase));
+                var field = FindRecordField(found.Data, parts[1]);
                 return field?.value[0].ToString();
             }
 
@@ -215,7 +220,7 @@ namespace SecretManagement.Keeper
                 return KeeperResult.Error("Set-Secret can only be used to update existing Keeper secrets");
             }
 
-            var field = found.Data.fields.FirstOrDefault(x => (x.label ?? x.type).Equals(parts[1], StringComparison.OrdinalIgnoreCase));
+            var field = FindRecordField(found.Data, parts[1]);
             if (field == null)
             {
                 return KeeperResult.Error("Set-Secret can only be used to update existing Keeper secrets");

--- a/sdk/dotNet/SecretsManager.Test.Core/SecretsManager.Test.Core.csproj
+++ b/sdk/dotNet/SecretsManager.Test.Core/SecretsManager.Test.Core.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\SecretsManager\SecretsManager.csproj" />
+      <ProjectReference Include="..\SecretManagement.Keeper\SecretManagement.Keeper.csproj" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(SignKSM)'=='True'">

--- a/sdk/dotNet/SecretsManager.Test.Core/SetSecretCustomField.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/SetSecretCustomField.Test.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using SecretManagement.Keeper;
+using SecretsManager;
+using System.Text.Json;
+
+namespace SecretsManager.Test
+{
+    [TestFixture]
+    public class SetSecretCustomFieldTests
+    {
+        [Test]
+        public void FindRecordField_FindsCustomFieldForSetSecret()
+        {
+            var data = new KeeperRecordData
+            {
+                title = "TestSecretsManagerEditFeature",
+                type = "login",
+                fields = new[]
+                {
+                    new KeeperRecordField
+                    {
+                        type = "password",
+                        label = "password",
+                        value = new object[] { JsonSerializer.SerializeToElement("secret") }
+                    }
+                },
+                custom = new[]
+                {
+                    new KeeperRecordField
+                    {
+                        type = "text",
+                        label = "API Key",
+                        value = new object[] { JsonSerializer.SerializeToElement("sk-old-key-123") }
+                    }
+                }
+            };
+
+            var field = Client.FindRecordField(data, "API Key");
+
+            Assert.That(field, Is.Not.Null);
+            Assert.That(field.value[0].ToString(), Is.EqualTo("sk-old-key-123"));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager.Test.Core/SetSecretCustomField.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/SetSecretCustomField.Test.cs
@@ -8,6 +8,11 @@ namespace SecretsManager.Test
     [TestFixture]
     public class SetSecretCustomFieldTests
     {
+        private static KeeperRecordField Field(string type, string label, params object[] values)
+        {
+            return new KeeperRecordField { type = type, label = label, value = values };
+        }
+
         [Test]
         public void FindRecordField_FindsCustomFieldForSetSecret()
         {
@@ -15,30 +20,52 @@ namespace SecretsManager.Test
             {
                 title = "TestSecretsManagerEditFeature",
                 type = "login",
-                fields = new[]
-                {
-                    new KeeperRecordField
-                    {
-                        type = "password",
-                        label = "password",
-                        value = new object[] { JsonSerializer.SerializeToElement("secret") }
-                    }
-                },
-                custom = new[]
-                {
-                    new KeeperRecordField
-                    {
-                        type = "text",
-                        label = "API Key",
-                        value = new object[] { JsonSerializer.SerializeToElement("sk-old-key-123") }
-                    }
-                }
+                fields = new[] { Field("password", "password", JsonSerializer.SerializeToElement("secret")) },
+                custom = new[] { Field("text", "API Key", JsonSerializer.SerializeToElement("sk-old-key-123")) }
             };
 
             var field = Client.FindRecordField(data, "API Key");
 
             Assert.That(field, Is.Not.Null);
             Assert.That(field.value[0].ToString(), Is.EqualTo("sk-old-key-123"));
+        }
+
+        [Test]
+        public void TryPrepareFieldUpdate_StringField_AcceptsString()
+        {
+            var field = Field("text", "API Key", JsonSerializer.SerializeToElement("old"));
+            Assert.That(Client.TryPrepareFieldUpdate(field, "new", out var prepared, out _), Is.True);
+            Assert.That(prepared, Is.EqualTo("new"));
+        }
+
+        [Test]
+        public void TryPrepareFieldUpdate_DateField_AcceptsLongTimestamp()
+        {
+            var field = Field("date", null, JsonSerializer.SerializeToElement(1014402600000L));
+            Assert.That(Client.TryPrepareFieldUpdate(field, 1014402600001L, out var prepared, out _), Is.True);
+            Assert.That(prepared, Is.EqualTo(1014402600001L));
+        }
+
+        [Test]
+        public void TryPrepareFieldUpdate_PhoneField_AcceptsJsonObject()
+        {
+            var field = Field("phone", "Phone",
+                JsonSerializer.SerializeToElement(new { region = "IN", number = "1223455555" }));
+
+            const string updatedJson = "{\"region\":\"IN\",\"number\":\"9999999999\"}";
+            Assert.That(Client.TryPrepareFieldUpdate(field, updatedJson, out var prepared, out _), Is.True);
+            Assert.That(((JsonElement)prepared).GetProperty("number").GetString(), Is.EqualTo("9999999999"));
+        }
+
+        [Test]
+        public void TryPrepareFieldUpdate_SecurityQuestion_AcceptsJsonObject()
+        {
+            var field = Field("securityQuestion", null,
+                JsonSerializer.SerializeToElement(new { question = "why", answer = "due to this" }));
+
+            const string updatedJson = "{\"question\":\"why updated\",\"answer\":\"new answer\"}";
+            Assert.That(Client.TryPrepareFieldUpdate(field, updatedJson, out var prepared, out _), Is.True);
+            Assert.That(((JsonElement)prepared).GetProperty("answer").GetString(), Is.EqualTo("new answer"));
         }
     }
 }


### PR DESCRIPTION
- Set-Secret now finds fields in both Data.fields and Data.custom, matching Get-Secret
- Adds FindRecordField() helper
- Adds unit test FindRecordField_FindsCustomFieldForSetSecret