### PR TITLE
Release Java SDK v17.3.0

### DIFF
--- a/.github/workflows/publish.maven.java.core.yml
+++ b/.github/workflows/publish.maven.java.core.yml
@@ -1,13 +1,22 @@
 name: Publish to Maven (Java Core SDK)
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to Maven Central (uncheck to build only)'
+        required: false
+        default: 'true'
+        type: boolean
 
 jobs:
   publish:
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable.maven.central.publish.yml
     with:
       working-directory: ./sdk/java/core
       project-name: keeper-secrets-manager-java
       project-title: Keeper Secrets Manager Java Core SDK
       java-version: '11'
+      publish: ${{ inputs.publish }}
     secrets: inherit

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -26,9 +26,13 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -87,6 +91,8 @@ jobs:
   test:
     needs: validate-version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -109,6 +115,8 @@ jobs:
   generate-and-upload-sbom:
     needs: [get-version, validate-version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -162,6 +170,8 @@ jobs:
     if: ${{ inputs.publish == true }}
     environment: prod
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     defaults:
       run:

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -159,6 +159,7 @@ jobs:
 
   publish-to-maven-central:
     needs: [get-version, test, generate-and-upload-sbom, confirm-publish]
+    if: ${{ inputs.publish == true }}
     environment: prod
     runs-on: ubuntu-latest
 

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           PROJECT_NAME: ${{ inputs.project-name }}
         run: |
-          VERSION=$(grep -Po 'version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
+          VERSION=$(grep -Po '^version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
           echo "Version retrieved: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -66,8 +66,48 @@ jobs:
           echo "Artifact ID retrieved: $ARTIFACT_ID"
           echo "artifact-id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
 
-  generate-and-upload-sbom:
+  validate-version:
     needs: get-version
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify version not already published on Maven Central
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+          ARTIFACT_ID: ${{ needs.get-version.outputs.artifact-id }}
+        run: |
+          GROUP_PATH="com/keepersecurity/secrets-manager"
+          POM_URL="https://repo1.maven.org/maven2/${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.pom"
+          if curl -sf "$POM_URL" > /dev/null 2>&1; then
+            echo "ERROR: ${ARTIFACT_ID} ${VERSION} already exists on Maven Central"
+            exit 1
+          fi
+          echo "Version ${VERSION} not yet published — OK to proceed"
+
+  test:
+    needs: validate-version
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Java ${{ inputs.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          gradle-version: '8.14'
+      - name: Build and Test
+        run: ./gradlew clean build --no-daemon
+
+  generate-and-upload-sbom:
+    needs: [get-version, validate-version]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -111,14 +151,14 @@ jobs:
           retention-days: 10
 
   confirm-publish:
-    needs: generate-and-upload-sbom
+    needs: [test, generate-and-upload-sbom]
     if: ${{ inputs.publish == true }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publish gate confirmed"
 
   publish-to-maven-central:
-    needs: [get-version, generate-and-upload-sbom, confirm-publish]
+    needs: [get-version, test, generate-and-upload-sbom, confirm-publish]
     environment: prod
     runs-on: ubuntu-latest
 
@@ -157,8 +197,8 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
-      - name: Build and test
-        run: ./gradlew clean build test
+      - name: Build
+        run: ./gradlew clean build -x test --no-daemon
 
       - name: Publish to staging directory
         run: ./gradlew publish
@@ -197,8 +237,8 @@ jobs:
               echo "Found deployment ID: $DEPLOYMENT_ID"
               echo "Checking deployment status via Central Portal API..."
 
-              # Create Bearer token from username:password
-              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64)
+              # Create Bearer token from username:password (no line wrapping)
+              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64 -w 0)
 
               # Poll Portal API for deployment status (max 20 attempts, 30 seconds each = 10 minutes)
               MAX_RETRIES=20

--- a/.github/workflows/reusable.maven.central.publish.yml
+++ b/.github/workflows/reusable.maven.central.publish.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: '11'
+      publish:
+        description: 'Publish to Maven Central (false = build only)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   get-version:
@@ -31,13 +36,17 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
       artifact-id: ${{ steps.extract-version.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Extract version and artifact ID from Gradle
         id: extract-version
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
         run: |
           VERSION=$(grep -Po 'version\s*=\s*"\K[^"]*' build.gradle.kts || echo "0.0.0-unknown")
           echo "Version retrieved: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           # Extract artifactId from settings.gradle.kts (rootProject.name)
           if [ -f "settings.gradle.kts" ]; then
@@ -51,11 +60,11 @@ jobs:
 
           # Final fallback to project-name input
           if [ -z "$ARTIFACT_ID" ]; then
-            ARTIFACT_ID="${{ inputs.project-name }}"
+            ARTIFACT_ID="$PROJECT_NAME"
           fi
 
           echo "Artifact ID retrieved: $ARTIFACT_ID"
-          echo "artifact-id=$ARTIFACT_ID" >> $GITHUB_OUTPUT
+          echo "artifact-id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
 
   generate-and-upload-sbom:
     needs: get-version
@@ -66,98 +75,50 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Build project and copy dependencies
-        run: |
-          echo "Building project to resolve dependencies..."
-          ./gradlew build -x test --no-daemon --refresh-dependencies
+      - name: Build project
+        run: ./gradlew build -x test --no-daemon
 
-          echo "Copying runtime dependencies for SBOM scanning..."
-          ./gradlew copyDependencies
+      - name: Generate SBOM with CycloneDX
+        run: ./gradlew cyclonedxBom --no-daemon
 
-          echo "Dependencies collected:"
-          ls -la build/sbom-deps/ || echo "Warning: sbom-deps directory not created"
-
-          echo "Excluding fatJar from SBOM (test artifact only):"
-          find build/libs -name "*.jar" -type f ! -name "*-fat.jar" || true
-
-      - name: Install SBOM tools
-        run: |
-          echo "Installing Syft v1.18.1..."
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.18.1
-
-          echo "Installing Manifest CLI v0.18.3..."
-          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b . v0.18.3
-          chmod +x ./manifest
-
-          echo "Verifying installations..."
-          syft version
-          ./manifest --version
-
-      - name: Generate and publish SBOM
-        env:
-          MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
-        run: |
-          echo "Creating Syft configuration for Java/Kotlin scanning..."
-          cat > syft-config.yaml << 'EOF'
-          package:
-            search:
-              scope: all-layers
-              unindexed-archives: true
-              indexed-archives: true
-            cataloger:
-              enabled: true
-              java:
-                enabled: true
-                search-unindexed-archives: true
-                search-indexed-archives: true
-                resolve-dependencies: true
-                use-network: false
-                max-parent-recursive-depth: 10
-              # Disable non-Java catalogers
-              ruby:
-                enabled: false
-              python:
-                enabled: false
-              nodejs:
-                enabled: false
-              dotnet:
-                enabled: false
-              golang:
-                enabled: false
-          EOF
-
-          echo "Generating SBOM with Manifest CLI..."
-          ./manifest sbom build/sbom-deps \
-            --generator=syft \
-            --generator-config=syft-config.yaml \
-            --name=${{ inputs.project-name }} \
-            --version=${{ needs.get-version.outputs.version }} \
-            --output=spdx-json \
-            --file=sbom.json \
-            --api-key=${MANIFEST_TOKEN} \
-            --publish=true \
-            --asset-label=application,sbom-generated,java,sdk,maven,security
+      - name: Publish SBOM to Manifest
+        uses: manifest-cyber/manifest-github-action@a90e8d22cb1a607317ec76cc9c53f61769c06213 # v1.6.0
+        with:
+          apiKey: ${{ secrets.MANIFEST_TOKEN }}
+          bomFilePath: ${{ inputs.working-directory }}/build/reports/cyclonedx/bom.json
+          sbomName: ${{ inputs.project-name }}
+          sbomVersion: ${{ needs.get-version.outputs.version }}
+          asset-labels: application,sbom-generated,java,sdk,maven,security
 
       - name: Archive SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: sbom-${{ inputs.project-name }}-${{ needs.get-version.outputs.version }}
-          path: ${{ inputs.working-directory }}/sbom.json
-          retention-days: 90
+          name: sbom-cyclonedx-${{ inputs.project-name }}-${{ needs.get-version.outputs.version }}
+          path: ${{ inputs.working-directory }}/build/reports/cyclonedx/bom.json
+          retention-days: 10
+
+  confirm-publish:
+    needs: generate-and-upload-sbom
+    if: ${{ inputs.publish == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Publish gate confirmed"
 
   publish-to-maven-central:
-    needs: [get-version, generate-and-upload-sbom]
+    needs: [get-version, generate-and-upload-sbom, confirm-publish]
     environment: prod
     runs-on: ubuntu-latest
 
@@ -167,13 +128,14 @@ jobs:
 
     steps:
       - name: Get the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Retrieve secrets from KSM
         id: ksmsecrets
-        uses: Keeper-Security/ksm-action@v1
+        uses: Keeper-Security/ksm-action@37abbada28637b6478ba845e73d3f8b9676572fe # master
         with:
           keeper-secret-config: ${{ secrets.KSM_ARTIFACT_JAVA_APP_CONFIG }}
           secrets: |
@@ -184,16 +146,16 @@ jobs:
             IR14oITcuvFr9Ek-lKVrXw/custom_field/centralPassword > env:JRELEASER_MAVENCENTRAL_PASSWORD
 
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
 
       - name: Build and test
         run: ./gradlew clean build test
@@ -212,10 +174,11 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ env.JRELEASER_MAVENCENTRAL_PASSWORD }}
 
       - name: Verify publication via Central Portal API
+        env:
+          ARTIFACT_ID: ${{ needs.get-version.outputs.artifact-id }}
+          VERSION: ${{ needs.get-version.outputs.version }}
         run: |
           GROUP_ID="com.keepersecurity.secrets-manager"
-          ARTIFACT_ID="${{ needs.get-version.outputs.artifact-id }}"
-          VERSION="${{ needs.get-version.outputs.version }}"
           GROUP_PATH="${GROUP_ID//./\/}"
 
           echo "Verifying publication for: ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"
@@ -235,7 +198,7 @@ jobs:
               echo "Checking deployment status via Central Portal API..."
 
               # Create Bearer token from username:password
-              AUTH_TOKEN=$(printf "%s:%s" "${{ env.JRELEASER_MAVENCENTRAL_USERNAME }}" "${{ env.JRELEASER_MAVENCENTRAL_PASSWORD }}" | base64)
+              AUTH_TOKEN=$(printf "%s:%s" "${JRELEASER_MAVENCENTRAL_USERNAME}" "${JRELEASER_MAVENCENTRAL_PASSWORD}" | base64)
 
               # Poll Portal API for deployment status (max 20 attempts, 30 seconds each = 10 minutes)
               MAX_RETRIES=20
@@ -332,9 +295,9 @@ jobs:
 
       - name: Upload JReleaser logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-logs-${{ inputs.project-name }}
           path: |
             ${{ inputs.working-directory }}/build/jreleaser/
-          retention-days: 5 
+          retention-days: 5

--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -3,6 +3,12 @@ name: Test-Java
 on:
   pull_request:
     branches: [ master ]
+    paths:
+      - 'sdk/java/core/**'
+      - '.github/workflows/test.java.yml'
+
+permissions:
+  contents: read
 
 jobs:
   test-java:
@@ -10,24 +16,25 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java-version: [ '8', '11', '16', '17', '18' ]
+        java-version: [ '8', '11', '17', '21' ]
     name: KSM test with Java ${{ matrix.java-version }}
     defaults:
       run:
         working-directory: ./sdk/java/core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Setup Java ${{ matrix.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java-version }}
 
-    - name: Setup, Build and Test
-      uses: gradle/actions/setup-gradle@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
         gradle-version: '8.14'
-        arguments: build test
-        build-root-directory: ./sdk/java/core
 
-
+    - name: Build and Test
+      run: gradle build test

--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -14,7 +14,6 @@ jobs:
   test-java:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         java-version: [ '8', '11', '17', '21' ]
     name: KSM test with Java ${{ matrix.java-version }}

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,11 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.3.0
+**Breaking Changes**
+- `KeeperFile.url` changed from `String` to `String?` — callers that access `url` directly must now handle null; `downloadFile()` already does this with a typed exception
+- `KeeperRecordData.custom` changed from `MutableList<KeeperRecordField>?` to `MutableList<KeeperRecordField>` — assigning `null` to this field will no longer compile; use an empty list instead
+- `KEY_SERVER_PUBIC_KEY_ID` is deprecated — replace with `KEY_SERVER_PUBLIC_KEY_ID` (corrected spelling); the old name is retained as a `@Deprecated` alias for back-compatibility
+
 - KSM-878 - Throttle retry with exponential backoff
   - Automatically retries HTTP 403 `{"error":"throttled"}` responses up to 5 times (`MAX_THROTTLE_RETRIES`)
   - Exponential backoff starting at 11s (1s margin over the backend's 10s memcached TTL), with ±25% jitter; uses `retry_after` from the response body when present

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -4,7 +4,7 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
-## 17.2.1
+## 17.3.0
 - KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
   - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
   - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -19,6 +19,17 @@ For more information see our official documentation page https://docs.keeper.io/
   - Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit `lastModified`
   - Previously threw `MissingFieldException` and silently skipped the file attachment
   - Now defaults to `0` when the field is absent, consistent with .NET SDK behavior (KSM-674)
+- KSM-753 - Fix record key decryption for shared folder records in flat `response.records[]`
+  - Records created via Commander/PowerShell in shared folders have their key encrypted with the folder key, not the app key
+  - SDK previously always used the app key for flat records, causing all field values to return null
+  - Now detects `innerFolderUid` and decrypts using the correct folder key
+- KSM-765 - Fix NPE crash when `url` field is absent from file response
+  - `KeeperFile.url` is now `String?` (nullable); server may omit it for files without a download URL
+- KSM-855 - Fix file descriptor leaks in `LocalConfigStorage` and HTTP connections
+  - `LocalConfigStorage`: replaced manual `stream.close()` calls with Kotlin `.use { }` in 4 locations — streams previously leaked on any I/O exception, and the init block never closed its reader at all
+  - `downloadFile`, `uploadFile`, `postFunction`: `HttpsURLConnection` is now explicitly disconnected in a `finally` block; `with()` is not try-with-resources and did not guarantee cleanup on exception
+- KSM-985 - Add typed empty-string guard to internal Base64 decoders (KSM-808 parity)
+  - `base64ToBytes("")` and `webSafe64ToBytes("")` now throw a `Keeper` exception instead of an opaque NPE from inside `java.util.Base64`
 
 ## 17.2.0
 - **SECURITY (KSM-699)** - Fix file permissions for config.json and cache.dat

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,7 +5,11 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
-- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
+- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
+  - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
+  - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table
+  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key on bind
+  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...")` persists key to storage
 - KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
   - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
   - Consistent with Commander and Vault which always include `"custom": []`

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -8,8 +8,10 @@ For more information see our official documentation page https://docs.keeper.io/
 - KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
   - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
   - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table
-  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key on bind
-  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...")` persists key to storage
+  - Layer 2 (extended OTT): 4-segment `REGION:clientKey:keyId:serverPublicKey` saves key and ID on bind
+  - Layer 3 (constructor param): `SecretsManagerOptions(serverPublicKey = "...", serverPublicKeyId = "...")` persists both to storage
+  - When a custom key is configured, a server key-rotation hint throws a clear error rather than silently overwriting the custom key ID
+  - Note: the storage constant for the key ID is `KEY_SERVER_PUBLIC_KEY_ID`
 - KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
   - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
   - Consistent with Commander and Vault which always include `"custom": []`

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -4,6 +4,16 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
+## 17.2.1
+- KSM-902 - Add IL5 (DoD Impact Level 5) region mapping (`IL5` → `il5.keepersecurity.us`)
+- KSM-823 - Fix `custom` field omitted from record create payload when no custom fields are set
+  - `KeeperRecordData.custom` now defaults to `mutableListOf()` instead of `null` — `kotlinx-serialization` previously skipped null fields, causing `"custom"` to be absent from the V3 API payload
+  - Consistent with Commander and Vault which always include `"custom": []`
+- KSM-854 - Fix `KeeperFileData` crash when `lastModified` field is absent from file metadata
+  - Files uploaded by non-SDK Keeper clients (iOS, Android, Web Vault) may omit `lastModified`
+  - Previously threw `MissingFieldException` and silently skipped the file attachment
+  - Now defaults to `0` when the field is absent, consistent with .NET SDK behavior (KSM-674)
+
 ## 17.2.0
 - **SECURITY (KSM-699)** - Fix file permissions for config.json and cache.dat
   - Config and cache files now created with 0600 permissions (owner read/write only)

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -12,7 +12,7 @@ For more information see our official documentation page https://docs.keeper.io/
 
 - KSM-878 - Throttle retry with exponential backoff
   - Automatically retries HTTP 403 `{"error":"throttled"}` responses up to 5 times (`MAX_THROTTLE_RETRIES`)
-  - Exponential backoff starting at 11s (1s margin over the backend's 10s memcached TTL), with ±25% jitter; uses `retry_after` from the response body when present
+  - Exponential backoff starting at 11s (1s margin over the backend's 10s memcached TTL), with one-sided 0-25% jitter (delay never undercuts the server's requested `retry_after`); uses `retry_after` from the response body when present, capped at 176s (`MAX_THROTTLE_DELAY_SEC`)
   - Warning logged to stderr on each retry (gated on `loggingEnabled`)
   - Exhausted retries throw `KeeperThrottleException` (public; catchable separately from generic `Exception`)
   - Injectable `throttleSleepMillis` hook in `SecretsManagerOptions` for test overrides

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -21,6 +21,11 @@ For more information see our official documentation page https://docs.keeper.io/
   - `getLinkData()` now returns `Map<String, Any?>` with typed scalars (String/Boolean/Int/Long/Double); nested objects and arrays are preserved
   - `getBooleanValue` checks the nested `allowedSettings` object for permission flags in `path:"meta"` links when `checkAllowedSettings = true`; accessors for `allowsRotation()`, `allowsConnections()`, etc. updated accordingly
   - Added `KeeperRecordLinkTest` suite covering all accessors, nested structures, and null preservation
+- KSM-1066 - Fix IL5 custom server public key not persisted by LocalConfigStorage
+  - `serverPublicKey` is now saved to and loaded from the on-disk config alongside `serverPublicKeyId`
+  - Without this fix, a second run after IL5 bind failed with "Key number X is not supported" because the key ID was stored but the key bytes were not
+- KSM-1067 - Fix IL5 stale-key diagnostic message swallowed by bare catch
+  - The actionable "Server rejected the custom server public key" error now propagates to callers instead of being swallowed
 - KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
   - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
   - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,17 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.3.0
+- KSM-878 - Throttle retry with exponential backoff
+  - Automatically retries HTTP 403 `{"error":"throttled"}` responses up to 5 times (`MAX_THROTTLE_RETRIES`)
+  - Exponential backoff starting at 11s (1s margin over the backend's 10s memcached TTL), with ±25% jitter; uses `retry_after` from the response body when present
+  - Warning logged to stderr on each retry (gated on `loggingEnabled`)
+  - Exhausted retries throw `KeeperThrottleException` (public; catchable separately from generic `Exception`)
+  - Injectable `throttleSleepMillis` hook in `SecretsManagerOptions` for test overrides
+- KSM-1008 - Align `KeeperRecordLink` accessors with Python reference
+  - Recursive `jsonElementToValue`/`jsonObjectToMap` helpers preserve JSON nulls (lossless, matching Python SDK)
+  - `getLinkData()` now returns `Map<String, Any?>` with typed scalars (String/Boolean/Int/Long/Double); nested objects and arrays are preserved
+  - `getBooleanValue` checks the nested `allowedSettings` object for permission flags in `path:"meta"` links when `checkAllowedSettings = true`; accessors for `allowsRotation()`, `allowsConnections()`, etc. updated accordingly
+  - Added `KeeperRecordLinkTest` suite covering all accessors, nested structures, and null preservation
 - KSM-902 - Add IL5 (DoD Impact Level 5) region mapping and dynamic server public key injection
   - Region: `IL5` OTT prefix maps to `il5.keepersecurity.us`
   - Layer 1 (config field): `serverPublicKey` in storage config overrides the embedded key table

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -46,6 +46,9 @@ For more information see our official documentation page https://docs.keeper.io/
   - `downloadFile`, `uploadFile`, `postFunction`: `HttpsURLConnection` is now explicitly disconnected in a `finally` block; `with()` is not try-with-resources and did not guarantee cleanup on exception
 - KSM-985 - Add typed empty-string guard to internal Base64 decoders (KSM-808 parity)
   - `base64ToBytes("")` and `webSafe64ToBytes("")` now throw a `Keeper` exception instead of an opaque NPE from inside `java.util.Base64`
+- KSM-1026 - Make `SecretsManagerException` public
+  - Java consumers can now `catch (SecretsManagerException e)` to handle SDK-level errors by type instead of catching bare `Exception`
+  - `SecureRandomException` / `SecureRandomSlowGenerationException` remain internal (no public use case)
 
 ## 17.2.0
 - **SECURITY (KSM-699)** - Fix file permissions for config.json and cache.dat

--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.2.1"
+version = "17.3.0"
 
 plugins {
     `java-library`

--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.2.0"
+version = "17.2.1"
 
 plugins {
     `java-library`
@@ -13,6 +13,7 @@ plugins {
     kotlin("plugin.serialization") version "2.2.10"
     `maven-publish`
     id("org.jreleaser") version "1.20.0"
+    id("org.cyclonedx.bom") version "3.2.4"
 }
 
 java {
@@ -168,12 +169,14 @@ tasks.javadoc {
     }
 }
 
-// Task to copy all runtime dependencies for SBOM generation
-tasks.register<Copy>("copyDependencies") {
-    from(configurations.runtimeClasspath)
-    into(layout.buildDirectory.dir("sbom-deps"))
+tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom") {
+    includeConfigs.set(listOf("runtimeClasspath"))
+    componentName.set("keeper-secrets-manager-java")
 }
 
+tasks.named<org.cyclonedx.gradle.CyclonedxAggregateTask>("cyclonedxBom") {
+    componentName.set("keeper-secrets-manager-java")
+}
 
 // Configure JReleaser for Central Portal publishing
 jreleaser {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -56,12 +56,12 @@ internal fun bytesToBase64(data: ByteArray): String {
 }
 
 internal fun base64ToBytes(data: String): ByteArray {
-    if (data.isEmpty()) throw Exception("Base64-encoded value is empty") // KSM-985
+    if (data.isEmpty()) throw SecretsManagerException("Base64-encoded value is empty") // KSM-985
     return Base64.getDecoder().decode(data)
 }
 
 internal fun webSafe64ToBytes(data: String): ByteArray {
-    if (data.isEmpty()) throw Exception("Base64url-encoded value is empty") // KSM-985
+    if (data.isEmpty()) throw SecretsManagerException("Base64url-encoded value is empty") // KSM-985
     return Base64.getUrlDecoder().decode(data)
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -56,10 +56,12 @@ internal fun bytesToBase64(data: ByteArray): String {
 }
 
 internal fun base64ToBytes(data: String): ByteArray {
+    if (data.isEmpty()) throw Exception("Base64-encoded value is empty") // KSM-985
     return Base64.getDecoder().decode(data)
 }
 
 internal fun webSafe64ToBytes(data: String): ByteArray {
+    if (data.isEmpty()) throw Exception("Base64url-encoded value is empty") // KSM-985
     return Base64.getUrlDecoder().decode(data)
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -74,7 +74,7 @@ class InMemoryStorage(configJson: String? = null) : KeyValueStorage {
             optSetFn(KEY_CLIENT_KEY, config.clientKey)
             optSetFn(KEY_APP_KEY, config.appKey)
             optSetFn(KEY_OWNER_PUBLIC_KEY, config.appOwnerPublicKey)
-            optSetFn(KEY_SERVER_PUBIC_KEY_ID, config.serverPublicKeyId)
+            optSetFn(KEY_SERVER_PUBLIC_KEY_ID, config.serverPublicKeyId)
         }
     }
 
@@ -134,7 +134,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.clientKey = storage.getString(KEY_CLIENT_KEY)
         config.appKey = storage.getString(KEY_APP_KEY)
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
-        config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBIC_KEY_ID)
+        config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
         val json = prettyJson.encodeToString(config)
         val outputStream = BufferedWriter(FileWriter(file))
         outputStream.write(json)

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -14,9 +14,7 @@ import kotlin.collections.HashMap
 
 fun saveCachedValue(data: ByteArray) {
     val file = File("cache.dat")
-    val fos = FileOutputStream(file)
-    fos.write(data)
-    fos.close()
+    FileOutputStream(file).use { fos -> fos.write(data) } // KSM-855: .use{} closes on exception
 
     // Set file permissions to 0600 (owner read/write only)
     try {
@@ -34,10 +32,7 @@ fun saveCachedValue(data: ByteArray) {
 
 fun getCachedValue(): ByteArray {
     try {
-        val fis = FileInputStream("cache.dat")
-        val bytes = fis.readBytes()
-        fis.close()
-        return bytes
+        return FileInputStream("cache.dat").use { it.readBytes() } // KSM-855: .use{} closes on exception
     } catch (e: Exception) {
         throw Exception("Cached value does not exist")
     }
@@ -117,8 +112,8 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private val file = configName?.let { File(it) }
     private var storage: InMemoryStorage = if (file != null && file.exists()) {
-        val inputStream = BufferedReader(FileReader(file))
-        InMemoryStorage(inputStream.readText())
+        val content = BufferedReader(FileReader(file)).use { it.readText() } // KSM-855: was never closed
+        InMemoryStorage(content)
     } else {
         InMemoryStorage()
     }
@@ -136,9 +131,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
         config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
         val json = prettyJson.encodeToString(config)
-        val outputStream = BufferedWriter(FileWriter(file))
-        outputStream.write(json)
-        outputStream.close()
+        BufferedWriter(FileWriter(file)).use { it.write(json) } // KSM-855: .use{} closes on exception
 
         // Set file permissions to 0600 (owner read/write only)
         try {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -34,7 +34,7 @@ fun getCachedValue(): ByteArray {
     try {
         return FileInputStream("cache.dat").use { it.readBytes() } // KSM-855: .use{} closes on exception
     } catch (e: Exception) {
-        throw Exception("Cached value does not exist")
+        throw SecretsManagerException("Cached value does not exist")
     }
 }
 
@@ -49,7 +49,8 @@ class InMemoryStorage(configJson: String? = null) : KeyValueStorage {
         var clientKey: String? = null,
         var appKey: String? = null,
         var appOwnerPublicKey: String? = null,
-        var serverPublicKeyId: String? = null
+        var serverPublicKeyId: String? = null,
+        var serverPublicKey: String? = null
     )
 
     private val strings: MutableMap<String, String> = HashMap()
@@ -70,6 +71,7 @@ class InMemoryStorage(configJson: String? = null) : KeyValueStorage {
             optSetFn(KEY_APP_KEY, config.appKey)
             optSetFn(KEY_OWNER_PUBLIC_KEY, config.appOwnerPublicKey)
             optSetFn(KEY_SERVER_PUBLIC_KEY_ID, config.serverPublicKeyId)
+            optSetFn(KEY_SERVER_PUBLIC_KEY, config.serverPublicKey)
         }
     }
 
@@ -107,7 +109,8 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         var clientKey: String? = null,
         var appKey: String? = null,
         var appOwnerPublicKey: String? = null,
-        var serverPublicKeyId: String? = null
+        var serverPublicKeyId: String? = null,
+        var serverPublicKey: String? = null
     )
 
     private val file = configName?.let { File(it) }
@@ -130,6 +133,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.appKey = storage.getString(KEY_APP_KEY)
         config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
         config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
+        config.serverPublicKey = storage.getString(KEY_SERVER_PUBLIC_KEY)
         val json = prettyJson.encodeToString(config)
         BufferedWriter(FileWriter(file)).use { it.write(json) } // KSM-855: .use{} closes on exception
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/Notation.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/Notation.kt
@@ -21,40 +21,40 @@ fun getValue(secrets: KeeperSecrets, notation: String): String {
         "notes" -> { return record.data.notes ?: "" }
         "file" -> {
             if (parameter == null)
-                throw Exception("Notation error - Missing required parameter: filename or file UID for files in record '$recordToken'")
+                throw SecretsManagerException("Notation error - Missing required parameter: filename or file UID for files in record '$recordToken'")
             if (record.files.isNullOrEmpty())
-                throw Exception("Notation error - Record $recordToken has no file attachments.")
+                throw SecretsManagerException("Notation error - Record $recordToken has no file attachments.")
             // file searches do not use indexes and rely on unique file names or fileUid
             val files = record.files.filter { (it.data.name == parameter) || (it.data.title == parameter) || (it.fileUid == parameter) }
             if (files.size > 1)
-                throw Exception("Notation error - Record $recordToken has multiple files matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has multiple files matching the search criteria '$parameter'")
             if (files.isEmpty())
-                throw Exception("Notation error - Record $recordToken has no files matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has no files matching the search criteria '$parameter'")
             val contents = downloadFile(files[0])
             return webSafe64FromBytes(contents)
         }
         "field", "custom_field" -> {
             if (parameter == null)
-                throw Exception("Notation error - Missing required parameter for the field (type or label): ex. /field/type or /custom_field/MyLabel")
+                throw SecretsManagerException("Notation error - Missing required parameter for the field (type or label): ex. /field/type or /custom_field/MyLabel")
 
             val fields = when(selector.lowercase()) {
                 "field" -> record.data.fields
                 "custom_field" -> record.data.custom ?: mutableListOf()
-                else -> throw Exception("Notation error - Expected /field or /custom_field but found /$selector")
+                else -> throw SecretsManagerException("Notation error - Expected /field or /custom_field but found /$selector")
             }
 
             val field = fields.find { parameter == fieldType(it) || parameter == it.label } ?:
-                throw Exception("Field $parameter not found in the record ${record.recordUid}")
+                throw SecretsManagerException("Field $parameter not found in the record ${record.recordUid}")
 
             // /<type|label>[index1][index2], ex. /url == /url[] == /url[][] == full value
             val idx = index1?.toIntOrNull() ?: -1 // -1 full value
             // valid only if [] or missing - ex. /field/phone or /field/phone[]
             if (idx == -1 && !(parsedNotation[2].index1?.second.isNullOrEmpty() || parsedNotation[2].index1?.second == "[]"))
-                throw Exception("Notation error - Invalid field index $idx")
+                throw SecretsManagerException("Notation error - Invalid field index $idx")
 
             val valuesCount = getFieldValuesCount(field)
             if (idx >= valuesCount)
-                throw Exception("Notation error - Field index out of bounds $idx >= $valuesCount for field $parameter")
+                throw SecretsManagerException("Notation error - Field index out of bounds $idx >= $valuesCount for field $parameter")
 
             //val fullObjValue = (parsedNotation[2].index2?.second.isNullOrEmpty() || parsedNotation[2].index2?.second == "[]")
             val objPropertyName = parsedNotation[2].index2?.first
@@ -83,7 +83,7 @@ fun getValue(secrets: KeeperSecrets, notation: String): String {
             }
             return ""
         }
-        else -> throw Exception("Invalid notation $notation")
+        else -> throw SecretsManagerException("Invalid notation $notation")
     }
 }
 
@@ -93,9 +93,9 @@ fun getFile(secrets: KeeperSecrets, notation: String): KeeperFile {
     if (selector == "file") {
         val fileId = parsedNotation[2].parameter?.first
         return record.files?.find { x -> x.data.name == fileId || x.data.title == fileId || x.fileUid == fileId }
-            ?: throw Exception("File $fileId not found in the record ${record.recordUid}")
+            ?: throw SecretsManagerException("File $fileId not found in the record ${record.recordUid}")
     } else {
-        throw Exception("Notation should include file tag")
+        throw SecretsManagerException("Notation should include file tag")
     }
 }
 
@@ -104,15 +104,15 @@ private data class RecordAndNotation(val record: KeeperRecord, val queryParts: L
 private fun getRecord(secrets: KeeperSecrets, notation: String): RecordAndNotation {
     val parsedNotation = parseNotation(notation, true) // prefix, record, selector, footer
     if (parsedNotation.size < 3) {
-        throw Exception("Invalid notation $notation")
+        throw SecretsManagerException("Invalid notation $notation")
     }
 
     val selector = parsedNotation[2].text?.first ?: // type|title|notes or file|field|custom_field
-        throw Exception("Invalid notation $notation")
+        throw SecretsManagerException("Invalid notation $notation")
     val recordToken = parsedNotation[1].text?.first ?: // UID or Title
-        throw Exception("Invalid notation $notation")
+        throw SecretsManagerException("Invalid notation $notation")
     val record = secrets.records.find { (it.recordUid == recordToken) || (it.data.title == recordToken) } ?:
-        throw Exception("Record '$recordToken' not found")
+        throw SecretsManagerException("Record '$recordToken' not found")
 
     return RecordAndNotation(record, parsedNotation, selector, recordToken)
 }
@@ -438,7 +438,7 @@ private fun getFieldValueProperty(field: KeeperRecordField, valueIdx: Int, prope
         is Schedules -> getObjectProperty(field.value[valueIdx], propertyName)
         is Scripts -> getObjectProperty(field.value[valueIdx], propertyName)
         is SecurityQuestions -> getObjectProperty(field.value[valueIdx], propertyName)
-        else -> throw Exception("Property name notation is not supported for ${fieldType(field)}")
+        else -> throw SecretsManagerException("Property name notation is not supported for ${fieldType(field)}")
     }
 }
 
@@ -521,7 +521,7 @@ private fun parseSubsection(text: String, position: Int, delimiters: String, esc
     if (text.isEmpty() || pos < 0 || pos >= text.length)
         return null
     if (delimiters.isEmpty() || delimiters.length > 2)
-        throw Exception("Notation parser: Internal error - Incorrect delimiters count. Delimiters: '$delimiters'")
+        throw SecretsManagerException("Notation parser: Internal error - Incorrect delimiters count. Delimiters: '$delimiters'")
 
     var token = ""
     var raw = ""
@@ -530,7 +530,7 @@ private fun parseSubsection(text: String, position: Int, delimiters: String, esc
             // notation cannot end in single char incomplete escape sequence
             // and only escape_chars should be escaped
             if (((pos + 1) >= text.length) || !ESCAPE_CHARS.contains(text[pos + 1]))
-                throw Exception("Notation parser: Incorrect escape sequence at position $pos")
+                throw SecretsManagerException("Notation parser: Incorrect escape sequence at position $pos")
             // copy the properly escaped character
             token += text[pos + 1]
             raw += "" + text[pos] + text[pos + 1]
@@ -544,9 +544,9 @@ private fun parseSubsection(text: String, position: Int, delimiters: String, esc
                     token += text[pos]
             } else { // 2 delimiters
                 if (raw[0] != delimiters[0])
-                    throw Exception("Notation parser: Index sections must start with '['")
+                    throw SecretsManagerException("Notation parser: Index sections must start with '['")
                 if (raw.length > 1 && text[pos] == delimiters[0])
-                    throw Exception("Notation parser: Index sections do not allow extra '[' inside.")
+                    throw SecretsManagerException("Notation parser: Index sections do not allow extra '[' inside.")
                 if (!delimiters.contains(text[pos]))
                     token += text[pos]
                 else if (text[pos] == delimiters[1])
@@ -559,19 +559,19 @@ private fun parseSubsection(text: String, position: Int, delimiters: String, esc
     if (delimiters.length == 2 && (
             (raw.length < 2 || raw[0] != delimiters[0] || raw[raw.length - 1] != delimiters[1]) ||
             (escaped && raw[raw.length - 2] == ESCAPE_CHAR)))
-        throw Exception("Notation parser: Index sections must be enclosed in '[' and ']'")
+        throw SecretsManagerException("Notation parser: Index sections must be enclosed in '[' and ']'")
 
     return Pair(token, raw)
 }
 
 private fun parseSection(notation: String, section: String, pos: Int): NotationSection {
     if (notation.isEmpty())
-        throw Exception("Keeper notation parsing error - missing notation URI")
+        throw SecretsManagerException("Keeper notation parsing error - missing notation URI")
 
     val sectionName = section.lowercase()
     val sections: List<String> = listOf("prefix", "record", "selector", "footer")
     if (!sections.contains(sectionName))
-        throw Exception("Keeper notation parsing error - unknown section: '$sectionName'")
+        throw SecretsManagerException("Keeper notation parsing error - unknown section: '$sectionName'")
 
     val result = NotationSection(section)
     result.startPos = pos
@@ -646,7 +646,7 @@ private fun parseSection(notation: String, section: String, pos: Int): NotationS
                 }
             }
         }
-        else -> throw Exception("Keeper notation parsing error - unknown section: '$sectionName'")
+        else -> throw SecretsManagerException("Keeper notation parsing error - unknown section: '$sectionName'")
     }
     return result
 }
@@ -654,7 +654,7 @@ private fun parseSection(notation: String, section: String, pos: Int): NotationS
 fun parseNotation(notationUri: String, legacyMode: Boolean = false): List<NotationSection> {
     var notation = notationUri
     if (notation.isEmpty())
-        throw Exception("Keeper notation is missing or invalid.")
+        throw SecretsManagerException("Keeper notation is missing or invalid.")
 
     // Notation is either plaintext keeper URI format or URL safe base64 string (UTF-8)
     // auto-detect format - '/' is not part of base64 URL safe alphabet
@@ -664,7 +664,7 @@ fun parseNotation(notationUri: String, legacyMode: Boolean = false): List<Notati
             val plaintext = bytes.decodeToString(0, bytes.size, true)
             notation = plaintext
         } catch (e: Exception) {
-            throw Exception("Keeper notation is in invalid format - plaintext URI or URL safe base64 string expected.")
+            throw SecretsManagerException("Keeper notation is in invalid format - plaintext URI or URL safe base64 string expected.")
         }
     }
 
@@ -682,23 +682,23 @@ fun parseNotation(notationUri: String, legacyMode: Boolean = false): List<Notati
     val fullSelectors: List<String> = listOf("field", "custom_field", "file")
     val selectors: List<String> = listOf("type", "title", "notes", "field", "custom_field", "file")
     if (!record.isPresent || !selector.isPresent)
-        throw Exception("Keeper notation URI missing information about the uid, file, field type, or field key.")
+        throw SecretsManagerException("Keeper notation URI missing information about the uid, file, field type, or field key.")
     if (footer.isPresent)
-        throw Exception("Keeper notation is invalid - extra characters after last section.")
+        throw SecretsManagerException("Keeper notation is invalid - extra characters after last section.")
     if (!selectors.contains(selector.text?.first?.lowercase() ?: ""))
-        throw Exception("Keeper notation is invalid - bad selector, must be one of (type, title, notes, field, custom_field, file).")
+        throw SecretsManagerException("Keeper notation is invalid - bad selector, must be one of (type, title, notes, field, custom_field, file).")
     if (shortSelectors.contains(selector.text?.first?.lowercase() ?: "") && selector.parameter != null)
-        throw Exception("Keeper notation is invalid - selectors (type, title, notes) do not have parameters.")
+        throw SecretsManagerException("Keeper notation is invalid - selectors (type, title, notes) do not have parameters.")
     if (fullSelectors.contains(selector.text?.first?.lowercase() ?: "")) {
         if (selector.parameter == null)
-            throw Exception("Keeper notation is invalid - selectors (field, custom_field, file) require parameters.")
+            throw SecretsManagerException("Keeper notation is invalid - selectors (field, custom_field, file) require parameters.")
         if ("file" == (selector.text?.first?.lowercase() ?: "") && (selector.index1 != null || selector.index2 != null))
-            throw Exception("Keeper notation is invalid - file selectors don't accept indexes.")
+            throw SecretsManagerException("Keeper notation is invalid - file selectors don't accept indexes.")
         if ("file" != (selector.text?.first?.lowercase() ?: "") && selector.index1 == null && selector.index2 != null)
-            throw Exception("Keeper notation is invalid - two indexes required.")
+            throw SecretsManagerException("Keeper notation is invalid - two indexes required.")
         if (selector.index1 != null && !(selector.index1?.second ?: "").matches(Regex("""^\[\d*\]$"""))) {
             if (!legacyMode)
-                throw Exception("Keeper notation is invalid - first index must be numeric: [n] or [].")
+                throw SecretsManagerException("Keeper notation is invalid - first index must be numeric: [n] or [].")
             if (selector.index2 == null) {   // in legacy mode convert /name[middle] to name[][middle]
                 selector.index2 = selector.index1
                 selector.index1 = Pair("", "[]")

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -684,6 +684,7 @@ data class PamSettingsConnection @JvmOverloads constructor(
 
     // Database-specific fields
     val database: String? = null,
+    val dbConnectionMethod: String? = null,
     val disableCsvExport: Boolean? = null,
     val disableCsvImport: Boolean? = null,
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -20,7 +20,7 @@ data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(),
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(), // KSM-823: always serialize "custom":[] even when empty
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
@@ -54,13 +54,13 @@ object FlexibleLongSerializer : KSerializer<Long> {
 }
 
 @Serializable
-data class KeeperFileData(
+data class KeeperFileData @JvmOverloads constructor(
     val title: String,
     val name: String,
     val type: String? = null,
     val size: Long,
-    @Serializable(with = FlexibleLongSerializer::class)
-    val lastModified: Long = 0
+    @Serializable(with = FlexibleLongSerializer::class) // KSM-673: iOS/Android clients send fractional epoch seconds
+    val lastModified: Long = 0 // KSM-854: non-SDK clients omit this field; default 0 matches .NET behavior
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -3,6 +3,8 @@
 
 package com.keepersecurity.secretsManager.core
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,20 +14,21 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    var custom: MutableList<KeeperRecordField>? = null,
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(),
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
-        return (fields + (custom ?: listOf())).find { x -> x is T } as? T
+        return (fields + custom).find { x -> x is T } as? T
     }
 
     fun getField(clazz: Class<out KeeperRecordField>): KeeperRecordField? {
-        return (fields + (custom ?: listOf())).find { x -> x.javaClass == clazz }
+        return (fields + custom).find { x -> x.javaClass == clazz }
     }
 }
 
@@ -57,7 +60,7 @@ data class KeeperFileData(
     val type: String? = null,
     val size: Long,
     @Serializable(with = FlexibleLongSerializer::class)
-    val lastModified: Long
+    val lastModified: Long = 0
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -35,6 +35,7 @@ const val KEEPER_CLIENT_VERSION = "mj17.3.0"
 // request, so the counter only clears after 10s of silence).
 const val MAX_THROTTLE_RETRIES = 5
 const val BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
+const val MAX_THROTTLE_DELAY_SEC = 176 // caps a backend-supplied retry_after from forcing an excessive wait
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
@@ -1761,21 +1762,22 @@ internal fun parseThrottle(body: String): Double? {
     val resultCode = ((obj["result_code"] ?: obj["error"]) as? JsonPrimitive)?.content
     if (resultCode != "throttled") return null
     val retryAfter = (obj["retry_after"] as? JsonPrimitive)?.content?.toDoubleOrNull() ?: 0.0
-    return if (retryAfter < 0.0) 0.0 else retryAfter
+    return retryAfter.coerceIn(0.0, MAX_THROTTLE_DELAY_SEC.toDouble())
 }
 
 // Backoff delay (milliseconds) for a 0-based [attempt]: retryAfter when > 0, otherwise
 // exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22, 44, 88, 176s). The
-// [jitter] fraction (typically in [-0.25, 0.25)) is then applied.
+// [jitter] fraction (typically in [0, 0.25)) is then applied.
 internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Double): Long {
     val baseSec = if (retryAfter > 0.0) retryAfter else BASE_THROTTLE_DELAY_SEC.toDouble() * (1L shl attempt)
     val sec = baseSec + baseSec * jitter
-    return (maxOf(sec, 0.0) * 1000).toLong()
+    return (sec * 1000).toLong()
 }
 
-// Random jitter multiplier in [-0.25, 0.25). Kept separate so unit tests exercise
-// throttleDelayMillis with a pinned jitter instead.
-internal fun throttleJitter(): Double = Random.nextDouble(-0.25, 0.25)
+// Random jitter multiplier in [0, 0.25) — one-sided so a delay is only ever padded, never
+// undercuts the server-requested (or exponential-backoff) floor. Kept separate so unit tests
+// exercise throttleDelayMillis with a pinned jitter instead.
+internal fun throttleJitter(): Double = Random.nextDouble(0.0, 0.25)
 
 @ExperimentalSerializationApi
 private inline fun <reified T> postQuery(

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -241,7 +241,7 @@ data class KeeperRecordLink(
     /**
      * Parse the link data as a JSON object, handling errors gracefully
      */
-    private fun parseJsonData(): Map<String, Any>? {
+    private fun parseJsonData(): Map<String, Any?>? {
         if (data == null) return null
         
         return try {
@@ -312,14 +312,14 @@ data class KeeperRecordLink(
 
     /**
      * Recursively convert a [JsonElement] to a plain Kotlin value: objects become
-     * `Map<String, Any>`, arrays become `List<Any>`, and primitives become typed scalars
+     * `Map<String, Any?>`, arrays become `List<Any?>`, and primitives become typed scalars
      * (String/Boolean/Int/Long/Double). Strings are never coerced, so a quoted "3"/"true"
-     * stays a String. JSON nulls are dropped by [jsonObjectToMap].
+     * stays a String. JSON nulls become Kotlin null and are preserved on both branches.
      */
     private fun jsonElementToValue(element: JsonElement): Any? = when (element) {
         is JsonNull -> null
         is JsonObject -> jsonObjectToMap(element)
-        is JsonArray -> element.mapNotNull { jsonElementToValue(it) }
+        is JsonArray -> element.map { jsonElementToValue(it) }
         is JsonPrimitive ->
             if (element.isString) element.content
             else element.booleanOrNull
@@ -330,11 +330,11 @@ data class KeeperRecordLink(
     }
 
     /**
-     * Convert a [JsonObject] to a nested `Map<String, Any>`, preserving nested objects and arrays
-     * (lossless). Keys whose value is JSON null are omitted.
+     * Convert a [JsonObject] to a nested `Map<String, Any?>`, preserving nested objects, arrays and
+     * JSON null values (lossless, matching the Python reference).
      */
-    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any> =
-        obj.entries.mapNotNull { (key, value) -> jsonElementToValue(value)?.let { key to it } }.toMap()
+    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any?> =
+        obj.entries.associate { (key, value) -> key to jsonElementToValue(value) }
 
     /**
      * Check if the link data indicates admin status for a user
@@ -409,20 +409,20 @@ data class KeeperRecordLink(
     /**
      * The `allowedSettings` object from the link data (empty map when absent).
      */
-    fun getAllowedSettings(): Map<String, Any> {
+    fun getAllowedSettings(): Map<String, Any?> {
         val parsed = parseJsonData() ?: return emptyMap()
         @Suppress("UNCHECKED_CAST")
-        return (parsed["allowedSettings"] as? Map<String, Any>) ?: emptyMap()
+        return (parsed["allowedSettings"] as? Map<String, Any?>) ?: emptyMap()
     }
 
     /**
      * The `rotation_settings` object from the link data (schedule, pwd_complexity, disabled, noop,
      * saas_record_uid_list), or null when absent.
      */
-    fun getRotationSettings(): Map<String, Any>? {
+    fun getRotationSettings(): Map<String, Any?>? {
         val parsed = parseJsonData() ?: return null
         @Suppress("UNCHECKED_CAST")
-        return parsed["rotation_settings"] as? Map<String, Any>
+        return parsed["rotation_settings"] as? Map<String, Any?>
     }
     
     /**
@@ -517,7 +517,7 @@ data class KeeperRecordLink(
      * @return Parsed data as a Map, or null if parsing fails
      */
     @JvmOverloads
-    fun getLinkData(recordKey: ByteArray? = null): Map<String, Any>? {
+    fun getLinkData(recordKey: ByteArray? = null): Map<String, Any?>? {
         if (data == null) return null
         
         // First, try to decode and check if it's plain JSON
@@ -546,7 +546,7 @@ data class KeeperRecordLink(
     /**
      * Helper method to parse JSON string to Map
      */
-    private fun parseJsonToMap(jsonString: String): Map<String, Any>? {
+    private fun parseJsonToMap(jsonString: String): Map<String, Any?>? {
         return try {
             val jsonElement = Json.parseToJsonElement(jsonString)
             when (jsonElement) {
@@ -590,7 +590,7 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key
      * @return Settings data as a Map, or null if not available
      */
-    fun getAiSettingsData(recordKey: ByteArray): Map<String, Any>? {
+    fun getAiSettingsData(recordKey: ByteArray): Map<String, Any?>? {
         if (path != "ai_settings") return null
         return getLinkData(recordKey)
     }
@@ -611,7 +611,7 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key
      * @return Settings data as a Map, or null if not available
      */
-    fun getJitSettingsData(recordKey: ByteArray): Map<String, Any>? {
+    fun getJitSettingsData(recordKey: ByteArray): Map<String, Any?>? {
         if (path != "jit_settings") return null
         return getLinkData(recordKey)
     }
@@ -628,7 +628,7 @@ data class KeeperRecordLink(
      * @return Settings data as a Map, or null if path doesn't match or parsing fails
      */
     @JvmOverloads
-    fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any>? {
+    fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any?>? {
         if (path != settingsPath) return null
         return getLinkData(recordKey)
     }
@@ -641,7 +641,7 @@ data class KeeperRecordLink(
      * the key is accepted for forward compatibility.
      */
     @JvmOverloads
-    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any>? = getSettingsForPath("meta", recordKey)
+    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any?>? = getSettingsForPath("meta", recordKey)
 }
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.*
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.2.0"
+const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
@@ -706,6 +706,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             "GOV" -> "govcloud.keepersecurity.us"
             "JP" -> "keepersecurity.jp"
             "CA" -> "keepersecurity.ca"
+            "IL5" -> "il5.keepersecurity.us"
             else -> tokenParts[0]
         }
         clientKey = tokenParts[1]
@@ -920,7 +921,7 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
 
             val fields = when(selector.lowercase()) {
                 "field" -> record.data.fields
-                "custom_field" -> record.data.custom ?: mutableListOf<KeeperRecordField>()
+                "custom_field" -> record.data.custom
                 else -> throw Exception("Notation error - Expected /field or /custom_field but found /$selector")
             }
 
@@ -991,9 +992,7 @@ fun completeTransaction(options: SecretsManagerOptions, recordUid: String, rollb
 @ExperimentalSerializationApi
 fun addCustomField(record: KeeperRecord, field: KeeperRecordField) {
     if (field.javaClass.superclass == KeeperRecordField::class.java) {
-        if (record.data.custom == null)
-            record.data.custom = mutableListOf()
-        record.data.custom!!.add(field)
+        record.data.custom.add(field)
     }
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -802,8 +802,8 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         }
         clientKey = tokenParts[1]
         // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
-        if (tokenParts.size > 4) {
-            throw Exception("Extended OTT token has unexpected extra segments (${tokenParts.size} parts, expected 2 or 4)")
+        if (tokenParts.size != 2 && tokenParts.size != 4) {
+            throw Exception("Extended OTT token has unexpected segment count (${tokenParts.size} parts, expected 2 or 4)")
         }
         if (tokenParts.size == 4) {
             val keyId = tokenParts[2]
@@ -1810,7 +1810,7 @@ private inline fun <reified T> postQuery(
                     if (options.loggingEnabled) {
                         System.err.println(
                             "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
-                                "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
+                                "retrying in ${"%.1f".format(Locale.US, delayMs / 1000.0)}s"
                         )
                     }
                     throttleSleep(delayMs)

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1730,10 +1730,12 @@ private inline fun <reified T> postQuery(
                         throw KeeperThrottleException("Request throttled by Keeper backend; exhausted $MAX_THROTTLE_RETRIES retries")
                     }
                     val delayMs = throttleDelayMillis(throttleAttempt, retryAfter, throttleJitter())
-                    System.err.println(
-                        "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
-                            "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
-                    )
+                    if (options.loggingEnabled) {
+                        System.err.println(
+                            "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
+                                "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
+                        )
+                    }
                     throttleSleep(delayMs)
                     throttleAttempt++
                     continue

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -23,6 +23,7 @@ const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
+const val KEY_SERVER_PUBLIC_KEY = "serverPublicKey" // custom server public key bytes (base64url), overrides embedded table
 const val KEY_CLIENT_ID = "clientId"
 const val KEY_CLIENT_KEY = "clientKey" // The key that is used to identify the client before public key
 const val KEY_APP_KEY = "appKey" // The application key with which all secrets are encrypted
@@ -44,10 +45,13 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val storage: KeyValueStorage,
     val queryFunction: QueryFunction? = null,
     val allowUnverifiedCertificate: Boolean = false,
-    val loggingEnabled: Boolean = true
+    val loggingEnabled: Boolean = true,
+    val serverPublicKey: String? = null  // Layer 3: inject custom server public key at construction time
 ) {
     init {
         testSecureRandom()
+        // Persist the injected key so generateTransmissionKey can pick it up without options in scope
+        serverPublicKey?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY, it) }
     }
 }
 
@@ -710,6 +714,11 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             else -> tokenParts[0]
         }
         clientKey = tokenParts[1]
+        // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
+        if (tokenParts.size >= 4) {
+            storage.saveString(KEY_SERVER_PUBIC_KEY_ID, tokenParts[2])
+            storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
+        }
     }
     val clientKeyBytes = webSafe64ToBytes(clientKey)
     val clientKeyHash = hash(clientKeyBytes, CLIENT_ID_HASH_TAG)
@@ -1593,7 +1602,10 @@ private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {
         getRandomBytes(32)
     }
     val keyNumber: Int = storage.getString(KEY_SERVER_PUBIC_KEY_ID)?.toInt() ?: 7
-    val keeperPublicKey = keeperPublicKeys[keyNumber] ?: throw Exception("Key number $keyNumber is not supported")
+    // Layer 1: serverPublicKey in storage (from config JSON, OTT, or constructor) takes priority
+    val keeperPublicKey: ByteArray = storage.getString(KEY_SERVER_PUBLIC_KEY)?.let { webSafe64ToBytes(it) }
+        ?: keeperPublicKeys[keyNumber]
+        ?: throw Exception("Key number $keyNumber is not supported")
     val encryptedKey = publicEncrypt(transmissionKey, keeperPublicKey)
     return TransmissionKey(keyNumber, transmissionKey, encryptedKey)
 }

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -38,6 +38,8 @@ const val BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
+@Deprecated("Typo; use KEY_SERVER_PUBLIC_KEY_ID", ReplaceWith("KEY_SERVER_PUBLIC_KEY_ID"))
+const val KEY_SERVER_PUBIC_KEY_ID = KEY_SERVER_PUBLIC_KEY_ID
 const val KEY_SERVER_PUBLIC_KEY = "serverPublicKey" // custom server public key bytes (base64url), overrides embedded table
 const val KEY_CLIENT_ID = "clientId"
 const val KEY_CLIENT_KEY = "clientKey" // The key that is used to identify the client before public key

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.*
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.2.1"
+const val KEEPER_CLIENT_VERSION = "mj17.3.0"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -8,6 +8,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.doubleOrNull
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URI
 import java.security.KeyManagementException
@@ -204,6 +211,26 @@ private data class SecretsManagerResponseRecord(
     val links: List<KeeperRecordLink>? = null
 )
 
+/**
+ * Typed view over a single linked-credential entry of a record (the entries in [KeeperRecord.links]).
+ *
+ * A link entry carries [recordUid], optional base64 [data], and an optional [path] discriminator.
+ * Observed payload shapes (verified against the live backend):
+ *
+ * - path "meta" (self-link, recordUid == owning record): plain base64 JSON with `allowedSettings`
+ *   (rotation, connections, portForwards, sessionRecording, typescriptRecording, aiEnabled,
+ *   aiSessionTerminate, remoteBrowserIsolation), plus `rotateOnTermination`, `version` and
+ *   `no_update_services`.
+ * - path null (credential link to another record): plain base64 JSON with `is_admin`,
+ *   `is_launch_credential`, `is_iam_user`, `belongs_to` and `rotation_settings`; or no data at all
+ *   (a pure record reference).
+ * - path "ai_settings" / "jit_settings" (self-links): data is AES-256-GCM encrypted under the
+ *   owning record's key — see [getDecryptedData].
+ *
+ * Accessors never throw: parse, decode or decryption failures yield null/false. [getLinkData]
+ * returns the complete parsed payload with nested objects and arrays preserved, so fields unknown
+ * to this SDK version are retained.
+ */
 @Serializable
 data class KeeperRecordLink(
     val recordUid: String,
@@ -228,22 +255,7 @@ data class KeeperRecordLink(
             
             val jsonElement = Json.parseToJsonElement(decodedData)
             if (jsonElement is JsonObject) {
-                jsonElement.entries.associate { (key, value) ->
-                    key to when {
-                        value is JsonPrimitive && value.isString -> value.content
-                        value is JsonPrimitive -> {
-                            // Try to parse as different types
-                            when {
-                                value.content == "true" -> true
-                                value.content == "false" -> false
-                                value.content.toIntOrNull() != null -> value.content.toInt()
-                                value.content.toLongOrNull() != null -> value.content.toLong()
-                                else -> value.content
-                            }
-                        }
-                        else -> value.toString()
-                    }
-                }
+                jsonObjectToMap(jsonElement)
             } else {
                 // Only log if it looked like JSON but wasn't a JSON object
                 System.err.println("KeeperRecordLink: Link data is not a JSON object (was JSON array or primitive)")
@@ -268,10 +280,20 @@ data class KeeperRecordLink(
     }
 
     /**
-     * Get a boolean value from the parsed JSON data
+     * Get a strict boolean value from the parsed JSON data; missing or non-boolean values are false.
+     *
+     * When [checkAllowedSettings] is true the nested `allowedSettings` object is consulted if the
+     * key is absent at the top level — a top-level boolean wins. The backend nests permission flags
+     * under `allowedSettings` in `path:"meta"` links.
      */
-    private fun getBooleanValue(key: String): Boolean {
-        return parseJsonData()?.get(key) as? Boolean ?: false
+    private fun getBooleanValue(key: String, checkAllowedSettings: Boolean = false): Boolean {
+        val parsed = parseJsonData() ?: return false
+        (parsed[key] as? Boolean)?.let { return it }
+        if (checkAllowedSettings) {
+            val allowed = parsed["allowedSettings"] as? Map<*, *>
+            (allowed?.get(key) as? Boolean)?.let { return it }
+        }
+        return false
     }
 
     /**
@@ -289,6 +311,32 @@ data class KeeperRecordLink(
     }
 
     /**
+     * Recursively convert a [JsonElement] to a plain Kotlin value: objects become
+     * `Map<String, Any>`, arrays become `List<Any>`, and primitives become typed scalars
+     * (String/Boolean/Int/Long/Double). Strings are never coerced, so a quoted "3"/"true"
+     * stays a String. JSON nulls are dropped by [jsonObjectToMap].
+     */
+    private fun jsonElementToValue(element: JsonElement): Any? = when (element) {
+        is JsonNull -> null
+        is JsonObject -> jsonObjectToMap(element)
+        is JsonArray -> element.mapNotNull { jsonElementToValue(it) }
+        is JsonPrimitive ->
+            if (element.isString) element.content
+            else element.booleanOrNull
+                ?: element.intOrNull
+                ?: element.longOrNull
+                ?: element.doubleOrNull
+                ?: element.content
+    }
+
+    /**
+     * Convert a [JsonObject] to a nested `Map<String, Any>`, preserving nested objects and arrays
+     * (lossless). Keys whose value is JSON null are omitted.
+     */
+    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any> =
+        obj.entries.mapNotNull { (key, value) -> jsonElementToValue(value)?.let { key to it } }.toMap()
+
+    /**
      * Check if the link data indicates admin status for a user
      */
     fun isAdminUser(): Boolean = getBooleanValue("is_admin")
@@ -301,37 +349,81 @@ data class KeeperRecordLink(
     /**
      * Check if rotation is allowed based on link settings
      */
-    fun allowsRotation(): Boolean = getBooleanValue("rotation")
+    fun allowsRotation(): Boolean = getBooleanValue("rotation", checkAllowedSettings = true)
     
     /**
      * Check if connections are allowed based on link settings
      */
-    fun allowsConnections(): Boolean = getBooleanValue("connections")
+    fun allowsConnections(): Boolean = getBooleanValue("connections", checkAllowedSettings = true)
     
     /**
      * Check if port forwards are allowed based on link settings
      */
-    fun allowsPortForwards(): Boolean = getBooleanValue("portForwards")
+    fun allowsPortForwards(): Boolean = getBooleanValue("portForwards", checkAllowedSettings = true)
     
     /**
      * Check if session recording is enabled
      */
-    fun allowsSessionRecording(): Boolean = getBooleanValue("sessionRecording")
+    fun allowsSessionRecording(): Boolean = getBooleanValue("sessionRecording", checkAllowedSettings = true)
     
     /**
      * Check if TypeScript recording is enabled
      */
-    fun allowsTypescriptRecording(): Boolean = getBooleanValue("typescriptRecording")
+    fun allowsTypescriptRecording(): Boolean = getBooleanValue("typescriptRecording", checkAllowedSettings = true)
     
     /**
      * Check if remote browser isolation is enabled
      */
-    fun allowsRemoteBrowserIsolation(): Boolean = getBooleanValue("remoteBrowserIsolation")
+    fun allowsRemoteBrowserIsolation(): Boolean = getBooleanValue("remoteBrowserIsolation", checkAllowedSettings = true)
     
     /**
      * Check if rotation on termination is enabled
      */
     fun rotatesOnTermination(): Boolean = getBooleanValue("rotateOnTermination")
+
+    /**
+     * Whether the linked user is an IAM user (`is_iam_user`).
+     */
+    fun isIamUser(): Boolean = getBooleanValue("is_iam_user")
+
+    /**
+     * Whether the linked credential belongs to the record (`belongs_to`).
+     */
+    fun belongsTo(): Boolean = getBooleanValue("belongs_to")
+
+    /**
+     * Whether service updates are disabled for this link (`no_update_services`).
+     */
+    fun noUpdateServices(): Boolean = getBooleanValue("no_update_services")
+
+    /**
+     * Whether AI features are enabled (`aiEnabled`, top-level or in `allowedSettings`).
+     */
+    fun aiEnabled(): Boolean = getBooleanValue("aiEnabled", checkAllowedSettings = true)
+
+    /**
+     * Whether AI session termination is enabled (`aiSessionTerminate`, top-level or in `allowedSettings`).
+     */
+    fun aiSessionTerminate(): Boolean = getBooleanValue("aiSessionTerminate", checkAllowedSettings = true)
+
+    /**
+     * The `allowedSettings` object from the link data (empty map when absent).
+     */
+    fun getAllowedSettings(): Map<String, Any> {
+        val parsed = parseJsonData() ?: return emptyMap()
+        @Suppress("UNCHECKED_CAST")
+        return (parsed["allowedSettings"] as? Map<String, Any>) ?: emptyMap()
+    }
+
+    /**
+     * The `rotation_settings` object from the link data (schedule, pwd_complexity, disabled, noop,
+     * saas_record_uid_list), or null when absent.
+     */
+    fun getRotationSettings(): Map<String, Any>? {
+        val parsed = parseJsonData() ?: return null
+        @Suppress("UNCHECKED_CAST")
+        return parsed["rotation_settings"] as? Map<String, Any>
+    }
     
     /**
      * Get the link data version (if available)
@@ -435,9 +527,10 @@ data class KeeperRecordLink(
             return null
         }
         
-        // If it looks like JSON, parse it directly
+        // If it looks like JSON, parse it directly; if that fails (coincidental ciphertext that
+        // happens to start with { or [), fall through to decryption rather than giving up.
         if (decodedData.startsWith("{") || decodedData.startsWith("[")) {
-            return parseJsonToMap(decodedData)
+            parseJsonToMap(decodedData)?.let { return it }
         }
         
         // If not JSON and we have a key, try decryption
@@ -457,30 +550,7 @@ data class KeeperRecordLink(
         return try {
             val jsonElement = Json.parseToJsonElement(jsonString)
             when (jsonElement) {
-                is JsonObject -> {
-                    jsonElement.entries.associate { (key, value) ->
-                        key to when (value) {
-                            is JsonPrimitive -> {
-                                when {
-                                    value.isString -> value.content
-                                    else -> {
-                                        // Try to parse as different types
-                                        when {
-                                            value.content == "true" -> true
-                                            value.content == "false" -> false
-                                            value.content.toIntOrNull() != null -> value.content.toInt()
-                                            value.content.toLongOrNull() != null -> value.content.toLong()
-                                            value.content.toDoubleOrNull() != null -> value.content.toDouble()
-                                            else -> value.content
-                                        }
-                                    }
-                                }
-                            }
-                            is JsonObject -> value.toString() // Nested objects as strings
-                            is kotlinx.serialization.json.JsonArray -> value.toString() // Arrays as strings
-                        }
-                    }
-                }
+                is JsonObject -> jsonObjectToMap(jsonElement)
                 else -> null
             }
         } catch (e: Exception) {
@@ -509,12 +579,10 @@ data class KeeperRecordLink(
     /**
      * Get AI settings data from this link
      * 
-     * Known fields for ai_settings (as of SDK v17.1.0):
-     * - aiEnabled: Boolean - Whether AI features are enabled
-     * - aiModel: String - The AI model being used
-     * - aiProvider: String - The AI provider (e.g., "openai", "anthropic")
-     * - aiSessionTerminate: Boolean - Whether to terminate AI session
-     * - allowedSettings: Map - Nested settings for allowed operations
+     * Encrypted under the owning record's key. Known fields (live-verified):
+     * - version: String - settings schema version, e.g. "v1.0.0"
+     * - riskLevels: Map - critical/high/medium/low, each with `tags` (allow/deny lists)
+     *   and `aiSessionTerminate`
      * 
      * Note: Additional fields may be present in newer versions.
      * The returned Map will preserve all fields sent by the server.
@@ -530,17 +598,12 @@ data class KeeperRecordLink(
     /**
      * Get JIT (Just-In-Time) settings data from this link
      * 
-     * Known fields for jit_settings (as of SDK v17.1.0):
-     * - enabled: Boolean - Whether JIT access is enabled
-     * - ttl: Int - Time-to-live in seconds
-     * - maxUses: Int - Maximum number of uses allowed
-     * - expiresAt: Long - Expiration timestamp in milliseconds
-     * - allowedSettings: Map - Nested settings for allowed operations:
-     *   - rotation: Boolean - Allow credential rotation
-     *   - connections: Boolean - Allow connections
-     *   - portForwards: Boolean - Allow port forwarding
-     *   - sessionRecording: Boolean - Enable session recording
-     *   - typescriptRecording: Boolean - Enable TypeScript recording
+     * Encrypted under the owning record's key. Known fields (live-verified):
+     * - createEphemeral: Boolean
+     * - elevate: Boolean
+     * - elevationMethod: String
+     * - elevationString: String
+     * - baseDistinguishedName: String
      * 
      * Note: Additional fields may be present in newer versions.
      * The returned Map will preserve all fields sent by the server.
@@ -564,10 +627,21 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key (required for encrypted data)
      * @return Settings data as a Map, or null if path doesn't match or parsing fails
      */
+    @JvmOverloads
     fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any>? {
         if (path != settingsPath) return null
         return getLinkData(recordKey)
     }
+
+    /**
+     * Get PAM settings data from this link — only when [path] == "meta".
+     *
+     * Meta links are self-links (recordUid == owning record) carrying the record's own PAM settings:
+     * `allowedSettings`, `rotateOnTermination`, `version`, `no_update_services`. Plain JSON today;
+     * the key is accepted for forward compatibility.
+     */
+    @JvmOverloads
+    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any>? = getSettingsForPath("meta", recordKey)
 }
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -802,19 +802,20 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         }
         clientKey = tokenParts[1]
         // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
-        if (tokenParts.size != 2 && tokenParts.size != 4) {
-            throw Exception("Extended OTT token has unexpected segment count (${tokenParts.size} parts, expected 2 or 4)")
-        }
-        if (tokenParts.size == 4) {
-            val keyId = tokenParts[2]
-            if (keyId.isEmpty() || !keyId.all { it.isDigit() }) {
-                throw Exception("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
+        when (tokenParts.size) {
+            2 -> {} // plain REGION:clientKey
+            4 -> {
+                val keyId = tokenParts[2]
+                if (keyId.isEmpty() || !keyId.all { it.isDigit() }) {
+                    throw Exception("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
+                }
+                if (tokenParts[3].length < 80) {
+                    throw Exception("Extended OTT token: serverPublicKey appears malformed")
+                }
+                storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, keyId)
+                storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
             }
-            if (tokenParts[3].length < 80) {
-                throw Exception("Extended OTT token: serverPublicKey appears malformed")
-            }
-            storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, keyId)
-            storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
+            else -> throw Exception("Extended OTT token has unexpected segment count (${tokenParts.size} parts, expected 2 or 4)")
         }
     }
     val clientKeyBytes = webSafe64ToBytes(clientKey)

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -738,7 +738,7 @@ data class KeeperRecord(
     }
 
     fun updatePassword(newPassword: String) {
-        val passwordField = data.getField<Password>() ?: throw Exception("Password field is not present on the record $recordUid")
+        val passwordField = data.getField<Password>() ?: throw SecretsManagerException("Password field is not present on the record $recordUid")
 
         if (passwordField.value.size == 0)
             passwordField.value.add(newPassword)
@@ -788,7 +788,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
     val host: String
     val clientKey: String
     if (tokenParts.size == 1) {
-        host = hostName ?: throw Exception("The hostname must be present in the token or as a parameter")
+        host = hostName ?: throw SecretsManagerException("The hostname must be present in the token or as a parameter")
         clientKey = oneTimeToken
     } else {
         host = when (tokenParts[0].uppercase(Locale.US)) {
@@ -808,15 +808,15 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
             4 -> {
                 val keyId = tokenParts[2]
                 if (keyId.isEmpty() || !keyId.all { it.isDigit() }) {
-                    throw Exception("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
+                    throw SecretsManagerException("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
                 }
                 if (tokenParts[3].length < 80) {
-                    throw Exception("Extended OTT token: serverPublicKey appears malformed")
+                    throw SecretsManagerException("Extended OTT token: serverPublicKey appears malformed")
                 }
                 storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, keyId)
                 storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
             }
-            else -> throw Exception("Extended OTT token has unexpected segment count (${tokenParts.size} parts, expected 2 or 4)")
+            else -> throw SecretsManagerException("Extended OTT token has unexpected segment count (${tokenParts.size} parts, expected 2 or 4)")
         }
     }
     val clientKeyBytes = webSafe64ToBytes(clientKey)
@@ -827,7 +827,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         if (clientId == existingClientId) {
             return   // the storage is already initialized
         }
-        throw Exception("The storage is already initialized with a different client Id (${existingClientId})")
+        throw SecretsManagerException("The storage is already initialized with a different client Id (${existingClientId})")
     }
     storage.saveString(KEY_HOSTNAME, host)
     storage.saveString(KEY_CLIENT_ID, clientId)
@@ -970,12 +970,12 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
 
     val parsedNotation = parseNotation(notation) // prefix, record, selector, footer
     if (parsedNotation.size < 3)
-        throw Exception("Invalid notation '$notation'")
+        throw SecretsManagerException("Invalid notation '$notation'")
 
     val selector = parsedNotation[2].text?.first ?: // type|title|notes or file|field|custom_field
-        throw Exception("Invalid notation '$notation'")
+        throw SecretsManagerException("Invalid notation '$notation'")
     val recordToken = parsedNotation[1].text?.first ?: // UID or Title
-        throw Exception("Invalid notation '$notation'")
+        throw SecretsManagerException("Invalid notation '$notation'")
 
     // to minimize traffic - if it looks like a Record UID try to pull a single record
     var records = listOf<KeeperRecord>()
@@ -995,9 +995,9 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
     }
 
     if (records.size > 1)
-        throw Exception("Notation error - multiple records match record '$recordToken'")
+        throw SecretsManagerException("Notation error - multiple records match record '$recordToken'")
     if (records.isEmpty())
-        throw Exception("Notation error - no records match record '$recordToken'")
+        throw SecretsManagerException("Notation error - no records match record '$recordToken'")
 
     val record = records[0]
     val parameter = parsedNotation[2].parameter?.first
@@ -1010,45 +1010,45 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
         "notes" -> if (record.data.notes != null) result.add(record.data.notes!!)
         "file" -> {
             if (parameter == null)
-                throw Exception("Notation error - Missing required parameter: filename or file UID for files in record '$recordToken'")
+                throw SecretsManagerException("Notation error - Missing required parameter: filename or file UID for files in record '$recordToken'")
             if ((record.files?.size ?: 0) < 1)
-                throw Exception("Notation error - Record $recordToken has no file attachments.")
+                throw SecretsManagerException("Notation error - Record $recordToken has no file attachments.")
             val files = record.files!!.filter { parameter == it.data.name || parameter == it.data.title || parameter == it.fileUid }
             // file searches do not use indexes and rely on unique file names or fileUid
             if (files.size > 1)
-                throw Exception("Notation error - Record $recordToken has multiple files matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has multiple files matching the search criteria '$parameter'")
             if (files.isEmpty())
-                throw Exception("Notation error - Record $recordToken has no files matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has no files matching the search criteria '$parameter'")
             val contents = downloadFile(files[0])
             val text = webSafe64FromBytes(contents)
             result.add(text)
         }
         "field", "custom_field" -> {
             if (parameter == null)
-                throw Exception("Notation error - Missing required parameter for the field (type or label): ex. /field/type or /custom_field/MyLabel")
+                throw SecretsManagerException("Notation error - Missing required parameter for the field (type or label): ex. /field/type or /custom_field/MyLabel")
 
             val fields = when(selector.lowercase()) {
                 "field" -> record.data.fields
                 "custom_field" -> record.data.custom
-                else -> throw Exception("Notation error - Expected /field or /custom_field but found /$selector")
+                else -> throw SecretsManagerException("Notation error - Expected /field or /custom_field but found /$selector")
             }
 
             val flds = fields.filter { parameter == fieldType(it) || parameter == it.label }
             if (flds.size > 1)
-                throw Exception("Notation error - Record $recordToken has multiple fields matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has multiple fields matching the search criteria '$parameter'")
             if (flds.isEmpty())
-                throw Exception("Notation error - Record $recordToken has no fields matching the search criteria '$parameter'")
+                throw SecretsManagerException("Notation error - Record $recordToken has no fields matching the search criteria '$parameter'")
             val field = flds[0]
             //val fieldType = fieldType(field)
 
             val idx = index1?.toIntOrNull() ?: -1 // -1 full value
             // valid only if [] or missing - ex. /field/phone or /field/phone[]
             if (idx == -1 && !(parsedNotation[2].index1?.second.isNullOrEmpty() || parsedNotation[2].index1?.second == "[]"))
-                throw Exception("Notation error - Invalid field index $idx")
+                throw SecretsManagerException("Notation error - Invalid field index $idx")
 
             val valuesCount = getFieldValuesCount(field)
             if (idx >= valuesCount)
-                throw Exception("Notation error - Field index out of bounds $idx >= $valuesCount for field $parameter")
+                throw SecretsManagerException("Notation error - Field index out of bounds $idx >= $valuesCount for field $parameter")
 
             //val fullObjValue = (parsedNotation[2].index2?.second.isNullOrEmpty() || parsedNotation[2].index2?.second == "[]")
             val objPropertyName = parsedNotation[2].index2?.first
@@ -1060,7 +1060,7 @@ fun getNotationResults(options: SecretsManagerOptions, notation: String): List<S
             if (res.isNotEmpty())
                 result.addAll(res)
         }
-        else -> throw Exception("Invalid notation '$notation'")
+        else -> throw SecretsManagerException("Invalid notation '$notation'")
     }
     return result
 }
@@ -1109,7 +1109,7 @@ fun addCustomField(record: KeeperRecord, field: KeeperRecordField) {
 fun createSecret(options: SecretsManagerOptions, folderUid: String, recordData: KeeperRecordData, secrets: KeeperSecrets = getSecrets(options)): String {
     val recordFromFolder = secrets.records.find { it.folderUid == folderUid }
     if (recordFromFolder?.folderKey == null) {
-        throw Exception("Unable to create record - folder key for $folderUid not found")
+        throw SecretsManagerException("Unable to create record - folder key for $folderUid not found")
     }
     val payload = prepareCreatePayload(options.storage, CreateOptions(folderUid), recordData, recordFromFolder.folderKey!!)
     postQuery(options, "create_secret", payload)
@@ -1120,7 +1120,7 @@ fun createSecret(options: SecretsManagerOptions, folderUid: String, recordData: 
 @JvmOverloads
 fun createSecret2(options: SecretsManagerOptions, createOptions: CreateOptions, recordData: KeeperRecordData, folders: List<KeeperFolder> = getFolders(options)): String {
     val sharedFolder: KeeperFolder = folders.find { it.folderUid == createOptions.folderUid }
-        ?: throw Exception("Unable to create record - folder key for ${createOptions.folderUid} not found")
+        ?: throw SecretsManagerException("Unable to create record - folder key for ${createOptions.folderUid} not found")
     val payload = prepareCreatePayload(options.storage, createOptions, recordData, sharedFolder.folderKey)
     postQuery(options, "create_secret", payload)
     return payload.recordUid
@@ -1130,7 +1130,7 @@ fun createSecret2(options: SecretsManagerOptions, createOptions: CreateOptions, 
 @JvmOverloads
 fun createFolder(options: SecretsManagerOptions, createOptions: CreateOptions, folderName: String, folders: List<KeeperFolder> = getFolders(options)): String {
     val sharedFolder: KeeperFolder = folders.find { it.folderUid == createOptions.folderUid }
-        ?: throw Exception("Unable to create folder - folder key for ${createOptions.folderUid} not found")
+        ?: throw SecretsManagerException("Unable to create folder - folder key for ${createOptions.folderUid} not found")
     val payload = prepareCreateFolderPayload(options.storage, createOptions, folderName, sharedFolder.folderKey)
     postQuery(options, "create_folder", payload)
     return payload.folderUid
@@ -1140,7 +1140,7 @@ fun createFolder(options: SecretsManagerOptions, createOptions: CreateOptions, f
 @JvmOverloads
 fun updateFolder(options: SecretsManagerOptions, folderUid: String, folderName: String, folders: List<KeeperFolder> = getFolders(options)) {
     val folder: KeeperFolder = folders.find { it.folderUid == folderUid }
-        ?: throw Exception("Unable to update folder - folder key for $folderUid not found")
+        ?: throw SecretsManagerException("Unable to update folder - folder key for $folderUid not found")
     val payload = prepareUpdateFolderPayload(options.storage, folderUid, folderName, folder.folderKey)
     postQuery(options, "update_folder", payload)
 }
@@ -1152,19 +1152,19 @@ fun uploadFile(options: SecretsManagerOptions, ownerRecord: KeeperRecord, file: 
     val response = nonStrictJson.decodeFromString<SecretsManagerAddFileResponse>(bytesToString(responseData))
     val uploadResult = uploadFile(response.url, response.parameters, payloadAndFile.encryptedFile)
     if (uploadResult.statusCode != response.successStatusCode) {
-        throw Exception("Upload failed (${bytesToString(uploadResult.data)}), code ${uploadResult.statusCode}")
+        throw SecretsManagerException("Upload failed (${bytesToString(uploadResult.data)}), code ${uploadResult.statusCode}")
     }
     return payloadAndFile.payload.fileRecordUid
 }
 
 fun downloadFile(file: KeeperFile): ByteArray {
-    val url = file.url ?: throw Exception("File ${file.fileUid} has no download URL")
+    val url = file.url ?: throw SecretsManagerException("File ${file.fileUid} has no download URL")
     return downloadFile(file, url)
 }
 
 fun downloadThumbnail(file: KeeperFile): ByteArray {
     if (file.thumbnailUrl == null) {
-        throw Exception("Thumbnail does not exist for the file ${file.fileUid}")
+        throw SecretsManagerException("Thumbnail does not exist for the file ${file.fileUid}")
     }
     return downloadFile(file, file.thumbnailUrl)
 }
@@ -1179,7 +1179,7 @@ private fun downloadFile(file: KeeperFile, url: String): ByteArray {
             else -> connection.inputStream.readBytes()
         }
         if (statusCode != HTTP_OK) {
-            throw Exception(String(data))
+            throw SecretsManagerException(String(data))
         }
         return decrypt(data, file.fileKey)
     } finally {
@@ -1236,7 +1236,7 @@ private fun fetchAndDecryptSecrets(
     val appKey: ByteArray
     if (response.encryptedAppKey != null) {
         justBound = true
-        val clientKey = storage.getBytes(KEY_CLIENT_KEY) ?: throw Exception("Client key is missing from the storage")
+        val clientKey = storage.getBytes(KEY_CLIENT_KEY) ?: throw SecretsManagerException("Client key is missing from the storage")
         appKey = decrypt(response.encryptedAppKey, clientKey)
         storage.saveBytes(KEY_APP_KEY, appKey)
         storage.delete(KEY_CLIENT_KEY)
@@ -1245,7 +1245,7 @@ private fun fetchAndDecryptSecrets(
             storage.saveString(KEY_OWNER_PUBLIC_KEY, it)
         }
     } else {
-        appKey = storage.getBytes(KEY_APP_KEY) ?: throw Exception("App key is missing from the storage")
+        appKey = storage.getBytes(KEY_APP_KEY) ?: throw SecretsManagerException("App key is missing from the storage")
     }
     // KSM-753: records created via non-SDK clients in shared folders appear in response.records[]
     // with innerFolderUid set; their recordKey is encrypted with the folder key, not the app key.
@@ -1427,12 +1427,12 @@ private fun fetchAndDecryptFolders(
         return emptyList()
     }
     val folders: MutableList<KeeperFolder> = mutableListOf()
-    val appKey = storage.getBytes(KEY_APP_KEY) ?: throw Exception("App key is missing from the storage")
+    val appKey = storage.getBytes(KEY_APP_KEY) ?: throw SecretsManagerException("App key is missing from the storage")
     response.folders.forEach { folder ->
         val folderKey: ByteArray = if (folder.parent == null) {
             decrypt(folder.folderKey, appKey)
         } else {
-            val sharedFolderKey = getSharedFolderKey(folders, response.folders, folder.parent) ?: throw Exception("Folder data inconsistent - unable to locate shared folder")
+            val sharedFolderKey = getSharedFolderKey(folders, response.folders, folder.parent) ?: throw SecretsManagerException("Folder data inconsistent - unable to locate shared folder")
             decrypt(folder.folderKey, sharedFolderKey, true)
         }
         val decryptedData = decrypt(folder.data!!, folderKey, true)
@@ -1455,7 +1455,7 @@ private fun prepareGetPayload(
     storage: KeyValueStorage,
     queryOptions: QueryOptions?
 ): GetPayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     val payload = GetPayload(
         KEEPER_CLIENT_VERSION,
         clientId,
@@ -1464,7 +1464,7 @@ private fun prepareGetPayload(
     )
     val appKey = storage.getBytes(KEY_APP_KEY)
     if (appKey == null) {
-        val publicKey = storage.getBytes(KEY_PUBLIC_KEY) ?: throw Exception("Public key is missing from the storage")
+        val publicKey = storage.getBytes(KEY_PUBLIC_KEY) ?: throw SecretsManagerException("Public key is missing from the storage")
         payload.publicKey = bytesToBase64(publicKey)
     }
     if (queryOptions != null) {
@@ -1486,7 +1486,7 @@ private fun prepareDeletePayload(
     storage: KeyValueStorage,
     recordUids: List<String>
 ): DeletePayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     return DeletePayload(KEEPER_CLIENT_VERSION, clientId, recordUids)
 }
 
@@ -1496,7 +1496,7 @@ private fun prepareDeleteFolderPayload(
     folderUids: List<String>,
     forceDeletion: Boolean
 ): DeleteFolderPayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     return DeleteFolderPayload(KEEPER_CLIENT_VERSION, clientId, folderUids, forceDeletion)
 }
 
@@ -1506,7 +1506,7 @@ private fun prepareUpdatePayload(
     record: KeeperRecord,
     updateOptions: UpdateOptions? = null
 ): UpdatePayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
 
     updateOptions?.linksToRemove?.takeIf { it.isNotEmpty() }?.let {
         val frefs = record.data.getField<FileRef>()
@@ -1534,7 +1534,7 @@ private fun prepareCompleteTransactionPayload(
     storage: KeyValueStorage,
     recordUid: String
 ): CompleteTransactionPayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     return CompleteTransactionPayload(KEEPER_CLIENT_VERSION, clientId, recordUid)
 }
 
@@ -1545,8 +1545,8 @@ private fun prepareCreatePayload(
     recordData: KeeperRecordData,
     folderKey: ByteArray
 ): CreatePayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
-    val ownerPublicKey = storage.getBytes(KEY_OWNER_PUBLIC_KEY) ?: throw Exception("Application owner public key is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
+    val ownerPublicKey = storage.getBytes(KEY_OWNER_PUBLIC_KEY) ?: throw SecretsManagerException("Application owner public key is missing from the configuration")
     val recordBytes = stringToBytes(Json.encodeToString(recordData))
     val recordKey = getRandomBytes(32)
     val recordUid = generateUid()
@@ -1569,7 +1569,7 @@ private fun prepareCreateFolderPayload(
     folderName: String,
     sharedFolderKey: ByteArray
 ): CreateFolderPayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     val folderDataBytes = stringToBytes(Json.encodeToString(KeeperFolderName(folderName)))
     val folderKey = getRandomBytes(32)
     val folderUid = generateUid()
@@ -1590,7 +1590,7 @@ private fun prepareUpdateFolderPayload(
     folderName: String,
     folderKey: ByteArray
 ): UpdateFolderPayload {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
     val folderDataBytes = stringToBytes(Json.encodeToString(KeeperFolderName(folderName)))
     val encryptedFolderData = encrypt(folderDataBytes, folderKey, true)
     return UpdateFolderPayload(KEEPER_CLIENT_VERSION, clientId,
@@ -1604,8 +1604,8 @@ private fun prepareFileUploadPayload(
     ownerRecord: KeeperRecord,
     file: KeeperFileUpload
 ): FileUploadPayloadAndFile {
-    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw Exception("Client Id is missing from the configuration")
-    val ownerPublicKey = storage.getBytes(KEY_OWNER_PUBLIC_KEY) ?: throw Exception("Application owner public key is missing from the configuration")
+    val clientId = storage.getString(KEY_CLIENT_ID) ?: throw SecretsManagerException("Client Id is missing from the configuration")
+    val ownerPublicKey = storage.getBytes(KEY_OWNER_PUBLIC_KEY) ?: throw SecretsManagerException("Application owner public key is missing from the configuration")
 
     val fileData = KeeperFileData(
         file.title,
@@ -1730,7 +1730,7 @@ private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {
     // Layer 1: serverPublicKey in storage (from config JSON, OTT, or constructor) takes priority
     val keeperPublicKey: ByteArray = storage.getString(KEY_SERVER_PUBLIC_KEY)?.let { webSafe64ToBytes(it) }
         ?: keeperPublicKeys[keyNumber]
-        ?: throw Exception("Key number $keyNumber is not supported")
+        ?: throw SecretsManagerException("Key number $keyNumber is not supported")
     val encryptedKey = publicEncrypt(transmissionKey, keeperPublicKey)
     return TransmissionKey(keyNumber, transmissionKey, encryptedKey)
 }
@@ -1743,7 +1743,7 @@ private inline fun <reified T> encryptAndSignPayload(
 ): EncryptedPayload {
     val payloadBytes = stringToBytes(Json.encodeToString(payload))
     val encryptedPayload = encrypt(payloadBytes, transmissionKey.key)
-    val privateKey = storage.getBytes(KEY_PRIVATE_KEY) ?: throw Exception("Private key is missing from the storage")
+    val privateKey = storage.getBytes(KEY_PRIVATE_KEY) ?: throw SecretsManagerException("Private key is missing from the storage")
     val signatureBase = transmissionKey.encryptedKey + encryptedPayload
     val signature = sign(signatureBase, privateKey)
     return EncryptedPayload(encryptedPayload, signature)
@@ -1785,7 +1785,7 @@ private inline fun <reified T> postQuery(
     path: String,
     payload: T
 ): ByteArray {
-    val hostName = options.storage.getString(KEY_HOSTNAME) ?: throw Exception("hostname is missing from the storage")
+    val hostName = options.storage.getString(KEY_HOSTNAME) ?: throw SecretsManagerException("hostname is missing from the storage")
     val url = "https://${hostName}/api/rest/sm/v1/${path}"
     val throttleSleep = options.throttleSleepMillis ?: { ms -> Thread.sleep(ms) }
     var throttleAttempt = 0
@@ -1821,20 +1821,18 @@ private inline fun <reified T> postQuery(
                     continue
                 }
             }
-            try {
-                val error = nonStrictJson.decodeFromString<KeeperError>(errorMessage)
-                if (error.error == "key") {
-                    val customKey = options.storage.getString(KEY_SERVER_PUBLIC_KEY)
-                    if (customKey != null) {
-                        val currentKeyId = options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
-                        throw Exception("Server rejected the custom server public key (id $currentKeyId). The server suggested key id ${error.key_id}. Please update your IL5 KSM configuration.")
-                    }
-                    options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, error.key_id.toString())
-                    continue
+            // Parse outside the bare catch so the actionable IL5 throw can escape.
+            val error = try { nonStrictJson.decodeFromString<KeeperError>(errorMessage) } catch (_: Exception) { null }
+            if (error?.error == "key") {
+                val customKey = options.storage.getString(KEY_SERVER_PUBLIC_KEY)
+                if (customKey != null) {
+                    val currentKeyId = options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
+                    throw SecretsManagerException("Server rejected the custom server public key (id $currentKeyId). The server suggested key id ${error.key_id}. Please update your IL5 KSM configuration.")
                 }
-            } catch (_: Exception) {
+                options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, error.key_id.toString())
+                continue
             }
-            throw Exception(errorMessage)
+            throw SecretsManagerException(errorMessage)
         }
         if (response.data.isEmpty()) {
             return response.data

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1700,6 +1700,7 @@ internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Doubl
 // throttleDelayMillis with a pinned jitter instead.
 internal fun throttleJitter(): Double = Random.nextDouble(-0.25, 0.25)
 
+@ExperimentalSerializationApi
 private inline fun <reified T> postQuery(
     options: SecretsManagerOptions,
     path: String,

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -22,7 +22,7 @@ import javax.net.ssl.*
 const val KEEPER_CLIENT_VERSION = "mj17.2.1"
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
-const val KEY_SERVER_PUBIC_KEY_ID = "serverPublicKeyId"
+const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
 const val KEY_SERVER_PUBLIC_KEY = "serverPublicKey" // custom server public key bytes (base64url), overrides embedded table
 const val KEY_CLIENT_ID = "clientId"
 const val KEY_CLIENT_KEY = "clientKey" // The key that is used to identify the client before public key
@@ -46,12 +46,13 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val queryFunction: QueryFunction? = null,
     val allowUnverifiedCertificate: Boolean = false,
     val loggingEnabled: Boolean = true,
-    val serverPublicKey: String? = null  // Layer 3: inject custom server public key at construction time
+    val serverPublicKey: String? = null,
+    val serverPublicKeyId: String? = null
 ) {
     init {
         testSecureRandom()
-        // Persist the injected key so generateTransmissionKey can pick it up without options in scope
         serverPublicKey?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY, it) }
+        serverPublicKeyId?.let { storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, it) }
     }
 }
 
@@ -715,8 +716,18 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         }
         clientKey = tokenParts[1]
         // Layer 2: extended OTT format REGION:clientKey:keyId:serverPublicKey
-        if (tokenParts.size >= 4) {
-            storage.saveString(KEY_SERVER_PUBIC_KEY_ID, tokenParts[2])
+        if (tokenParts.size > 4) {
+            throw Exception("Extended OTT token has unexpected extra segments (${tokenParts.size} parts, expected 2 or 4)")
+        }
+        if (tokenParts.size == 4) {
+            val keyId = tokenParts[2]
+            if (keyId.isEmpty() || !keyId.all { it.isDigit() }) {
+                throw Exception("Extended OTT token: serverPublicKeyId '$keyId' must be a positive integer")
+            }
+            if (tokenParts[3].length < 80) {
+                throw Exception("Extended OTT token: serverPublicKey appears malformed")
+            }
+            storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, keyId)
             storage.saveString(KEY_SERVER_PUBLIC_KEY, tokenParts[3])
         }
     }
@@ -1601,7 +1612,7 @@ private fun generateTransmissionKey(storage: KeyValueStorage): TransmissionKey {
     } else {
         getRandomBytes(32)
     }
-    val keyNumber: Int = storage.getString(KEY_SERVER_PUBIC_KEY_ID)?.toInt() ?: 7
+    val keyNumber: Int = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)?.toInt() ?: 7
     // Layer 1: serverPublicKey in storage (from config JSON, OTT, or constructor) takes priority
     val keeperPublicKey: ByteArray = storage.getString(KEY_SERVER_PUBLIC_KEY)?.let { webSafe64ToBytes(it) }
         ?: keeperPublicKeys[keyNumber]
@@ -1645,7 +1656,12 @@ private inline fun <reified T> postQuery(
             try {
                 val error = nonStrictJson.decodeFromString<KeeperError>(errorMessage)
                 if (error.error == "key") {
-                    options.storage.saveString(KEY_SERVER_PUBIC_KEY_ID, error.key_id.toString())
+                    val customKey = options.storage.getString(KEY_SERVER_PUBLIC_KEY)
+                    if (customKey != null) {
+                        val currentKeyId = options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
+                        throw Exception("Server rejected the custom server public key (id $currentKeyId). The server suggested key id ${error.key_id}. Please update your IL5 KSM configuration.")
+                    }
+                    options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, error.key_id.toString())
                     continue
                 }
             } catch (_: Exception) {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -575,7 +575,7 @@ private data class SecretsManagerResponseFile(
     val fileUid: String,
     val fileKey: String,
     val data: String,
-    val url: String,
+    val url: String?, // KSM-765: server may omit url; nullable prevents NPE on deserialization
     val thumbnailUrl: String?
 )
 
@@ -684,7 +684,7 @@ data class KeeperFile(
     val fileKey: ByteArray,
     val fileUid: String,
     val data: KeeperFileData,
-    val url: String,
+    val url: String?, // KSM-765: nullable; server may omit url for files without a download URL
     val thumbnailUrl: String?
 )
 
@@ -1070,7 +1070,8 @@ fun uploadFile(options: SecretsManagerOptions, ownerRecord: KeeperRecord, file: 
 }
 
 fun downloadFile(file: KeeperFile): ByteArray {
-    return downloadFile(file, file.url)
+    val url = file.url ?: throw Exception("File ${file.fileUid} has no download URL")
+    return downloadFile(file, url)
 }
 
 fun downloadThumbnail(file: KeeperFile): ByteArray {
@@ -1081,17 +1082,20 @@ fun downloadThumbnail(file: KeeperFile): ByteArray {
 }
 
 private fun downloadFile(file: KeeperFile, url: String): ByteArray {
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "GET"
-        val statusCode = responseCode
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
+        connection.requestMethod = "GET"
+        val statusCode = connection.responseCode
         val data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
         if (statusCode != HTTP_OK) {
             throw Exception(String(data))
         }
         return decrypt(data, file.fileKey)
+    } finally {
+        connection.disconnect()
     }
 }
 
@@ -1101,28 +1105,31 @@ private fun uploadFile(url: String, parameters: String, fileData: ByteArray): Ke
     val boundary = String.format("----------%x", Instant.now().epochSecond)
     val boundaryBytes: ByteArray = stringToBytes("\r\n--$boundary")
     val paramJson = Json.parseToJsonElement(parameters) as JsonObject
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
-        requestMethod = "POST"
-        useCaches = false
-        doInput = true
-        doOutput = true
-        setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
-        with(outputStream) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
+        connection.requestMethod = "POST"
+        connection.useCaches = false
+        connection.doInput = true
+        connection.doOutput = true
+        connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+        connection.outputStream.use { os ->
             for (param in paramJson.entries) {
-                write(boundaryBytes)
-                write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
+                os.write(boundaryBytes)
+                os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"${param.key}\"\r\n\r\n${param.value.jsonPrimitive.content}"))
             }
-            write(boundaryBytes)
-            write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
-            write(fileData)
-            write(boundaryBytes)
-            write(stringToBytes("--\r\n"))
+            os.write(boundaryBytes)
+            os.write(stringToBytes("\r\nContent-Disposition: form-data; name=\"file\"\r\nContent-Type: application/octet-stream\r\n\r\n"))
+            os.write(fileData)
+            os.write(boundaryBytes)
+            os.write(stringToBytes("--\r\n"))
         }
-        statusCode = responseCode
+        statusCode = connection.responseCode
         data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }
@@ -1152,13 +1159,29 @@ private fun fetchAndDecryptSecrets(
     } else {
         appKey = storage.getBytes(KEY_APP_KEY) ?: throw Exception("App key is missing from the storage")
     }
+    // KSM-753: records created via non-SDK clients in shared folders appear in response.records[]
+    // with innerFolderUid set; their recordKey is encrypted with the folder key, not the app key.
+    val folderKeyMap: Map<String, ByteArray> = response.folders
+        ?.mapNotNull { f ->
+            try { f.folderUid to decrypt(f.folderKey, appKey) } catch (e: Exception) { null }
+        }?.toMap() ?: emptyMap()
+
     val records: MutableList<KeeperRecord> = mutableListOf()
     if (response.records != null) {
         response.records.forEach {
             try {
-                val recordKey = decrypt(it.recordKey, appKey)
+                val decryptKey = if (it.innerFolderUid != null && folderKeyMap.containsKey(it.innerFolderUid)) {
+                    folderKeyMap[it.innerFolderUid]!!
+                } else {
+                    appKey
+                }
+                val recordKey = decrypt(it.recordKey, decryptKey)
                 val decryptedRecord = decryptRecord(it, recordKey, options)
                 if (decryptedRecord != null) {
+                    if (it.innerFolderUid != null && folderKeyMap.containsKey(it.innerFolderUid)) {
+                        decryptedRecord.folderUid = it.innerFolderUid
+                        decryptedRecord.folderKey = folderKeyMap[it.innerFolderUid]
+                    }
                     records.add(decryptedRecord)
                 }
             } catch (e: Exception) {
@@ -1560,22 +1583,25 @@ fun postFunction(
 ): KeeperHttpResponse {
     var statusCode: Int
     var data: ByteArray
-    with(URI.create(url).toURL().openConnection() as HttpsURLConnection) {
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    try {
         if (allowUnverifiedCertificate) {
-            sslSocketFactory = trustAllSocketFactory()
+            connection.sslSocketFactory = trustAllSocketFactory()
         }
-        requestMethod = "POST"
-        doOutput = true
-        setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
-        setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
-        setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
-        outputStream.write(payload.payload)
-        outputStream.flush()
-        statusCode = responseCode
+        connection.requestMethod = "POST"
+        connection.doOutput = true
+        connection.setRequestProperty("PublicKeyId", transmissionKey.publicKeyId.toString())
+        connection.setRequestProperty("TransmissionKey", bytesToBase64(transmissionKey.encryptedKey))
+        connection.setRequestProperty("Authorization", "Signature ${bytesToBase64(payload.signature)}")
+        connection.outputStream.write(payload.payload)
+        connection.outputStream.flush()
+        statusCode = connection.responseCode
         data = when {
-            errorStream != null -> errorStream.readBytes()
-            else -> inputStream.readBytes()
+            connection.errorStream != null -> connection.errorStream.readBytes()
+            else -> connection.inputStream.readBytes()
         }
+    } finally {
+        connection.disconnect()
     }
     return KeeperHttpResponse(statusCode, data)
 }

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -791,7 +791,7 @@ fun initializeStorage(storage: KeyValueStorage, oneTimeToken: String, hostName: 
         host = hostName ?: throw Exception("The hostname must be present in the token or as a parameter")
         clientKey = oneTimeToken
     } else {
-        host = when (tokenParts[0].uppercase(Locale.getDefault())) {
+        host = when (tokenParts[0].uppercase(Locale.US)) {
             "US" -> "keepersecurity.com"
             "EU" -> "keepersecurity.eu"
             "AU" -> "keepersecurity.com.au"

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URI
 import java.security.KeyManagementException
@@ -17,9 +18,16 @@ import java.security.cert.X509Certificate
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.*
+import kotlin.random.Random
 import javax.net.ssl.*
 
 const val KEEPER_CLIENT_VERSION = "mj17.2.1"
+
+// Throttle retry (KSM-876 / KSM-878). The backend throttles HTTP 403 {"error":"throttled"}
+// per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+// request, so the counter only clears after 10s of silence).
+const val MAX_THROTTLE_RETRIES = 5
+const val BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
@@ -47,7 +55,9 @@ data class SecretsManagerOptions @JvmOverloads constructor(
     val allowUnverifiedCertificate: Boolean = false,
     val loggingEnabled: Boolean = true,
     val serverPublicKey: String? = null,
-    val serverPublicKeyId: String? = null
+    val serverPublicKeyId: String? = null,
+    // Override the sleep between throttle retries (primarily for tests). Defaults to Thread.sleep.
+    val throttleSleepMillis: ((Long) -> Unit)? = null
 ) {
     init {
         testSecureRandom()
@@ -1662,6 +1672,34 @@ private inline fun <reified T> encryptAndSignPayload(
 }
 
 @ExperimentalSerializationApi
+// Returns the throttle retry_after (>= 0) when [body] is a backend throttle error
+// (result_code/error == "throttled"), otherwise null so the caller falls through to normal
+// error handling. Non-JSON / non-object bodies return null. (KSM-876 / KSM-878)
+internal fun parseThrottle(body: String): Double? {
+    val obj = try {
+        nonStrictJson.parseToJsonElement(body).jsonObject
+    } catch (e: Exception) {
+        return null
+    }
+    val resultCode = ((obj["result_code"] ?: obj["error"]) as? JsonPrimitive)?.content
+    if (resultCode != "throttled") return null
+    val retryAfter = (obj["retry_after"] as? JsonPrimitive)?.content?.toDoubleOrNull() ?: 0.0
+    return if (retryAfter < 0.0) 0.0 else retryAfter
+}
+
+// Backoff delay (milliseconds) for a 0-based [attempt]: retryAfter when > 0, otherwise
+// exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22, 44, 88, 176s). The
+// [jitter] fraction (typically in [-0.25, 0.25)) is then applied.
+internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Double): Long {
+    val baseSec = if (retryAfter > 0.0) retryAfter else BASE_THROTTLE_DELAY_SEC.toDouble() * (1L shl attempt)
+    val sec = baseSec + baseSec * jitter
+    return (maxOf(sec, 0.0) * 1000).toLong()
+}
+
+// Random jitter multiplier in [-0.25, 0.25). Kept separate so unit tests exercise
+// throttleDelayMillis with a pinned jitter instead.
+internal fun throttleJitter(): Double = Random.nextDouble(-0.25, 0.25)
+
 private inline fun <reified T> postQuery(
     options: SecretsManagerOptions,
     path: String,
@@ -1669,6 +1707,8 @@ private inline fun <reified T> postQuery(
 ): ByteArray {
     val hostName = options.storage.getString(KEY_HOSTNAME) ?: throw Exception("hostname is missing from the storage")
     val url = "https://${hostName}/api/rest/sm/v1/${path}"
+    val throttleSleep = options.throttleSleepMillis ?: { ms -> Thread.sleep(ms) }
+    var throttleAttempt = 0
     while (true) {
         val transmissionKey = generateTransmissionKey(options.storage)
         val encryptedPayload = encryptAndSignPayload(options.storage, transmissionKey, payload)
@@ -1679,6 +1719,26 @@ private inline fun <reified T> postQuery(
         }
         if (response.statusCode != HTTP_OK) {
             val errorMessage = String(response.data)
+            // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-878). Checked before
+            // key-rotation so that path (incl. the IL5 custom-key suppression) is untouched, and
+            // gated on the 403 status so a non-403 response carrying a {"error":"throttled"} body
+            // is not mistaken for a throttle and retried.
+            if (response.statusCode == HTTP_FORBIDDEN) {
+                val retryAfter = parseThrottle(errorMessage)
+                if (retryAfter != null) {
+                    if (throttleAttempt >= MAX_THROTTLE_RETRIES) {
+                        throw KeeperThrottleException("Request throttled by Keeper backend; exhausted $MAX_THROTTLE_RETRIES retries")
+                    }
+                    val delayMs = throttleDelayMillis(throttleAttempt, retryAfter, throttleJitter())
+                    System.err.println(
+                        "WARNING: Request throttled (attempt ${throttleAttempt + 1}/$MAX_THROTTLE_RETRIES); " +
+                            "retrying in ${"%.1f".format(delayMs / 1000.0)}s"
+                    )
+                    throttleSleep(delayMs)
+                    throttleAttempt++
+                    continue
+                }
+            }
             try {
                 val error = nonStrictJson.decodeFromString<KeeperError>(errorMessage)
                 if (error.error == "key") {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
@@ -2,7 +2,7 @@
 
 package com.keepersecurity.secretsManager.core
 
-internal open class SecretsManagerException(message: String): Exception(message)
+open class SecretsManagerException(message: String): Exception(message)
 
 internal class SecureRandomException(message: String): SecretsManagerException(message)
 internal class SecureRandomSlowGenerationException(message: String): SecretsManagerException(message)

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
@@ -6,3 +6,10 @@ internal open class SecretsManagerException(message: String): Exception(message)
 
 internal class SecureRandomException(message: String): SecretsManagerException(message)
 internal class SecureRandomSlowGenerationException(message: String): SecretsManagerException(message)
+
+/**
+ * Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the SDK
+ * has exhausted its automatic retries (see MAX_THROTTLE_RETRIES). Public so callers can catch
+ * throttling specifically; extends Exception so existing `catch (e: Exception)` handlers still work.
+ */
+class KeeperThrottleException(message: String): Exception(message)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/IL5EdgeCaseTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/IL5EdgeCaseTest.kt
@@ -1,0 +1,59 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import java.io.File
+import kotlin.test.*
+
+@ExperimentalSerializationApi
+internal class IL5EdgeCaseTest {
+
+    private val fakeServerPublicKey =
+        "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
+
+    @BeforeTest
+    fun setUp() {
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+    }
+
+    @Test
+    fun localConfigStoragePersistsServerPublicKey() {
+        // Delete immediately — we only want the unique path, not an empty file that would fail JSON parse.
+        val configFile = File.createTempFile("ksm-test-", ".json").also { it.delete() }
+        try {
+            initializeStorage(LocalConfigStorage(configFile.absolutePath), "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
+
+            // Simulate a second run: fresh LocalConfigStorage loading from the same file.
+            val storage2 = LocalConfigStorage(configFile.absolutePath)
+            assertEquals(
+                fakeServerPublicKey,
+                storage2.getString(KEY_SERVER_PUBLIC_KEY),
+                "serverPublicKey must survive a save/load round-trip through LocalConfigStorage"
+            )
+            assertEquals("20", storage2.getString(KEY_SERVER_PUBLIC_KEY_ID))
+        } finally {
+            configFile.delete()
+        }
+    }
+
+    @Test
+    fun customKeyRejection_surfacesActionableIl5Message() {
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
+        storage.saveBytes(KEY_APP_KEY, ByteArray(32))
+
+        val mock: QueryFunction = { _, _, _ ->
+            KeeperHttpResponse(400, """{"error":"key","key_id":21}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, mock)
+
+        val ex = assertFailsWith<Exception> { getSecrets(options) }
+        assertTrue(
+            ex.message?.contains("Server rejected the custom server public key") == true,
+            "Expected actionable IL5 message, got: ${ex.message}"
+        )
+        assertTrue(
+            ex.message?.contains("21") == true,
+            "Expected suggested key id 21 in message, got: ${ex.message}"
+        )
+    }
+}

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
@@ -295,15 +295,20 @@ class KeeperRecordLinkTest {
 
     @Test
     fun losslessnessPreservesNestedStructures() {
-        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}}""")
+        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}, "maybe": null, "list": [1, null, 2]}""")
         val data = link.getLinkData()
         assertNotNull(data)
 
         val future = data["futureField"]
         assertTrue(future is Map<*, *>)               // nested object preserved as a Map, not a String
         @Suppress("UNCHECKED_CAST")
-        val nested = (future as Map<String, Any>)["nested"]
+        val nested = (future as Map<String, Any?>)["nested"]
         assertEquals(listOf(1, 2, 3), nested)         // nested array preserved as a List of ints
+
+        // JSON nulls are preserved (matching the Python reference), not dropped.
+        assertTrue(data.containsKey("maybe"))
+        assertNull(data["maybe"])
+        assertEquals(listOf(1, null, 2), data["list"])
 
         // Raw link fields are untouched.
         assertEquals("RU_test", link.recordUid)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
@@ -1,0 +1,330 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the [KeeperRecordLink] typed accessor layer.
+ *
+ * Mirrors the Python reference suite `sdk/python/core/tests/record_link_test.py` (KSM-992, PR #1036)
+ * so the Java accessors match the live-verified backend payload shapes: permission booleans with an
+ * `allowedSettings` fallback (top-level wins), the new credential/meta accessors, lossless
+ * `getLinkData()`, and the encrypted ai/jit settings.
+ */
+class KeeperRecordLinkTest {
+
+    private val recordKey: ByteArray = getRandomBytes(32)
+
+    /** Build a link whose data is base64 of the given plain JSON payload. */
+    private fun plainLink(json: String, path: String? = null, recordUid: String = "RU_test") =
+        KeeperRecordLink(recordUid, bytesToBase64(json.toByteArray(Charsets.UTF_8)), path)
+
+    /** Build a link whose data is base64 of the payload encrypted (AES-256-GCM) under [key]. */
+    private fun encryptedLink(json: String, key: ByteArray, path: String? = null, recordUid: String = "RU_test") =
+        KeeperRecordLink(recordUid, bytesToBase64(encrypt(json.toByteArray(Charsets.UTF_8), key)), path)
+
+    /**
+     * Produce a base64 AES-GCM ciphertext whose first decoded byte equals [marker] ('{' or '[').
+     * The IV is random per call, so we re-encrypt until we hit the marker (~1/256 each try). The
+     * result is a real, decryptable ciphertext that also trips the plain-JSON fast path.
+     */
+    private fun ciphertextStartingWith(marker: Char, json: String, key: ByteArray): String {
+        val target = marker.code.toByte()
+        repeat(100_000) {
+            val ct = encrypt(json.toByteArray(Charsets.UTF_8), key)
+            if (ct.isNotEmpty() && ct[0] == target) return bytesToBase64(ct)
+        }
+        throw IllegalStateException("Could not generate ciphertext starting with '$marker'")
+    }
+
+    @Test
+    fun booleanAccessorsReadPlainJson() {
+        val link = plainLink("""{"is_admin": true, "rotation": true, "connections": false}""")
+        assertTrue(link.isAdminUser())
+        assertTrue(link.allowsRotation())
+        assertFalse(link.allowsConnections())
+        assertFalse(link.allowsPortForwards())
+        assertFalse(link.isLaunchCredential())
+        assertFalse(link.isIamUser())
+        assertFalse(link.belongsTo())
+        assertFalse(link.noUpdateServices())
+    }
+
+    @Test
+    fun versionAndDecodedData() {
+        val link = plainLink("""{"version": 3, "is_admin": false}""")
+        assertEquals(3, link.getLinkDataVersion())
+        assertTrue(link.getDecodedData()!!.startsWith("{"))
+        assertTrue(link.hasReadableData())
+
+        val notJson = plainLink("not json at all")
+        assertFalse(notJson.hasReadableData())
+        assertNull(notJson.getLinkDataVersion())
+
+        val badBase64 = KeeperRecordLink("RU_test", "!!! not base64 !!!", null)
+        assertNull(badBase64.getDecodedData())
+        assertNull(badBase64.getLinkData())
+    }
+
+    @Test
+    fun mightBeEncryptedByPath() {
+        assertTrue(plainLink("{}", path = "ai_settings").mightBeEncrypted())
+        assertTrue(plainLink("{}", path = "jit_settings").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = "meta").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = "something_else").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = null).mightBeEncrypted())
+    }
+
+    @Test
+    fun getDecryptedDataRoundtrip() {
+        val link = encryptedLink("""{"enabled": true, "ttl": 3600}""", recordKey, path = "jit_settings")
+        val decrypted = link.getDecryptedData(recordKey)
+        assertNotNull(decrypted)
+        assertTrue(decrypted.contains("enabled"))
+        assertNull(link.getDecryptedData(null))
+        assertNull(link.getDecryptedData(getRandomBytes(32))) // wrong key fails gracefully
+    }
+
+    @Test
+    fun getLinkDataPlainAndEncrypted() {
+        val plain = plainLink("""{"aiEnabled": true}""", path = "ai_settings")
+        assertEquals(true, plain.getLinkData()!!["aiEnabled"])
+
+        val encrypted = encryptedLink("""{"enabled": true}""", recordKey, path = "jit_settings")
+        assertNull(encrypted.getLinkData())              // can't decrypt without a key
+        assertEquals(true, encrypted.getLinkData(recordKey)!!["enabled"])
+    }
+
+    @Test
+    fun settingsPathFilters() {
+        val ai = plainLink("""{"aiEnabled": true}""", path = "ai_settings")
+        val jit = plainLink("""{"enabled": true}""", path = "jit_settings")
+
+        assertNotNull(ai.getAiSettingsData(recordKey))
+        assertNull(ai.getJitSettingsData(recordKey))
+        assertNotNull(jit.getJitSettingsData(recordKey))
+        assertNull(jit.getAiSettingsData(recordKey))
+        assertNotNull(ai.getSettingsForPath("ai_settings"))
+        assertNull(ai.getSettingsForPath("other"))
+    }
+
+    @Test
+    fun stringEncodedValuesAreNotCoerced() {
+        val strings = plainLink("""{"is_admin": "true", "rotation": "false", "version": "3"}""")
+        assertFalse(strings.isAdminUser())          // "true" string is not a boolean
+        assertFalse(strings.allowsRotation())       // "false" string is not a boolean
+        assertNull(strings.getLinkDataVersion())    // "3" string is not an integer
+
+        val real = plainLink("""{"is_admin": true, "version": 3}""")
+        assertTrue(real.isAdminUser())
+        assertEquals(3, real.getLinkDataVersion())
+
+        // A JSON boolean must not be read as an integer version.
+        assertNull(plainLink("""{"version": true}""").getLinkDataVersion())
+    }
+
+    @Test
+    fun hasEncryptedDataDetection() {
+        // Non-printable bytes that are neither a JSON object nor printable text.
+        val encryptedLooking = KeeperRecordLink("RU_test", bytesToBase64(ByteArray(40) { (it % 32).toByte() }), null)
+        assertTrue(encryptedLooking.hasEncryptedData())
+
+        assertFalse(plainLink("just plain readable text, not json").hasEncryptedData())
+        assertFalse(plainLink("""{"a": 1}""").hasEncryptedData())
+        assertFalse(KeeperRecordLink("RU_test", null, null).hasEncryptedData())
+    }
+
+    @Test
+    fun getSettingsForPathEncrypted() {
+        val link = encryptedLink("""{"customSetting": 42}""", recordKey, path = "custom_settings")
+        assertEquals(42, link.getSettingsForPath("custom_settings", recordKey)!!["customSetting"])
+        assertNull(link.getSettingsForPath("other", recordKey))
+    }
+
+    @Test
+    fun metaLinkLiveShape() {
+        val meta = plainLink(
+            """
+            {
+              "allowedSettings": {
+                "rotation": true,
+                "connections": true,
+                "portForwards": true,
+                "sessionRecording": true,
+                "typescriptRecording": false,
+                "aiEnabled": true,
+                "aiSessionTerminate": true,
+                "remoteBrowserIsolation": true
+              },
+              "rotateOnTermination": false,
+              "version": 1,
+              "no_update_services": true
+            }
+            """.trimIndent(),
+            path = "meta"
+        )
+
+        // Permission booleans are absent at the top level — read via the allowedSettings fallback.
+        assertTrue(meta.allowsRotation())
+        assertTrue(meta.allowsConnections())
+        assertTrue(meta.allowsPortForwards())
+        assertTrue(meta.allowsSessionRecording())
+        assertFalse(meta.allowsTypescriptRecording())
+        assertTrue(meta.allowsRemoteBrowserIsolation())
+        assertTrue(meta.aiEnabled())
+        assertTrue(meta.aiSessionTerminate())
+
+        assertFalse(meta.rotatesOnTermination())   // top-level
+        assertEquals(1, meta.getLinkDataVersion())
+        assertTrue(meta.noUpdateServices())        // top-level
+
+        assertEquals(true, meta.getAllowedSettings()["rotation"])
+        assertNotNull(meta.getMetaData())
+        assertNull(plainLink("{}", path = null).getMetaData()) // path-gated
+    }
+
+    @Test
+    fun topLevelWinsOverAllowedSettings() {
+        val both = plainLink("""{"rotation": false, "allowedSettings": {"rotation": true}}""")
+        assertFalse(both.allowsRotation())          // top-level false wins
+
+        val fallbackOnly = plainLink("""{"allowedSettings": {"rotation": true}}""")
+        assertTrue(fallbackOnly.allowsRotation())   // fallback applies when top-level absent
+    }
+
+    @Test
+    fun credentialLinkLiveShape() {
+        val credential = plainLink(
+            """
+            {
+              "is_admin": true,
+              "is_iam_user": false,
+              "belongs_to": true,
+              "is_launch_credential": true,
+              "rotation_settings": {
+                "schedule": "",
+                "pwd_complexity": "ZmFrZS1jb21wbGV4aXR5",
+                "disabled": false,
+                "noop": false,
+                "saas_record_uid_list": []
+              }
+            }
+            """.trimIndent()
+        )
+        assertTrue(credential.isAdminUser())
+        assertFalse(credential.isIamUser())
+        assertTrue(credential.belongsTo())
+        assertTrue(credential.isLaunchCredential())
+
+        val rotation = credential.getRotationSettings()
+        assertNotNull(rotation)
+        assertEquals("", rotation["schedule"])
+        assertEquals(false, rotation["disabled"])
+        assertEquals(emptyList<Any>(), rotation["saas_record_uid_list"])
+
+        assertNull(plainLink("""{"is_admin": true}""").getRotationSettings())
+    }
+
+    @Test
+    fun dataLessReferenceLink() {
+        val ref = KeeperRecordLink("RU_ref", null, null)
+        assertEquals("RU_ref", ref.recordUid)
+        assertFalse(ref.isAdminUser())
+        assertFalse(ref.allowsRotation())
+        assertNull(ref.getLinkDataVersion())
+        assertNull(ref.getDecodedData())
+        assertNull(ref.getDecryptedData(recordKey))
+        assertNull(ref.getLinkData())
+        assertTrue(ref.getAllowedSettings().isEmpty())
+        assertNull(ref.getRotationSettings())
+        assertFalse(ref.hasReadableData())
+        assertFalse(ref.hasEncryptedData())
+    }
+
+    @Test
+    fun aiSettingsLiveShape() {
+        val ai = encryptedLink(
+            """
+            {
+              "version": "v1.0.0",
+              "riskLevels": {
+                "critical": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "high": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "medium": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "low": {"tags": {"allow": []}, "aiSessionTerminate": false}
+              }
+            }
+            """.trimIndent(),
+            recordKey,
+            path = "ai_settings"
+        )
+        val data = ai.getAiSettingsData(recordKey)
+        assertNotNull(data)
+        assertEquals("v1.0.0", data["version"])
+        assertTrue(data["riskLevels"] is Map<*, *>)   // nested object preserved, not stringified
+        assertNull(ai.getLinkDataVersion())            // string version is not an integer
+    }
+
+    @Test
+    fun jitSettingsLiveShape() {
+        val jit = encryptedLink(
+            """
+            {
+              "createEphemeral": true,
+              "elevate": true,
+              "elevationMethod": "group",
+              "elevationString": "arn:aws",
+              "baseDistinguishedName": ""
+            }
+            """.trimIndent(),
+            recordKey,
+            path = "jit_settings"
+        )
+        val data = jit.getJitSettingsData(recordKey)
+        assertNotNull(data)
+        assertEquals(true, data["createEphemeral"])
+        assertEquals(true, data["elevate"])
+        assertEquals("group", data["elevationMethod"])
+        assertEquals("arn:aws", data["elevationString"])
+        assertEquals("", data["baseDistinguishedName"])
+    }
+
+    @Test
+    fun losslessnessPreservesNestedStructures() {
+        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}}""")
+        val data = link.getLinkData()
+        assertNotNull(data)
+
+        val future = data["futureField"]
+        assertTrue(future is Map<*, *>)               // nested object preserved as a Map, not a String
+        @Suppress("UNCHECKED_CAST")
+        val nested = (future as Map<String, Any>)["nested"]
+        assertEquals(listOf(1, 2, 3), nested)         // nested array preserved as a List of ints
+
+        // Raw link fields are untouched.
+        assertEquals("RU_test", link.recordUid)
+        assertNull(link.path)
+        assertNotNull(link.data)
+    }
+
+    @Test
+    fun ciphertextWithJsonLikeFirstByte() {
+        val payload = """{"createEphemeral": true, "elevate": true}"""
+        for (marker in listOf('{', '[')) {
+            val link = KeeperRecordLink("RU_test", ciphertextStartingWith(marker, payload, recordKey), "jit_settings")
+            assertEquals(marker, link.getDecodedData()!![0])
+            assertNull(link.getLinkData(null))         // leading {/[ is coincidental; no key -> null
+            val data = link.getLinkData(recordKey)     // falls through to decryption
+            assertNotNull(data)
+            assertEquals(true, data["createEphemeral"])
+            assertEquals(true, data["elevate"])
+            assertNotNull(link.getJitSettingsData(recordKey))
+        }
+        // Plain JSON is unaffected and parses without a key.
+        assertEquals(1, plainLink("""{"a": 1}""").getLinkData()!!["a"])
+    }
+}

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -109,6 +109,9 @@ internal class SecretsManagerTest {
         initializeStorage(storage, "eu:ONE_TIME_TOKEN")
         assertEquals("keepersecurity.eu", storage.getString("hostname"))
         storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:ONE_TIME_TOKEN")
+        assertEquals("il5.keepersecurity.us", storage.getString("hostname"))
+        storage = InMemoryStorage()
         initializeStorage(storage, "fake.keepersecurity.com:ONE_TIME_TOKEN")
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
     }
@@ -120,6 +123,44 @@ internal class SecretsManagerTest {
                 "V9LRVkiLCAgICAKInNlcnZlclB1YmxpY0tleUlkIjogIjEwIiB9"
         val storage = InMemoryStorage(fakeBase64Config)
         assertEquals("fake.keepersecurity.com", storage.getString("hostname"))
+    }
+
+    @Test
+    fun testRecordCreateEmptyCustomSerialized() {
+        // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
+        val recordData = KeeperRecordData(
+            title = "Test Record",
+            type = "login",
+            fields = mutableListOf()
+        )
+        val json = Json.encodeToString(recordData)
+        assertTrue(json.contains("\"custom\":[]") || json.contains("\"custom\": []"),
+            "Serialized payload must include custom:[] even when no custom fields are set. Got: $json")
+    }
+
+    @Test
+    fun testKeeperFileDataMissingLastModified() {
+        // GH-973 / KSM-854: lastModified entirely absent — must deserialize without throwing
+        val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(0L, result.lastModified)
+        assertEquals("test.txt", result.name)
+    }
+
+    @Test
+    fun testKeeperFileDataIntegerLastModified() {
+        // Regression guard: normal integer lastModified
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1700000000000}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1700000000000L, result.lastModified)
+    }
+
+    @Test
+    fun testKeeperFileDataFractionalLastModified() {
+        // Regression guard for KSM-673: fractional lastModified (iOS client format)
+        val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1760646182.790214}"""
+        val result = Json.decodeFromString<KeeperFileData>(json)
+        assertEquals(1760646182L, result.lastModified)
     }
 
 //    @Test // uncomment to debug the integration test

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -132,7 +132,7 @@ internal class SecretsManagerTest {
         val storage = InMemoryStorage()
         initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
         assertEquals("il5.keepersecurity.us", storage.getString(KEY_HOSTNAME))
-        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBLIC_KEY_ID))
         assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
     }
 
@@ -147,20 +147,26 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIL5ConfigFieldOverridesEmbeddedTable() {
-        // KSM-902: serverPublicKey in storage is used instead of the embedded key table
-        // Validated by removing key 10 from the table and feeding the same bytes back via storage
-        val key10B64 = "BNYIh_Sv03nRZUUJveE8d2mxKLIDXv654UbshaItHrCJhd6cT7pdZ_XwbdyxAOCWMkBb9AZ4t1XRCsM8-wkEBRg"
+        // KSM-902: KEY_SERVER_PUBLIC_KEY in storage must be used instead of the embedded key table.
+        // Key ID 999 is not in the embedded table. With a custom key in storage, generateTransmissionKey
+        // must use the storage key. If it falls through to the table, it throws
+        // "Key number 999 is not supported" and the post function is never called.
+        val customKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
         val storage = InMemoryStorage()
-        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "10")
-        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
-        // generateTransmissionKey is private; verify indirectly through storage state
-        // If key lookup fell through to the table it would also work, but we verify the
-        // storage field is read by ensuring a non-table key ID doesn't throw
-        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "20")
-        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
-        // Storage has key ID 20 (not in table) + custom key bytes — must not throw
-        assertNotNull(storage.getString(KEY_SERVER_PUBLIC_KEY))
-        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:999:$customKey")
+        assertEquals("999", storage.getString(KEY_SERVER_PUBLIC_KEY_ID))
+        assertEquals(customKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+
+        var capturedKeyId: Int? = null
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+        val testPostFunction: (String, TransmissionKey, EncryptedPayload) -> KeeperHttpResponse = { _, tk, _ ->
+            capturedKeyId = tk.publicKeyId
+            KeeperHttpResponse(400, """{"error":"generic","message":"intercepted"}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, testPostFunction)
+        try { getSecrets(options) } catch (_: Exception) {}
+
+        assertEquals(999, capturedKeyId, "generateTransmissionKey must use storage key (ID 999) not the embedded table")
     }
 
     @Test

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -247,14 +247,13 @@ internal class SecretsManagerTest {
         val folderKey = getRandomBytes(32)
         val recordKey = getRandomBytes(32)
         val folderUid = "testFolderUid001"
-        val recordUid = "testRecordUid001"
 
         val encFolderKey = bytesToBase64(encrypt(folderKey, appKey))
         val encRecordKey = bytesToBase64(encrypt(recordKey, folderKey))
         val recordDataJson = """{"title":"Shared Record","type":"login","fields":[],"custom":[]}"""
         val encData = bytesToBase64(encrypt(stringToBytes(recordDataJson), recordKey))
 
-        val responseJson = """{"encryptedAppKey":null,"folders":[{"folderUid":"$folderUid","folderKey":"$encFolderKey","data":null,"parent":null,"records":null}],"records":[{"recordUid":"$recordUid","recordKey":"$encRecordKey","data":"$encData","revision":1,"isEditable":true,"files":null,"innerFolderUid":"$folderUid"}]}"""
+        val responseJson = """{"encryptedAppKey":null,"folders":[{"folderUid":"$folderUid","folderKey":"$encFolderKey","data":null,"parent":null,"records":null}],"records":[{"recordUid":"testRecordUid001","recordKey":"$encRecordKey","data":"$encData","revision":1,"isEditable":true,"files":null,"innerFolderUid":"$folderUid"}]}"""
         val encryptedResponse = encrypt(stringToBytes(responseJson), transmissionKey)
 
         val storage = InMemoryStorage()

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -224,6 +224,42 @@ internal class SecretsManagerTest {
         assertTrue(webSafe64Ex.message?.isNotEmpty() == true)
     }
 
+    @Test
+    fun testSharedFolderFlatRecordUsesFolderKey() {
+        // A flat records[] entry with innerFolderUid set has its recordKey encrypted with the
+        // folder key, not the app key. Decrypting with the app key yields garbage and the record
+        // is silently skipped, so all of its fields come back missing.
+        val transmissionKey = ByteArray(32) { it.toByte() }
+        TestStubs.transmissionKeyStub = { transmissionKey }
+
+        val appKey = getRandomBytes(32)
+        val folderKey = getRandomBytes(32)
+        val recordKey = getRandomBytes(32)
+        val folderUid = "testFolderUid001"
+        val recordUid = "testRecordUid001"
+
+        val encFolderKey = bytesToBase64(encrypt(folderKey, appKey))
+        val encRecordKey = bytesToBase64(encrypt(recordKey, folderKey))
+        val recordDataJson = """{"title":"Shared Record","type":"login","fields":[],"custom":[]}"""
+        val encData = bytesToBase64(encrypt(stringToBytes(recordDataJson), recordKey))
+
+        val responseJson = """{"encryptedAppKey":null,"folders":[{"folderUid":"$folderUid","folderKey":"$encFolderKey","data":null,"parent":null,"records":null}],"records":[{"recordUid":"$recordUid","recordKey":"$encRecordKey","data":"$encData","revision":1,"isEditable":true,"files":null,"innerFolderUid":"$folderUid"}]}"""
+        val encryptedResponse = encrypt(stringToBytes(responseJson), transmissionKey)
+
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "US:FAKE_CLIENT_KEY")
+        storage.saveBytes(KEY_APP_KEY, appKey)
+
+        val options = SecretsManagerOptions(storage, queryFunction = { _, _, _ -> KeeperHttpResponse(200, encryptedResponse) })
+        val secrets = getSecrets(options)
+
+        assertEquals(1, secrets.records.size)
+        val record = secrets.records[0]
+        assertEquals("Shared Record", record.data.title,
+            "flat record with innerFolderUid must decrypt with the folder key, not the app key")
+        assertEquals(folderUid, record.folderUid)
+    }
+
 //    @Test // uncomment to debug the integration test
     fun integrationTest() {
         val trustAllPostFunction: (

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -137,6 +137,17 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testExtendedOttRejectsThreeSegments() {
+        // A 3-segment OTT was previously accepted and silently misparsed as a 2-segment token
+        // with the third segment dropped; it must now be rejected loudly instead.
+        val storage = InMemoryStorage()
+        val ex = assertFailsWith<Exception> {
+            initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20")
+        }
+        assertTrue(ex.message?.contains("segment count") == true, "Got: ${ex.message}")
+    }
+
+    @Test
     fun testIL5ConstructorParamPersistsToStorage() {
         // KSM-902: serverPublicKey constructor param is saved to storage so generateTransmissionKey can use it
         val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -126,6 +126,44 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testIL5OttFourSegmentParsing() {
+        // KSM-902: 4-segment OTT IL5:clientKey:keyId:serverPublicKey stores key and ID in storage
+        val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
+        assertEquals("il5.keepersecurity.us", storage.getString(KEY_HOSTNAME))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+        assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+    }
+
+    @Test
+    fun testIL5ConstructorParamPersistsToStorage() {
+        // KSM-902: serverPublicKey constructor param is saved to storage so generateTransmissionKey can use it
+        val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
+        val storage = InMemoryStorage()
+        SecretsManagerOptions(storage, serverPublicKey = fakeServerPublicKey)
+        assertEquals(fakeServerPublicKey, storage.getString(KEY_SERVER_PUBLIC_KEY))
+    }
+
+    @Test
+    fun testIL5ConfigFieldOverridesEmbeddedTable() {
+        // KSM-902: serverPublicKey in storage is used instead of the embedded key table
+        // Validated by removing key 10 from the table and feeding the same bytes back via storage
+        val key10B64 = "BNYIh_Sv03nRZUUJveE8d2mxKLIDXv654UbshaItHrCJhd6cT7pdZ_XwbdyxAOCWMkBb9AZ4t1XRCsM8-wkEBRg"
+        val storage = InMemoryStorage()
+        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "10")
+        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
+        // generateTransmissionKey is private; verify indirectly through storage state
+        // If key lookup fell through to the table it would also work, but we verify the
+        // storage field is read by ensuring a non-table key ID doesn't throw
+        storage.saveString(KEY_SERVER_PUBIC_KEY_ID, "20")
+        storage.saveString(KEY_SERVER_PUBLIC_KEY, key10B64)
+        // Storage has key ID 20 (not in table) + custom key bytes — must not throw
+        assertNotNull(storage.getString(KEY_SERVER_PUBLIC_KEY))
+        assertEquals("20", storage.getString(KEY_SERVER_PUBIC_KEY_ID))
+    }
+
+    @Test
     fun testRecordCreateEmptyCustomSerialized() {
         // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
         val recordData = KeeperRecordData(

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -207,6 +207,23 @@ internal class SecretsManagerTest {
         assertEquals(1760646182L, result.lastModified)
     }
 
+    @Test
+    fun testKeeperFileNullUrl() {
+        // KSM-765: KeeperFile.url must be nullable; server may omit url for files without a download link
+        val fileData = KeeperFileData("test.txt", "test.txt", "text/plain", 1024)
+        val file = KeeperFile(ByteArray(32), "uid123", fileData, null, null)
+        assertNull(file.url)
+    }
+
+    @Test
+    fun testBase64EmptyStringThrowsTypedException() {
+        // KSM-985: empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64
+        val base64Ex = assertFailsWith<Exception> { base64ToBytes("") }
+        assertTrue(base64Ex.message?.isNotEmpty() == true)
+        val webSafe64Ex = assertFailsWith<Exception> { webSafe64ToBytes("") }
+        assertTrue(webSafe64Ex.message?.isNotEmpty() == true)
+    }
+
 //    @Test // uncomment to debug the integration test
     fun integrationTest() {
         val trustAllPostFunction: (

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -49,7 +49,7 @@ internal class ThrottleTest {
 
     @Test
     fun throttleDelay_jitterBounds() {
-        assertEquals(8250L, throttleDelayMillis(0, 0.0, -0.25))
+        assertEquals(11000L, throttleDelayMillis(0, 0.0, 0.0))
         assertEquals(13750L, throttleDelayMillis(0, 0.0, 0.25))
     }
 
@@ -61,6 +61,7 @@ internal class ThrottleTest {
         assertEquals(5.0, parseThrottle("""{"result_code":"throttled","retry_after":5}"""))
         assertEquals(3.0, parseThrottle("""{"error":"throttled","retry_after":"3"}"""))
         assertEquals(0.0, parseThrottle("""{"error":"throttled","retry_after":-2}"""))
+        assertEquals(176.0, parseThrottle("""{"error":"throttled","retry_after":300}"""))
         assertNull(parseThrottle("""{"error":"key"}"""))
         assertNull(parseThrottle("not json"))
         assertNull(parseThrottle(""))
@@ -125,8 +126,8 @@ internal class ThrottleTest {
         val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
 
         assertFailsWith<KeeperThrottleException> { getSecrets(options) }
-        // retry_after = 3s with +/-25% jitter -> [2250ms, 3750ms]
-        assertTrue(sleeps[0] in 2250L..3750L, "first delay was ${sleeps[0]}ms")
+        // retry_after = 3s with one-sided [0, 0.25) jitter -> [3000ms, 3750ms]
+        assertTrue(sleeps[0] in 3000L..3750L, "first delay was ${sleeps[0]}ms")
     }
 
     @Test

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -154,4 +154,53 @@ internal class ThrottleTest {
         assertFailsWith<Exception> { getSecrets(options) }
         assertEquals(0, sleeps.size)
     }
+
+    // --- logging gate (PR #1043 review): the throttle warning must respect options.loggingEnabled ---
+
+    // Runs one throttle-then-success getSecrets with the given flag, returning whatever the SDK
+    // wrote to stderr. Tests run sequentially here (shared TestStubs, no parallel config), so
+    // temporarily swapping System.err is safe.
+    private fun captureThrottleStderr(loggingEnabled: Boolean): String {
+        var calls = 0
+        val mock: QueryFunction = { _, transmissionKey, _ ->
+            calls++
+            if (calls == 1) {
+                KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+            } else {
+                val body = """{"records":[],"folders":[],"encryptedAppKey":null}""".toByteArray()
+                KeeperHttpResponse(HTTP_OK, encrypt(body, transmissionKey.key))
+            }
+        }
+        val options = SecretsManagerOptions(
+            buildStorage(), mock, loggingEnabled = loggingEnabled, throttleSleepMillis = { }
+        )
+        val original = System.err
+        val buf = java.io.ByteArrayOutputStream()
+        System.setErr(java.io.PrintStream(buf, true))
+        try {
+            getSecrets(options)
+        } finally {
+            System.setErr(original)
+        }
+        return buf.toString()
+    }
+
+    @Test
+    fun throttleWarning_suppressedWhenLoggingDisabled() {
+        val err = captureThrottleStderr(loggingEnabled = false)
+        assertFalse(
+            err.contains("throttled", ignoreCase = true),
+            "no throttle warning should reach stderr when loggingEnabled=false, got: $err"
+        )
+    }
+
+    @Test
+    fun throttleWarning_emittedWhenLoggingEnabled() {
+        val err = captureThrottleStderr(loggingEnabled = true)
+        assertTrue(err.contains("throttled", ignoreCase = true), "expected a throttle warning on stderr")
+        assertTrue(
+            Regex("attempt 1/$MAX_THROTTLE_RETRIES").containsMatchIn(err),
+            "expected attempt counter in warning, got: $err"
+        )
+    }
 }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -1,0 +1,157 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_OK
+import kotlin.test.*
+
+// Throttle retry with exponential backoff (KSM-876 / KSM-878). Unit tests exercise the internal
+// helpers; e2e tests drive getSecrets through postQuery with a mocked queryFunction returning
+// HTTP 403 {"error":"throttled"} responses and a recording throttleSleepMillis so retries never
+// actually wait.
+@ExperimentalSerializationApi
+internal class ThrottleTest {
+
+    private val fakeToken = "YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c"
+
+    @BeforeTest
+    fun setUp() {
+        // A deterministic, valid 32-byte transmission key. Also avoids leakage from getSecretsE2E,
+        // whose stub closes over its own (by now out-of-range) response index.
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+    }
+
+    private fun throttleBody(retryAfter: Double? = null): ByteArray {
+        val json = if (retryAfter == null) {
+            """{"error":"throttled","message":"throttled"}"""
+        } else {
+            """{"error":"throttled","message":"throttled","retry_after":$retryAfter}"""
+        }
+        return json.toByteArray()
+    }
+
+    // --- unit: throttleDelayMillis ---
+
+    @Test
+    fun throttleDelay_exponentialSequence_noJitter() {
+        val expected = listOf(11000L, 22000L, 44000L, 88000L, 176000L)
+        expected.forEachIndexed { attempt, want ->
+            assertEquals(want, throttleDelayMillis(attempt, 0.0, 0.0))
+        }
+    }
+
+    @Test
+    fun throttleDelay_retryAfterPrecedence_andNonPositiveIgnored() {
+        assertEquals(7000L, throttleDelayMillis(3, 7.0, 0.0))
+        assertEquals(11000L, throttleDelayMillis(0, 0.0, 0.0))
+        assertEquals(22000L, throttleDelayMillis(1, -5.0, 0.0))
+    }
+
+    @Test
+    fun throttleDelay_jitterBounds() {
+        assertEquals(8250L, throttleDelayMillis(0, 0.0, -0.25))
+        assertEquals(13750L, throttleDelayMillis(0, 0.0, 0.25))
+    }
+
+    // --- unit: parseThrottle ---
+
+    @Test
+    fun parseThrottle_table() {
+        assertEquals(0.0, parseThrottle("""{"error":"throttled"}"""))
+        assertEquals(5.0, parseThrottle("""{"result_code":"throttled","retry_after":5}"""))
+        assertEquals(3.0, parseThrottle("""{"error":"throttled","retry_after":"3"}"""))
+        assertEquals(0.0, parseThrottle("""{"error":"throttled","retry_after":-2}"""))
+        assertNull(parseThrottle("""{"error":"key"}"""))
+        assertNull(parseThrottle("not json"))
+        assertNull(parseThrottle(""))
+    }
+
+    // --- e2e via getSecrets ---
+
+    private fun buildStorage(): KeyValueStorage {
+        val storage = InMemoryStorage()
+        initializeStorage(storage, fakeToken, "fake.keepersecurity.com")
+        // Seed an app key so the (non-bound) empty success response decrypts without error; the
+        // key itself is unused because the mocked responses carry no records.
+        storage.saveBytes(KEY_APP_KEY, ByteArray(32))
+        return storage
+    }
+
+    @Test
+    fun retriesThenSucceeds() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, transmissionKey, _ ->
+            calls++
+            if (calls == 1) {
+                KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+            } else {
+                val body = """{"records":[],"folders":[],"encryptedAppKey":null}""".toByteArray()
+                KeeperHttpResponse(HTTP_OK, encrypt(body, transmissionKey.key))
+            }
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        val secrets = getSecrets(options)
+        assertTrue(secrets.records.isEmpty())
+        assertEquals(1, sleeps.size)
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun exhaustionThrowsKeeperThrottleException() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            calls++
+            KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<KeeperThrottleException> { getSecrets(options) }
+        assertEquals(5, sleeps.size) // five backoff sleeps before giving up
+        assertEquals(6, calls) // 5 retries + the final throttled response
+    }
+
+    @Test
+    fun retryAfterIsHonored() {
+        var calls = 0
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            calls++
+            if (calls == 1) KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody(3.0))
+            else KeeperHttpResponse(HTTP_FORBIDDEN, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<KeeperThrottleException> { getSecrets(options) }
+        // retry_after = 3s with +/-25% jitter -> [2250ms, 3750ms]
+        assertTrue(sleeps[0] in 2250L..3750L, "first delay was ${sleeps[0]}ms")
+    }
+
+    @Test
+    fun nonThrottle403NotRetried() {
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            KeeperHttpResponse(HTTP_FORBIDDEN, """{"error":"access_denied","message":"nope"}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        val e = assertFailsWith<Exception> { getSecrets(options) }
+        assertFalse(e is KeeperThrottleException, "a non-throttle 403 must not become a throttle error")
+        assertEquals(0, sleeps.size)
+    }
+
+    @Test
+    fun non403ThrottleBodyNotRetried() {
+        // A 502 carrying a {"error":"throttled"} body must NOT be retried (403 gate).
+        val sleeps = mutableListOf<Long>()
+        val mock: QueryFunction = { _, _, _ ->
+            KeeperHttpResponse(502, throttleBody())
+        }
+        val options = SecretsManagerOptions(buildStorage(), mock, throttleSleepMillis = { sleeps.add(it) })
+
+        assertFailsWith<Exception> { getSecrets(options) }
+        assertEquals(0, sleeps.size)
+    }
+}


### PR DESCRIPTION
## Summary
Release branch for Java SDK v17.3.0 — eleven changes: throttle retry backoff with one-sided jitter and a retry-after cap, KeeperRecordLink accessor alignment, IL5 region support, a public SDK exception type, serialization correctness for record create, file attachment crash fixes, shared folder record decryption, null file URL handling, file descriptor leak fixes, and Base64 null guard.

> Continues from #975. That PR targeted `release/sdk/java/core/v17.2.1`; the release was promoted to a minor bump (17.2.1 → 17.3.0) because it carries a new feature (IL5 dynamic key, KSM-902) alongside the fixes. Same commits, retargeted to `release/sdk/java/core/v17.3.0` ([REL-5094](https://keeper.atlassian.net/browse/REL-5094)).

## Changes

### New Features
- **Throttle retry with exponential backoff** (KSM-878, refined by KSM-1032): `postQuery` now automatically retries HTTP 403 `{"error":"throttled"}` responses up to 5 times. Backoff starts at 11s (1s margin over the backend's 10s memcached TTL) with one-sided 0-25% jitter — a delay is only ever padded up, never undercuts the server's requested `retry_after` or the exponential floor; `retry_after` from the response body is honored when present, capped at 176s (`MAX_THROTTLE_DELAY_SEC`) so a misbehaving response can't force an excessive wait. Each retry logs a warning to stderr (gated on `loggingEnabled`). Exhausted retries throw `KeeperThrottleException` (public, catchable separately from `Exception`). `SecretsManagerOptions` accepts an injectable `throttleSleepMillis` hook for test overrides.
- **`KeeperRecordLink` accessor alignment with Python reference** (KSM-1008): recursive `jsonElementToValue`/`jsonObjectToMap` helpers preserve JSON nulls and typed scalars (String/Boolean/Int/Long/Double) across nested objects and arrays. `getBooleanValue` now supports an optional `checkAllowedSettings` parameter to look up permission flags nested under `allowedSettings` in `path:"meta"` links; `allowsRotation()` and related accessors updated accordingly. Added `KeeperRecordLinkTest` suite covering all accessor methods, nested structures, and null preservation.
- **IL5 region mapping** (KSM-902): added `"IL5" -> "il5.keepersecurity.us"` to the `initializeStorage()` region map in `SecretsManager.kt`. Tokens prefixed `IL5:` now route to the DoD Impact Level 5 environment. Extended OTT tokens are strictly validated to 2 or 4 segments; a malformed 3-segment token is now rejected rather than silently parsed as a 2-segment token with the third segment dropped. Region-prefix matching (`tokenParts[0].uppercase(...)`) is pinned to `Locale.US` — on a Turkish-locale JVM, `"il5".uppercase(Locale.getDefault())` produces `"İL5"` (dotted capital I), which would fail to match `"IL5"`.
- **Public SDK exception type** (KSM-1026): `SecretsManagerException` changed from `internal` to a public `open class`, so Java consumers can `catch (SecretsManagerException e)` to handle SDK-level errors by type instead of catching bare `Exception`. `SecureRandomException`/`SecureRandomSlowGenerationException` remain internal (no public use case identified).

### Bug Fixes
- **Custom field omitted from record create payload** (KSM-823): `KeeperRecordData.custom` defaulted to `null`, causing `kotlinx-serialization` to omit `"custom"` from the V3 API payload when no custom fields were set. Changed default to `mutableListOf()` and added `@EncodeDefault` to force inclusion. Regression test added.
- **KeeperFileData crash when `lastModified` absent** (KSM-854): files uploaded by non-SDK clients (iOS, Android, Web Vault) omit `lastModified`; `kotlinx-serialization` treated it as required, throwing `MissingFieldException` and silently dropping the attachment. Added `= 0` default, consistent with .NET SDK behavior (KSM-674).
- **Shared folder records return null fields** (KSM-753): records created via Commander/PowerShell in shared folders appear in `response.records[]` with `innerFolderUid` set, but their `recordKey` is encrypted with the folder key, not the app key. Now builds a folder-key map before processing flat records and uses the correct key when `innerFolderUid` matches.
- **NPE crash when file `url` absent** (KSM-765): `KeeperFile.url` and `SecretsManagerResponseFile.url` changed from `String` to `String?`; `downloadFile()` now throws a typed exception when `url` is null rather than crashing with an NPE.
- **File descriptor leaks** (KSM-855): `LocalConfigStorage` replaced four manual `stream.close()` patterns with Kotlin `.use { }` — the init block never closed its reader at all. `downloadFile`, `uploadFile`, and `postFunction` now wrap `HttpsURLConnection` in `try/finally` + `disconnect()` — `with()` is a scope function, not try-with-resources, and did not guarantee cleanup on exception.
- **Opaque NPE from Base64 decoders** (KSM-985): `base64ToBytes("")` and `webSafe64ToBytes("")` now throw a typed Keeper exception on empty input instead of an NPE from inside `java.util.Base64` (KSM-808 parity).

### Breaking Changes
- `KeeperFile.url` changed from `String` to `String?`. Callers that previously treated `url` as non-null must now handle the nullable case. This is a correctness fix — the server can omit this field and the previous behavior was an NPE crash.
- `KeeperRecordData.custom` changed from `MutableList<KeeperRecordField>?` to a non-null `MutableList<KeeperRecordField>` (KSM-823). Assigning `null` no longer compiles; use an empty list instead.
- `KEY_SERVER_PUBIC_KEY_ID` (the misspelled constant published in 17.2.0) is deprecated in favor of `KEY_SERVER_PUBLIC_KEY_ID`. The old name is retained as a `@Deprecated` alias so existing source and bytecode keep working; the stored config value (`"serverPublicKeyId"`) is unchanged.

## Related Issues
- Closes #973
- Supersedes #975
- KSM-878, KSM-1008, KSM-902, KSM-1026, KSM-823, KSM-854, KSM-753, KSM-765, KSM-855, KSM-985, KSM-1032

[REL-5094]: https://keeper.atlassian.net/browse/REL-5094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

