### PR TITLE
feat(sdk/java): align KeeperRecordLink accessors with Python reference (KSM-1008)

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -241,7 +241,7 @@ data class KeeperRecordLink(
     /**
      * Parse the link data as a JSON object, handling errors gracefully
      */
-    private fun parseJsonData(): Map<String, Any>? {
+    private fun parseJsonData(): Map<String, Any?>? {
         if (data == null) return null
         
         return try {
@@ -312,14 +312,14 @@ data class KeeperRecordLink(
 
     /**
      * Recursively convert a [JsonElement] to a plain Kotlin value: objects become
-     * `Map<String, Any>`, arrays become `List<Any>`, and primitives become typed scalars
+     * `Map<String, Any?>`, arrays become `List<Any?>`, and primitives become typed scalars
      * (String/Boolean/Int/Long/Double). Strings are never coerced, so a quoted "3"/"true"
-     * stays a String. JSON nulls are dropped by [jsonObjectToMap].
+     * stays a String. JSON nulls become Kotlin null and are preserved on both branches.
      */
     private fun jsonElementToValue(element: JsonElement): Any? = when (element) {
         is JsonNull -> null
         is JsonObject -> jsonObjectToMap(element)
-        is JsonArray -> element.mapNotNull { jsonElementToValue(it) }
+        is JsonArray -> element.map { jsonElementToValue(it) }
         is JsonPrimitive ->
             if (element.isString) element.content
             else element.booleanOrNull
@@ -330,11 +330,11 @@ data class KeeperRecordLink(
     }
 
     /**
-     * Convert a [JsonObject] to a nested `Map<String, Any>`, preserving nested objects and arrays
-     * (lossless). Keys whose value is JSON null are omitted.
+     * Convert a [JsonObject] to a nested `Map<String, Any?>`, preserving nested objects, arrays and
+     * JSON null values (lossless, matching the Python reference).
      */
-    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any> =
-        obj.entries.mapNotNull { (key, value) -> jsonElementToValue(value)?.let { key to it } }.toMap()
+    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any?> =
+        obj.entries.associate { (key, value) -> key to jsonElementToValue(value) }
 
     /**
      * Check if the link data indicates admin status for a user
@@ -409,20 +409,20 @@ data class KeeperRecordLink(
     /**
      * The `allowedSettings` object from the link data (empty map when absent).
      */
-    fun getAllowedSettings(): Map<String, Any> {
+    fun getAllowedSettings(): Map<String, Any?> {
         val parsed = parseJsonData() ?: return emptyMap()
         @Suppress("UNCHECKED_CAST")
-        return (parsed["allowedSettings"] as? Map<String, Any>) ?: emptyMap()
+        return (parsed["allowedSettings"] as? Map<String, Any?>) ?: emptyMap()
     }
 
     /**
      * The `rotation_settings` object from the link data (schedule, pwd_complexity, disabled, noop,
      * saas_record_uid_list), or null when absent.
      */
-    fun getRotationSettings(): Map<String, Any>? {
+    fun getRotationSettings(): Map<String, Any?>? {
         val parsed = parseJsonData() ?: return null
         @Suppress("UNCHECKED_CAST")
-        return parsed["rotation_settings"] as? Map<String, Any>
+        return parsed["rotation_settings"] as? Map<String, Any?>
     }
     
     /**
@@ -517,7 +517,7 @@ data class KeeperRecordLink(
      * @return Parsed data as a Map, or null if parsing fails
      */
     @JvmOverloads
-    fun getLinkData(recordKey: ByteArray? = null): Map<String, Any>? {
+    fun getLinkData(recordKey: ByteArray? = null): Map<String, Any?>? {
         if (data == null) return null
         
         // First, try to decode and check if it's plain JSON
@@ -546,7 +546,7 @@ data class KeeperRecordLink(
     /**
      * Helper method to parse JSON string to Map
      */
-    private fun parseJsonToMap(jsonString: String): Map<String, Any>? {
+    private fun parseJsonToMap(jsonString: String): Map<String, Any?>? {
         return try {
             val jsonElement = Json.parseToJsonElement(jsonString)
             when (jsonElement) {
@@ -590,7 +590,7 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key
      * @return Settings data as a Map, or null if not available
      */
-    fun getAiSettingsData(recordKey: ByteArray): Map<String, Any>? {
+    fun getAiSettingsData(recordKey: ByteArray): Map<String, Any?>? {
         if (path != "ai_settings") return null
         return getLinkData(recordKey)
     }
@@ -611,7 +611,7 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key
      * @return Settings data as a Map, or null if not available
      */
-    fun getJitSettingsData(recordKey: ByteArray): Map<String, Any>? {
+    fun getJitSettingsData(recordKey: ByteArray): Map<String, Any?>? {
         if (path != "jit_settings") return null
         return getLinkData(recordKey)
     }
@@ -628,7 +628,7 @@ data class KeeperRecordLink(
      * @return Settings data as a Map, or null if path doesn't match or parsing fails
      */
     @JvmOverloads
-    fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any>? {
+    fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any?>? {
         if (path != settingsPath) return null
         return getLinkData(recordKey)
     }
@@ -641,7 +641,7 @@ data class KeeperRecordLink(
      * the key is accepted for forward compatibility.
      */
     @JvmOverloads
-    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any>? = getSettingsForPath("meta", recordKey)
+    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any?>? = getSettingsForPath("meta", recordKey)
 }
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -8,6 +8,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.doubleOrNull
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URI
 import java.security.KeyManagementException
@@ -204,6 +211,26 @@ private data class SecretsManagerResponseRecord(
     val links: List<KeeperRecordLink>? = null
 )
 
+/**
+ * Typed view over a single linked-credential entry of a record (the entries in [KeeperRecord.links]).
+ *
+ * A link entry carries [recordUid], optional base64 [data], and an optional [path] discriminator.
+ * Observed payload shapes (verified against the live backend):
+ *
+ * - path "meta" (self-link, recordUid == owning record): plain base64 JSON with `allowedSettings`
+ *   (rotation, connections, portForwards, sessionRecording, typescriptRecording, aiEnabled,
+ *   aiSessionTerminate, remoteBrowserIsolation), plus `rotateOnTermination`, `version` and
+ *   `no_update_services`.
+ * - path null (credential link to another record): plain base64 JSON with `is_admin`,
+ *   `is_launch_credential`, `is_iam_user`, `belongs_to` and `rotation_settings`; or no data at all
+ *   (a pure record reference).
+ * - path "ai_settings" / "jit_settings" (self-links): data is AES-256-GCM encrypted under the
+ *   owning record's key — see [getDecryptedData].
+ *
+ * Accessors never throw: parse, decode or decryption failures yield null/false. [getLinkData]
+ * returns the complete parsed payload with nested objects and arrays preserved, so fields unknown
+ * to this SDK version are retained.
+ */
 @Serializable
 data class KeeperRecordLink(
     val recordUid: String,
@@ -228,22 +255,7 @@ data class KeeperRecordLink(
             
             val jsonElement = Json.parseToJsonElement(decodedData)
             if (jsonElement is JsonObject) {
-                jsonElement.entries.associate { (key, value) ->
-                    key to when {
-                        value is JsonPrimitive && value.isString -> value.content
-                        value is JsonPrimitive -> {
-                            // Try to parse as different types
-                            when {
-                                value.content == "true" -> true
-                                value.content == "false" -> false
-                                value.content.toIntOrNull() != null -> value.content.toInt()
-                                value.content.toLongOrNull() != null -> value.content.toLong()
-                                else -> value.content
-                            }
-                        }
-                        else -> value.toString()
-                    }
-                }
+                jsonObjectToMap(jsonElement)
             } else {
                 // Only log if it looked like JSON but wasn't a JSON object
                 System.err.println("KeeperRecordLink: Link data is not a JSON object (was JSON array or primitive)")
@@ -268,10 +280,20 @@ data class KeeperRecordLink(
     }
 
     /**
-     * Get a boolean value from the parsed JSON data
+     * Get a strict boolean value from the parsed JSON data; missing or non-boolean values are false.
+     *
+     * When [checkAllowedSettings] is true the nested `allowedSettings` object is consulted if the
+     * key is absent at the top level — a top-level boolean wins. The backend nests permission flags
+     * under `allowedSettings` in `path:"meta"` links.
      */
-    private fun getBooleanValue(key: String): Boolean {
-        return parseJsonData()?.get(key) as? Boolean ?: false
+    private fun getBooleanValue(key: String, checkAllowedSettings: Boolean = false): Boolean {
+        val parsed = parseJsonData() ?: return false
+        (parsed[key] as? Boolean)?.let { return it }
+        if (checkAllowedSettings) {
+            val allowed = parsed["allowedSettings"] as? Map<*, *>
+            (allowed?.get(key) as? Boolean)?.let { return it }
+        }
+        return false
     }
 
     /**
@@ -289,6 +311,32 @@ data class KeeperRecordLink(
     }
 
     /**
+     * Recursively convert a [JsonElement] to a plain Kotlin value: objects become
+     * `Map<String, Any>`, arrays become `List<Any>`, and primitives become typed scalars
+     * (String/Boolean/Int/Long/Double). Strings are never coerced, so a quoted "3"/"true"
+     * stays a String. JSON nulls are dropped by [jsonObjectToMap].
+     */
+    private fun jsonElementToValue(element: JsonElement): Any? = when (element) {
+        is JsonNull -> null
+        is JsonObject -> jsonObjectToMap(element)
+        is JsonArray -> element.mapNotNull { jsonElementToValue(it) }
+        is JsonPrimitive ->
+            if (element.isString) element.content
+            else element.booleanOrNull
+                ?: element.intOrNull
+                ?: element.longOrNull
+                ?: element.doubleOrNull
+                ?: element.content
+    }
+
+    /**
+     * Convert a [JsonObject] to a nested `Map<String, Any>`, preserving nested objects and arrays
+     * (lossless). Keys whose value is JSON null are omitted.
+     */
+    private fun jsonObjectToMap(obj: JsonObject): Map<String, Any> =
+        obj.entries.mapNotNull { (key, value) -> jsonElementToValue(value)?.let { key to it } }.toMap()
+
+    /**
      * Check if the link data indicates admin status for a user
      */
     fun isAdminUser(): Boolean = getBooleanValue("is_admin")
@@ -301,37 +349,81 @@ data class KeeperRecordLink(
     /**
      * Check if rotation is allowed based on link settings
      */
-    fun allowsRotation(): Boolean = getBooleanValue("rotation")
+    fun allowsRotation(): Boolean = getBooleanValue("rotation", checkAllowedSettings = true)
     
     /**
      * Check if connections are allowed based on link settings
      */
-    fun allowsConnections(): Boolean = getBooleanValue("connections")
+    fun allowsConnections(): Boolean = getBooleanValue("connections", checkAllowedSettings = true)
     
     /**
      * Check if port forwards are allowed based on link settings
      */
-    fun allowsPortForwards(): Boolean = getBooleanValue("portForwards")
+    fun allowsPortForwards(): Boolean = getBooleanValue("portForwards", checkAllowedSettings = true)
     
     /**
      * Check if session recording is enabled
      */
-    fun allowsSessionRecording(): Boolean = getBooleanValue("sessionRecording")
+    fun allowsSessionRecording(): Boolean = getBooleanValue("sessionRecording", checkAllowedSettings = true)
     
     /**
      * Check if TypeScript recording is enabled
      */
-    fun allowsTypescriptRecording(): Boolean = getBooleanValue("typescriptRecording")
+    fun allowsTypescriptRecording(): Boolean = getBooleanValue("typescriptRecording", checkAllowedSettings = true)
     
     /**
      * Check if remote browser isolation is enabled
      */
-    fun allowsRemoteBrowserIsolation(): Boolean = getBooleanValue("remoteBrowserIsolation")
+    fun allowsRemoteBrowserIsolation(): Boolean = getBooleanValue("remoteBrowserIsolation", checkAllowedSettings = true)
     
     /**
      * Check if rotation on termination is enabled
      */
     fun rotatesOnTermination(): Boolean = getBooleanValue("rotateOnTermination")
+
+    /**
+     * Whether the linked user is an IAM user (`is_iam_user`).
+     */
+    fun isIamUser(): Boolean = getBooleanValue("is_iam_user")
+
+    /**
+     * Whether the linked credential belongs to the record (`belongs_to`).
+     */
+    fun belongsTo(): Boolean = getBooleanValue("belongs_to")
+
+    /**
+     * Whether service updates are disabled for this link (`no_update_services`).
+     */
+    fun noUpdateServices(): Boolean = getBooleanValue("no_update_services")
+
+    /**
+     * Whether AI features are enabled (`aiEnabled`, top-level or in `allowedSettings`).
+     */
+    fun aiEnabled(): Boolean = getBooleanValue("aiEnabled", checkAllowedSettings = true)
+
+    /**
+     * Whether AI session termination is enabled (`aiSessionTerminate`, top-level or in `allowedSettings`).
+     */
+    fun aiSessionTerminate(): Boolean = getBooleanValue("aiSessionTerminate", checkAllowedSettings = true)
+
+    /**
+     * The `allowedSettings` object from the link data (empty map when absent).
+     */
+    fun getAllowedSettings(): Map<String, Any> {
+        val parsed = parseJsonData() ?: return emptyMap()
+        @Suppress("UNCHECKED_CAST")
+        return (parsed["allowedSettings"] as? Map<String, Any>) ?: emptyMap()
+    }
+
+    /**
+     * The `rotation_settings` object from the link data (schedule, pwd_complexity, disabled, noop,
+     * saas_record_uid_list), or null when absent.
+     */
+    fun getRotationSettings(): Map<String, Any>? {
+        val parsed = parseJsonData() ?: return null
+        @Suppress("UNCHECKED_CAST")
+        return parsed["rotation_settings"] as? Map<String, Any>
+    }
     
     /**
      * Get the link data version (if available)
@@ -435,9 +527,10 @@ data class KeeperRecordLink(
             return null
         }
         
-        // If it looks like JSON, parse it directly
+        // If it looks like JSON, parse it directly; if that fails (coincidental ciphertext that
+        // happens to start with { or [), fall through to decryption rather than giving up.
         if (decodedData.startsWith("{") || decodedData.startsWith("[")) {
-            return parseJsonToMap(decodedData)
+            parseJsonToMap(decodedData)?.let { return it }
         }
         
         // If not JSON and we have a key, try decryption
@@ -457,30 +550,7 @@ data class KeeperRecordLink(
         return try {
             val jsonElement = Json.parseToJsonElement(jsonString)
             when (jsonElement) {
-                is JsonObject -> {
-                    jsonElement.entries.associate { (key, value) ->
-                        key to when (value) {
-                            is JsonPrimitive -> {
-                                when {
-                                    value.isString -> value.content
-                                    else -> {
-                                        // Try to parse as different types
-                                        when {
-                                            value.content == "true" -> true
-                                            value.content == "false" -> false
-                                            value.content.toIntOrNull() != null -> value.content.toInt()
-                                            value.content.toLongOrNull() != null -> value.content.toLong()
-                                            value.content.toDoubleOrNull() != null -> value.content.toDouble()
-                                            else -> value.content
-                                        }
-                                    }
-                                }
-                            }
-                            is JsonObject -> value.toString() // Nested objects as strings
-                            is kotlinx.serialization.json.JsonArray -> value.toString() // Arrays as strings
-                        }
-                    }
-                }
+                is JsonObject -> jsonObjectToMap(jsonElement)
                 else -> null
             }
         } catch (e: Exception) {
@@ -509,12 +579,10 @@ data class KeeperRecordLink(
     /**
      * Get AI settings data from this link
      * 
-     * Known fields for ai_settings (as of SDK v17.1.0):
-     * - aiEnabled: Boolean - Whether AI features are enabled
-     * - aiModel: String - The AI model being used
-     * - aiProvider: String - The AI provider (e.g., "openai", "anthropic")
-     * - aiSessionTerminate: Boolean - Whether to terminate AI session
-     * - allowedSettings: Map - Nested settings for allowed operations
+     * Encrypted under the owning record's key. Known fields (live-verified):
+     * - version: String - settings schema version, e.g. "v1.0.0"
+     * - riskLevels: Map - critical/high/medium/low, each with `tags` (allow/deny lists)
+     *   and `aiSessionTerminate`
      * 
      * Note: Additional fields may be present in newer versions.
      * The returned Map will preserve all fields sent by the server.
@@ -530,17 +598,12 @@ data class KeeperRecordLink(
     /**
      * Get JIT (Just-In-Time) settings data from this link
      * 
-     * Known fields for jit_settings (as of SDK v17.1.0):
-     * - enabled: Boolean - Whether JIT access is enabled
-     * - ttl: Int - Time-to-live in seconds
-     * - maxUses: Int - Maximum number of uses allowed
-     * - expiresAt: Long - Expiration timestamp in milliseconds
-     * - allowedSettings: Map - Nested settings for allowed operations:
-     *   - rotation: Boolean - Allow credential rotation
-     *   - connections: Boolean - Allow connections
-     *   - portForwards: Boolean - Allow port forwarding
-     *   - sessionRecording: Boolean - Enable session recording
-     *   - typescriptRecording: Boolean - Enable TypeScript recording
+     * Encrypted under the owning record's key. Known fields (live-verified):
+     * - createEphemeral: Boolean
+     * - elevate: Boolean
+     * - elevationMethod: String
+     * - elevationString: String
+     * - baseDistinguishedName: String
      * 
      * Note: Additional fields may be present in newer versions.
      * The returned Map will preserve all fields sent by the server.
@@ -564,10 +627,21 @@ data class KeeperRecordLink(
      * @param recordKey The record's encryption key (required for encrypted data)
      * @return Settings data as a Map, or null if path doesn't match or parsing fails
      */
+    @JvmOverloads
     fun getSettingsForPath(settingsPath: String, recordKey: ByteArray? = null): Map<String, Any>? {
         if (path != settingsPath) return null
         return getLinkData(recordKey)
     }
+
+    /**
+     * Get PAM settings data from this link — only when [path] == "meta".
+     *
+     * Meta links are self-links (recordUid == owning record) carrying the record's own PAM settings:
+     * `allowedSettings`, `rotateOnTermination`, `version`, `no_update_services`. Plain JSON today;
+     * the key is accepted for forward compatibility.
+     */
+    @JvmOverloads
+    fun getMetaData(recordKey: ByteArray? = null): Map<String, Any>? = getSettingsForPath("meta", recordKey)
 }
 
 @Serializable

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
@@ -295,15 +295,20 @@ class KeeperRecordLinkTest {
 
     @Test
     fun losslessnessPreservesNestedStructures() {
-        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}}""")
+        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}, "maybe": null, "list": [1, null, 2]}""")
         val data = link.getLinkData()
         assertNotNull(data)
 
         val future = data["futureField"]
         assertTrue(future is Map<*, *>)               // nested object preserved as a Map, not a String
         @Suppress("UNCHECKED_CAST")
-        val nested = (future as Map<String, Any>)["nested"]
+        val nested = (future as Map<String, Any?>)["nested"]
         assertEquals(listOf(1, 2, 3), nested)         // nested array preserved as a List of ints
+
+        // JSON nulls are preserved (matching the Python reference), not dropped.
+        assertTrue(data.containsKey("maybe"))
+        assertNull(data["maybe"])
+        assertEquals(listOf(1, null, 2), data["list"])
 
         // Raw link fields are untouched.
         assertEquals("RU_test", link.recordUid)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
@@ -1,0 +1,330 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the [KeeperRecordLink] typed accessor layer.
+ *
+ * Mirrors the Python reference suite `sdk/python/core/tests/record_link_test.py` (KSM-992, PR #1036)
+ * so the Java accessors match the live-verified backend payload shapes: permission booleans with an
+ * `allowedSettings` fallback (top-level wins), the new credential/meta accessors, lossless
+ * `getLinkData()`, and the encrypted ai/jit settings.
+ */
+class KeeperRecordLinkTest {
+
+    private val recordKey: ByteArray = getRandomBytes(32)
+
+    /** Build a link whose data is base64 of the given plain JSON payload. */
+    private fun plainLink(json: String, path: String? = null, recordUid: String = "RU_test") =
+        KeeperRecordLink(recordUid, bytesToBase64(json.toByteArray(Charsets.UTF_8)), path)
+
+    /** Build a link whose data is base64 of the payload encrypted (AES-256-GCM) under [key]. */
+    private fun encryptedLink(json: String, key: ByteArray, path: String? = null, recordUid: String = "RU_test") =
+        KeeperRecordLink(recordUid, bytesToBase64(encrypt(json.toByteArray(Charsets.UTF_8), key)), path)
+
+    /**
+     * Produce a base64 AES-GCM ciphertext whose first decoded byte equals [marker] ('{' or '[').
+     * The IV is random per call, so we re-encrypt until we hit the marker (~1/256 each try). The
+     * result is a real, decryptable ciphertext that also trips the plain-JSON fast path.
+     */
+    private fun ciphertextStartingWith(marker: Char, json: String, key: ByteArray): String {
+        val target = marker.code.toByte()
+        repeat(100_000) {
+            val ct = encrypt(json.toByteArray(Charsets.UTF_8), key)
+            if (ct.isNotEmpty() && ct[0] == target) return bytesToBase64(ct)
+        }
+        throw IllegalStateException("Could not generate ciphertext starting with '$marker'")
+    }
+
+    @Test
+    fun booleanAccessorsReadPlainJson() {
+        val link = plainLink("""{"is_admin": true, "rotation": true, "connections": false}""")
+        assertTrue(link.isAdminUser())
+        assertTrue(link.allowsRotation())
+        assertFalse(link.allowsConnections())
+        assertFalse(link.allowsPortForwards())
+        assertFalse(link.isLaunchCredential())
+        assertFalse(link.isIamUser())
+        assertFalse(link.belongsTo())
+        assertFalse(link.noUpdateServices())
+    }
+
+    @Test
+    fun versionAndDecodedData() {
+        val link = plainLink("""{"version": 3, "is_admin": false}""")
+        assertEquals(3, link.getLinkDataVersion())
+        assertTrue(link.getDecodedData()!!.startsWith("{"))
+        assertTrue(link.hasReadableData())
+
+        val notJson = plainLink("not json at all")
+        assertFalse(notJson.hasReadableData())
+        assertNull(notJson.getLinkDataVersion())
+
+        val badBase64 = KeeperRecordLink("RU_test", "!!! not base64 !!!", null)
+        assertNull(badBase64.getDecodedData())
+        assertNull(badBase64.getLinkData())
+    }
+
+    @Test
+    fun mightBeEncryptedByPath() {
+        assertTrue(plainLink("{}", path = "ai_settings").mightBeEncrypted())
+        assertTrue(plainLink("{}", path = "jit_settings").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = "meta").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = "something_else").mightBeEncrypted())
+        assertFalse(plainLink("{}", path = null).mightBeEncrypted())
+    }
+
+    @Test
+    fun getDecryptedDataRoundtrip() {
+        val link = encryptedLink("""{"enabled": true, "ttl": 3600}""", recordKey, path = "jit_settings")
+        val decrypted = link.getDecryptedData(recordKey)
+        assertNotNull(decrypted)
+        assertTrue(decrypted.contains("enabled"))
+        assertNull(link.getDecryptedData(null))
+        assertNull(link.getDecryptedData(getRandomBytes(32))) // wrong key fails gracefully
+    }
+
+    @Test
+    fun getLinkDataPlainAndEncrypted() {
+        val plain = plainLink("""{"aiEnabled": true}""", path = "ai_settings")
+        assertEquals(true, plain.getLinkData()!!["aiEnabled"])
+
+        val encrypted = encryptedLink("""{"enabled": true}""", recordKey, path = "jit_settings")
+        assertNull(encrypted.getLinkData())              // can't decrypt without a key
+        assertEquals(true, encrypted.getLinkData(recordKey)!!["enabled"])
+    }
+
+    @Test
+    fun settingsPathFilters() {
+        val ai = plainLink("""{"aiEnabled": true}""", path = "ai_settings")
+        val jit = plainLink("""{"enabled": true}""", path = "jit_settings")
+
+        assertNotNull(ai.getAiSettingsData(recordKey))
+        assertNull(ai.getJitSettingsData(recordKey))
+        assertNotNull(jit.getJitSettingsData(recordKey))
+        assertNull(jit.getAiSettingsData(recordKey))
+        assertNotNull(ai.getSettingsForPath("ai_settings"))
+        assertNull(ai.getSettingsForPath("other"))
+    }
+
+    @Test
+    fun stringEncodedValuesAreNotCoerced() {
+        val strings = plainLink("""{"is_admin": "true", "rotation": "false", "version": "3"}""")
+        assertFalse(strings.isAdminUser())          // "true" string is not a boolean
+        assertFalse(strings.allowsRotation())       // "false" string is not a boolean
+        assertNull(strings.getLinkDataVersion())    // "3" string is not an integer
+
+        val real = plainLink("""{"is_admin": true, "version": 3}""")
+        assertTrue(real.isAdminUser())
+        assertEquals(3, real.getLinkDataVersion())
+
+        // A JSON boolean must not be read as an integer version.
+        assertNull(plainLink("""{"version": true}""").getLinkDataVersion())
+    }
+
+    @Test
+    fun hasEncryptedDataDetection() {
+        // Non-printable bytes that are neither a JSON object nor printable text.
+        val encryptedLooking = KeeperRecordLink("RU_test", bytesToBase64(ByteArray(40) { (it % 32).toByte() }), null)
+        assertTrue(encryptedLooking.hasEncryptedData())
+
+        assertFalse(plainLink("just plain readable text, not json").hasEncryptedData())
+        assertFalse(plainLink("""{"a": 1}""").hasEncryptedData())
+        assertFalse(KeeperRecordLink("RU_test", null, null).hasEncryptedData())
+    }
+
+    @Test
+    fun getSettingsForPathEncrypted() {
+        val link = encryptedLink("""{"customSetting": 42}""", recordKey, path = "custom_settings")
+        assertEquals(42, link.getSettingsForPath("custom_settings", recordKey)!!["customSetting"])
+        assertNull(link.getSettingsForPath("other", recordKey))
+    }
+
+    @Test
+    fun metaLinkLiveShape() {
+        val meta = plainLink(
+            """
+            {
+              "allowedSettings": {
+                "rotation": true,
+                "connections": true,
+                "portForwards": true,
+                "sessionRecording": true,
+                "typescriptRecording": false,
+                "aiEnabled": true,
+                "aiSessionTerminate": true,
+                "remoteBrowserIsolation": true
+              },
+              "rotateOnTermination": false,
+              "version": 1,
+              "no_update_services": true
+            }
+            """.trimIndent(),
+            path = "meta"
+        )
+
+        // Permission booleans are absent at the top level — read via the allowedSettings fallback.
+        assertTrue(meta.allowsRotation())
+        assertTrue(meta.allowsConnections())
+        assertTrue(meta.allowsPortForwards())
+        assertTrue(meta.allowsSessionRecording())
+        assertFalse(meta.allowsTypescriptRecording())
+        assertTrue(meta.allowsRemoteBrowserIsolation())
+        assertTrue(meta.aiEnabled())
+        assertTrue(meta.aiSessionTerminate())
+
+        assertFalse(meta.rotatesOnTermination())   // top-level
+        assertEquals(1, meta.getLinkDataVersion())
+        assertTrue(meta.noUpdateServices())        // top-level
+
+        assertEquals(true, meta.getAllowedSettings()["rotation"])
+        assertNotNull(meta.getMetaData())
+        assertNull(plainLink("{}", path = null).getMetaData()) // path-gated
+    }
+
+    @Test
+    fun topLevelWinsOverAllowedSettings() {
+        val both = plainLink("""{"rotation": false, "allowedSettings": {"rotation": true}}""")
+        assertFalse(both.allowsRotation())          // top-level false wins
+
+        val fallbackOnly = plainLink("""{"allowedSettings": {"rotation": true}}""")
+        assertTrue(fallbackOnly.allowsRotation())   // fallback applies when top-level absent
+    }
+
+    @Test
+    fun credentialLinkLiveShape() {
+        val credential = plainLink(
+            """
+            {
+              "is_admin": true,
+              "is_iam_user": false,
+              "belongs_to": true,
+              "is_launch_credential": true,
+              "rotation_settings": {
+                "schedule": "",
+                "pwd_complexity": "ZmFrZS1jb21wbGV4aXR5",
+                "disabled": false,
+                "noop": false,
+                "saas_record_uid_list": []
+              }
+            }
+            """.trimIndent()
+        )
+        assertTrue(credential.isAdminUser())
+        assertFalse(credential.isIamUser())
+        assertTrue(credential.belongsTo())
+        assertTrue(credential.isLaunchCredential())
+
+        val rotation = credential.getRotationSettings()
+        assertNotNull(rotation)
+        assertEquals("", rotation["schedule"])
+        assertEquals(false, rotation["disabled"])
+        assertEquals(emptyList<Any>(), rotation["saas_record_uid_list"])
+
+        assertNull(plainLink("""{"is_admin": true}""").getRotationSettings())
+    }
+
+    @Test
+    fun dataLessReferenceLink() {
+        val ref = KeeperRecordLink("RU_ref", null, null)
+        assertEquals("RU_ref", ref.recordUid)
+        assertFalse(ref.isAdminUser())
+        assertFalse(ref.allowsRotation())
+        assertNull(ref.getLinkDataVersion())
+        assertNull(ref.getDecodedData())
+        assertNull(ref.getDecryptedData(recordKey))
+        assertNull(ref.getLinkData())
+        assertTrue(ref.getAllowedSettings().isEmpty())
+        assertNull(ref.getRotationSettings())
+        assertFalse(ref.hasReadableData())
+        assertFalse(ref.hasEncryptedData())
+    }
+
+    @Test
+    fun aiSettingsLiveShape() {
+        val ai = encryptedLink(
+            """
+            {
+              "version": "v1.0.0",
+              "riskLevels": {
+                "critical": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "high": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "medium": {"tags": {"allow": [], "deny": []}, "aiSessionTerminate": true},
+                "low": {"tags": {"allow": []}, "aiSessionTerminate": false}
+              }
+            }
+            """.trimIndent(),
+            recordKey,
+            path = "ai_settings"
+        )
+        val data = ai.getAiSettingsData(recordKey)
+        assertNotNull(data)
+        assertEquals("v1.0.0", data["version"])
+        assertTrue(data["riskLevels"] is Map<*, *>)   // nested object preserved, not stringified
+        assertNull(ai.getLinkDataVersion())            // string version is not an integer
+    }
+
+    @Test
+    fun jitSettingsLiveShape() {
+        val jit = encryptedLink(
+            """
+            {
+              "createEphemeral": true,
+              "elevate": true,
+              "elevationMethod": "group",
+              "elevationString": "arn:aws",
+              "baseDistinguishedName": ""
+            }
+            """.trimIndent(),
+            recordKey,
+            path = "jit_settings"
+        )
+        val data = jit.getJitSettingsData(recordKey)
+        assertNotNull(data)
+        assertEquals(true, data["createEphemeral"])
+        assertEquals(true, data["elevate"])
+        assertEquals("group", data["elevationMethod"])
+        assertEquals("arn:aws", data["elevationString"])
+        assertEquals("", data["baseDistinguishedName"])
+    }
+
+    @Test
+    fun losslessnessPreservesNestedStructures() {
+        val link = plainLink("""{"is_admin": true, "futureField": {"nested": [1, 2, 3]}}""")
+        val data = link.getLinkData()
+        assertNotNull(data)
+
+        val future = data["futureField"]
+        assertTrue(future is Map<*, *>)               // nested object preserved as a Map, not a String
+        @Suppress("UNCHECKED_CAST")
+        val nested = (future as Map<String, Any>)["nested"]
+        assertEquals(listOf(1, 2, 3), nested)         // nested array preserved as a List of ints
+
+        // Raw link fields are untouched.
+        assertEquals("RU_test", link.recordUid)
+        assertNull(link.path)
+        assertNotNull(link.data)
+    }
+
+    @Test
+    fun ciphertextWithJsonLikeFirstByte() {
+        val payload = """{"createEphemeral": true, "elevate": true}"""
+        for (marker in listOf('{', '[')) {
+            val link = KeeperRecordLink("RU_test", ciphertextStartingWith(marker, payload, recordKey), "jit_settings")
+            assertEquals(marker, link.getDecodedData()!![0])
+            assertNull(link.getLinkData(null))         // leading {/[ is coincidental; no key -> null
+            val data = link.getLinkData(recordKey)     // falls through to decryption
+            assertNotNull(data)
+            assertEquals(true, data["createEphemeral"])
+            assertEquals(true, data["elevate"])
+            assertNotNull(link.getJitSettingsData(recordKey))
+        }
+        // Plain JSON is unaffected and parses without a key.
+        assertEquals(1, plainLink("""{"a": 1}""").getLinkData()!!["a"])
+    }
+}


### PR DESCRIPTION
## Summary

`KeeperRecordLink`'s accessors were stale against the live backend. The PAM permission flags now arrive nested under `allowedSettings` on `path:"meta"` self-links, but the booleans (`allowsRotation()`, …) only read top-level keys — so they returned `false` on all current `meta` data. This aligns the Java accessors with the Python reference (KSM-992, #1036), already shipped for Rust (KSM-1009, #1037) and JavaScript (KSM-1010).

**Purely additive — no protocol/wire changes; raw `links` deserialization is unchanged.**

## What changes

- **`allowedSettings` fallback (top-level wins).** `allowsRotation`, `allowsConnections`, `allowsPortForwards`, `allowsSessionRecording`, `allowsTypescriptRecording`, `allowsRemoteBrowserIsolation` now read the top-level key first, then fall back to the nested `allowedSettings` object.
- **New accessors:** `isIamUser()`, `belongsTo()`, `noUpdateServices()`, `aiEnabled()`, `aiSessionTerminate()`, `getAllowedSettings()`, `getRotationSettings()`, and `getMetaData()` (path-gated to `"meta"`).
- **Lossless `getLinkData()`.** A single shared recursive JSON converter (objects → `Map`, arrays → `List`, primitives → typed scalars) replaces the previous `value.toString()` stringification, so nested objects/arrays are preserved. `getLinkData()` also falls through to decryption when ciphertext coincidentally starts with `{`/`[`.
- **KDoc refresh** for the class and `getAiSettingsData`/`getJitSettingsData` to the live-verified payload shapes (drops the stale "as of SDK v17.1.0" field lists).
- Strict typing preserved: quoted `"3"`/`"true"` are not coerced to int/bool.

## Why it matters

On current data, every PAM permission boolean returns `false` because the flags moved into `allowedSettings` — callers can't tell what a linked credential is actually allowed to do. This fixes that and adds the credential/meta/AI accessors the other SDKs already expose.

## Tests

New `KeeperRecordLinkTest` (17 cases, mirroring Python `tests/record_link_test.py`); existing suites unaffected. `./gradlew test` → **46 tests, 0 failures** (KeeperRecordLinkTest 17/17, SecretsManagerTest 14/14).

| Test | Asserts |
|------|---------|
| `metaLinkLiveShape` | all eight permission booleans read via the `allowedSettings` fallback on a `path:"meta"` payload; `version` / `no_update_services` / `getAllowedSettings` / `getMetaData` |
| `topLevelWinsOverAllowedSettings` | a top-level boolean overrides `allowedSettings`; fallback applies only when the key is absent |
| `credentialLinkLiveShape` | `is_admin` / `is_iam_user` / `belongs_to` / `is_launch_credential` + nested `rotation_settings`; absent → null |
| `dataLessReferenceLink` | pure record reference (no data) → every accessor null/false/empty |
| `aiSettingsLiveShape`, `jitSettingsLiveShape` | encrypted payloads decrypt; nested structures preserved; string `version` ⇒ `getLinkDataVersion()` null |
| `losslessnessPreservesNestedStructures` | `getLinkData()` returns nested objects/arrays as `Map`/`List`, not strings |
| `ciphertextWithJsonLikeFirstByte` | ciphertext starting with `{`/`[` falls through to decryption; no key ⇒ null |
| + 10 more | boolean defaults, strict typing / no coercion, version & decoded-data, `mightBeEncrypted` by path, decrypt roundtrip + wrong key, plain-vs-encrypted, path-gating, encrypted-data detection |

## Follow-ups (not in this PR)

- .NET (KSM-1011) and Ruby (KSM-1013) still need the same accessor update; both are in Triage.

Jira: KSM-1008
