### PR TITLE
feat(sdk/ruby): add KeeperRecordLink typed accessors and get_links (KSM-1013)

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [17.2.0]
 
 ### Added
+- KSM-1013 - Typed linked-credential accessors: `KeeperRecordLink` (via `KeeperRecord#get_links`) wraps each raw `links` entry with never-raising typed accessors — permission booleans with an `allowedSettings` fallback (top-level wins), AES-256-GCM `get_decrypted_data`/`get_link_data`, and `meta`/`ai_settings`/`jit_settings` settings accessors. Adds a `request_links:` keyword to `get_secrets`. Purely additive; the raw `record.links` list is unchanged. Mirrors the Python reference (KSM-992).
 - KSM-883 - Automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `post_query` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus 0–25% jitter (one-sided, so the delay always meets or exceeds the floor), honoring `retry_after` from the response when present, and raises `ThrottledError` once retries are exhausted. Replaces the previous fixed 60-second sleep (which had no backoff, jitter, or retry cap). Existing key-rotation retry behavior is unchanged.
 
 ### Fixed

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -8,6 +8,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - KSM-685 - Fixed `CreateOptions.subfolder_uid` parameter API transmission
 - KSM-686 - Implemented disaster recovery caching with `CachingPostFunction`
 - KSM-687 - Added missing DTO fields for complete SDK parity (links, is_editable, inner_folder_uid, thumbnail_url, last_modified, expires_on)
+- KSM-1013 - Added typed linked-credential accessors (`KeeperRecordLink` via `record.get_links`) and a `request_links:` option on `get_secrets`
 - KSM-692 - Added HTTP proxy support for enterprise environments
 - KSM-694 - Added convenience methods (`upload_file_from_path`, `try_get_notation`)
 - KSM-696 - Fixed file permissions for Ruby SDK config files
@@ -54,6 +55,30 @@ records = secrets_manager.get_secrets
 record = records.first
 puts "Password: #{record.password}"
 ```
+
+## Linked Credentials (PAM)
+
+PAM records can carry linked credentials. Request them with `request_links: true`, then use the typed `KeeperRecordLink` accessors returned by `record.get_links` (the raw entries remain available on `record.links`):
+
+```ruby
+records = secrets_manager.get_secrets(request_links: true)
+
+records.each do |record|
+  record.get_links.each do |link|
+    puts "-> #{link.record_uid} (path: #{link.path.inspect})"
+
+    # Permission booleans read allowedSettings when nested (e.g. on "meta" links)
+    puts "  rotation allowed: #{link.allows_rotation?}"
+    puts "  admin user: #{link.admin_user?}"
+
+    # Encrypted ai_settings / jit_settings decrypt with the owning record's key
+    ai = link.get_ai_settings_data(record.record_key)
+    puts "  ai settings: #{ai.inspect}" if ai
+  end
+end
+```
+
+Accessors never raise — decode or decryption failures return `nil`/`false`.
 
 ## Proxy Support
 

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -97,10 +97,10 @@ module KeeperSecretsManager
       end
 
       # Get secrets with optional filtering
-      def get_secrets(uids = nil, full_response: false)
+      def get_secrets(uids = nil, full_response: false, request_links: false)
         uids = [uids] if uids.is_a?(String)
 
-        query_options = Dto::QueryOptions.new(records: uids, folders: nil)
+        query_options = Dto::QueryOptions.new(records: uids, folders: nil, request_links: request_links)
         get_secrets_with_options(query_options, full_response: full_response)
       end
 

--- a/sdk/ruby/lib/keeper_secrets_manager/dto.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/dto.rb
@@ -1,6 +1,8 @@
 require 'json'
 require 'ostruct'
 require_relative 'dto/payload'
+require_relative 'utils'
+require_relative 'crypto'
 
 module KeeperSecretsManager
   module Dto
@@ -122,6 +124,22 @@ module KeeperSecretsManager
         end
       end
 
+      # Return this record's linked-credential entries as typed KeeperRecordLink objects.
+      #
+      # Typed view over the raw `links` list (populated when secrets are fetched with
+      # QueryOptions(..., request_links: true)). The raw `links` list is left unchanged
+      # for backward compatibility; entries without a String recordUid are skipped.
+      def get_links
+        (links || []).each_with_object([]) do |link_dict, result|
+          next unless link_dict.is_a?(Hash)
+
+          record_uid = link_dict['recordUid']
+          next unless record_uid.is_a?(String) && !record_uid.empty?
+
+          result << KeeperRecordLink.new(link_dict)
+        end
+      end
+
       # Dynamic field access methods
       def method_missing(method, *args, &block)
         method_name = method.to_s
@@ -165,6 +183,299 @@ module KeeperSecretsManager
         %w[login password url fileRef oneTimeCode name phone email address
            paymentCard bankAccount birthDate secureNote sshKey host
            databaseType script passkey]
+      end
+    end
+
+    # Typed view over a single linked-credential entry of a record (`record.links`).
+    #
+    # A link entry carries `recordUid`, optional base64 `data`, and an optional `path`
+    # discriminator. Observed payload shapes (verified against the live backend):
+    #
+    # - path "meta" (self-link, recordUid == owning record): plain base64 JSON with
+    #   `allowedSettings` (rotation, connections, portForwards, sessionRecording,
+    #   typescriptRecording, aiEnabled, aiSessionTerminate, remoteBrowserIsolation),
+    #   plus `rotateOnTermination`, `version` and `no_update_services`.
+    # - path nil (credential link to another record): plain base64 JSON with
+    #   `is_admin`, `is_launch_credential`, `is_iam_user`, `belongs_to` and
+    #   `rotation_settings`; or no data at all (pure record reference).
+    # - path "ai_settings" / "jit_settings" (self-links): data is AES-256-GCM
+    #   encrypted under the owning record's key - see #get_decrypted_data.
+    #
+    # Accessors never raise: parse, decode or decryption failures yield nil/false.
+    # The original link hash is kept untouched in `raw`, and #get_link_data returns the
+    # complete parsed payload, so fields unknown to this SDK version are preserved.
+    #
+    # Naming: Ruby predicates take a trailing `?` and drop the redundant `is_` prefix
+    # (house style), so the Python reference's is_admin_user/is_launch_credential/
+    # is_iam_user map to admin_user?/launch_credential?/iam_user? here.
+    class KeeperRecordLink
+      attr_reader :raw, :record_uid, :data, :path
+
+      def initialize(link_dict = {})
+        link_dict = {} unless link_dict.is_a?(Hash)
+        @raw = link_dict.dup
+        @record_uid = link_dict['recordUid']
+        @data = link_dict['data']
+        @path = link_dict['path']
+      end
+
+      def to_s
+        "[KeeperRecordLink: record_uid=#{@record_uid}, path=#{@path}]"
+      end
+
+      # --- User / permission boolean accessors ---
+
+      # Whether the linked user is an admin (`is_admin`).
+      def admin_user?
+        boolean_value('is_admin')
+      end
+
+      # Whether this is a launch credential link (`is_launch_credential`).
+      def launch_credential?
+        boolean_value('is_launch_credential')
+      end
+
+      # Whether the linked user is an IAM user (`is_iam_user`).
+      def iam_user?
+        boolean_value('is_iam_user')
+      end
+
+      # Whether the linked credential belongs to the record (`belongs_to`).
+      def belongs_to?
+        boolean_value('belongs_to')
+      end
+
+      # Whether service updates are disabled for this link (`no_update_services`).
+      def no_update_services?
+        boolean_value('no_update_services')
+      end
+
+      # Whether rotation is allowed (`rotation`, top-level or in `allowedSettings`).
+      def allows_rotation?
+        boolean_value('rotation', true)
+      end
+
+      # Whether connections are allowed (`connections`, top-level or in `allowedSettings`).
+      def allows_connections?
+        boolean_value('connections', true)
+      end
+
+      # Whether port forwards are allowed (`portForwards`, top-level or in `allowedSettings`).
+      def allows_port_forwards?
+        boolean_value('portForwards', true)
+      end
+
+      # Whether session recording is enabled (`sessionRecording`, top-level or in `allowedSettings`).
+      def allows_session_recording?
+        boolean_value('sessionRecording', true)
+      end
+
+      # Whether typescript recording is enabled (`typescriptRecording`, top-level or in `allowedSettings`).
+      def allows_typescript_recording?
+        boolean_value('typescriptRecording', true)
+      end
+
+      # Whether remote browser isolation is enabled (`remoteBrowserIsolation`, top-level or in `allowedSettings`).
+      def allows_remote_browser_isolation?
+        boolean_value('remoteBrowserIsolation', true)
+      end
+
+      # Whether AI features are enabled (`aiEnabled`, top-level or in `allowedSettings`).
+      def ai_enabled?
+        boolean_value('aiEnabled', true)
+      end
+
+      # Whether AI session termination is enabled (`aiSessionTerminate`, top-level or in `allowedSettings`).
+      def ai_session_terminate?
+        boolean_value('aiSessionTerminate', true)
+      end
+
+      # Whether rotation on termination is enabled (`rotateOnTermination`).
+      def rotates_on_termination?
+        boolean_value('rotateOnTermination')
+      end
+
+      # --- Data accessors ---
+
+      # The link data schema version (`version`) when it is an integer, else nil.
+      def get_link_data_version
+        int_value('version')
+      end
+
+      # The `allowedSettings` object from the link data (empty hash when absent).
+      def get_allowed_settings
+        parsed = parse_json_data
+        allowed = parsed ? parsed['allowedSettings'] : nil
+        allowed.is_a?(Hash) ? allowed : {}
+      end
+
+      # The `rotation_settings` object from the link data, or nil when absent.
+      def get_rotation_settings
+        parsed = parse_json_data
+        rotation = parsed ? parsed['rotation_settings'] : nil
+        rotation.is_a?(Hash) ? rotation : nil
+      end
+
+      # Base64-decode `data` to a string (for debugging/advanced use), or nil.
+      def get_decoded_data
+        return nil if @data.nil?
+
+        Utils.base64_to_bytes(@data).force_encoding('UTF-8').scrub
+      rescue StandardError
+        nil
+      end
+
+      # Whether the link has readable JSON data (vs. encrypted/binary data).
+      def has_readable_data?
+        decoded = get_decoded_data
+        !decoded.nil? && (decoded.start_with?('{') || decoded.start_with?('['))
+      end
+
+      # Whether this link's path indicates potentially encrypted data (currently
+      # ai_settings / jit_settings; other paths carry plain base64 JSON).
+      def might_be_encrypted?
+        %w[ai_settings jit_settings].include?(@path)
+      end
+
+      # Whether the data appears encrypted, by inspecting the actual content (non-JSON
+      # and mostly non-printable) rather than path naming conventions.
+      def has_encrypted_data?
+        decoded = get_decoded_data
+        return false if decoded.nil?
+        return false if decoded.start_with?('{') || decoded.start_with?('[')
+
+        !printable_text?(decoded)
+      end
+
+      # Decrypt the link data with the owning record's key (AES-256-GCM). record_key is
+      # the record's decrypted key bytes (record.record_key). Returns the decrypted
+      # string, or nil if data/key is missing or decryption fails.
+      def get_decrypted_data(record_key = nil)
+        return nil if @data.nil? || record_key.nil?
+
+        encrypted = Utils.base64_to_bytes(@data)
+        Crypto.decrypt_aes_gcm(encrypted, record_key).force_encoding('UTF-8').scrub
+      rescue StandardError
+        nil
+      end
+
+      # The complete link data payload, handling both plain and encrypted JSON. Plain
+      # base64 JSON parses without a key; encrypted data requires the owning record's
+      # key. Ciphertext can coincidentally start with "{" or "[", so a failed
+      # plain-JSON parse falls through to decryption rather than giving up. The returned
+      # hash preserves all fields sent by the server, including ones this SDK version
+      # doesn't know about yet.
+      def get_link_data(record_key = nil)
+        decoded = get_decoded_data
+        return nil if decoded.nil?
+
+        if decoded.start_with?('{') || decoded.start_with?('[')
+          parsed = parse_json_to_dict(decoded)
+          return parsed unless parsed.nil?
+          # Leading {/[ was coincidental ciphertext - fall through to decryption.
+        end
+
+        decrypted = get_decrypted_data(record_key)
+        return nil if decrypted.nil?
+
+        parse_json_to_dict(decrypted)
+      end
+
+      # --- Settings accessors (path-gated) ---
+
+      # PAM settings data from this link - only when path == "meta" (plain JSON today;
+      # the key is accepted for forward compatibility).
+      def get_meta_data(record_key = nil)
+        get_settings_for_path('meta', record_key)
+      end
+
+      # AI settings data from this link - only when path == "ai_settings" (encrypted
+      # under the owning record's key). Returns nil for any other path.
+      def get_ai_settings_data(record_key = nil)
+        return nil unless @path == 'ai_settings'
+
+        get_link_data(record_key)
+      end
+
+      # JIT settings data from this link - only when path == "jit_settings" (encrypted
+      # under the owning record's key). Returns nil for any other path.
+      def get_jit_settings_data(record_key = nil)
+        return nil unless @path == 'jit_settings'
+
+        get_link_data(record_key)
+      end
+
+      # Settings data for any path, current or future. Automatically detects whether the
+      # data is plain or encrypted and handles it appropriately. Returns nil when the
+      # path doesn't match or parsing fails.
+      def get_settings_for_path(settings_path, record_key = nil)
+        return nil unless @path == settings_path
+
+        get_link_data(record_key)
+      end
+
+      private
+
+      # Decode `data` and parse it as a JSON object, handling errors gracefully.
+      def parse_json_data
+        decoded = get_decoded_data
+        return nil if decoded.nil? || !(decoded.start_with?('{') || decoded.start_with?('['))
+
+        parsed = JSON.parse(decoded)
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Read a strict boolean from the link data; missing or non-bool values are false.
+      # With check_allowed_settings the nested `allowedSettings` object is consulted when
+      # the key is absent at the top level (a top-level boolean wins).
+      def boolean_value(key, check_allowed_settings = false)
+        parsed = parse_json_data
+        return false if parsed.nil?
+
+        value = parsed[key]
+        return value if strict_boolean?(value)
+
+        if check_allowed_settings
+          allowed = parsed['allowedSettings']
+          if allowed.is_a?(Hash)
+            nested = allowed[key]
+            return nested if strict_boolean?(nested)
+          end
+        end
+        false
+      end
+
+      # Read a strict integer from the link data; strings and booleans yield nil.
+      def int_value(key)
+        parsed = parse_json_data
+        value = parsed ? parsed[key] : nil
+        return value if value.is_a?(Integer) && !strict_boolean?(value)
+
+        nil
+      end
+
+      def strict_boolean?(value)
+        value == true || value == false
+      end
+
+      # Parse a JSON string, returning a hash only for JSON objects.
+      def parse_json_to_dict(json_str)
+        parsed = JSON.parse(json_str)
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Whether a string is mostly printable text (>90% of the first 100 chars), used to
+      # distinguish encrypted bytes from plain text.
+      def printable_text?(text)
+        return false if text.nil? || text.empty?
+
+        sample = text[0, 100]
+        printable = sample.each_char.count { |c| (c >= ' ' && c <= '~') || ["\n", "\r", "\t"].include?(c) }
+        (printable.to_f / sample.length) > 0.9
       end
     end
 

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/record_link_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/record_link_spec.rb
@@ -1,0 +1,387 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'base64'
+require 'openssl'
+
+# Ports the Python reference suite sdk/python/core/tests/record_link_test.py (18 cases,
+# KSM-992) to Ruby (KSM-1013). Ruby predicate accessors use a trailing `?` and drop the
+# redundant `is_` prefix, so is_admin_user/is_launch_credential/is_iam_user become
+# admin_user?/launch_credential?/iam_user?.
+RSpec.describe KeeperSecretsManager::Dto::KeeperRecordLink do
+  # --- fixture helpers (mirror the Python plain_link/encrypted_link helpers) ---
+
+  def random_key
+    KeeperSecretsManager::Crypto.generate_random_bytes(32)
+  end
+
+  # A link whose data is base64 of the given plain JSON payload.
+  def plain_link(payload, path: nil, record_uid: 'RU_test')
+    described_class.new(
+      'recordUid' => record_uid,
+      'data' => Base64.strict_encode64(JSON.generate(payload)),
+      'path' => path
+    )
+  end
+
+  # A link whose data is base64 of the payload encrypted with AES-256-GCM.
+  def encrypted_link(payload, key, path: nil, record_uid: 'RU_test')
+    ciphertext = KeeperSecretsManager::Crypto.encrypt_aes_gcm(JSON.generate(payload), key)
+    described_class.new(
+      'recordUid' => record_uid,
+      'data' => Base64.strict_encode64(ciphertext),
+      'path' => path
+    )
+  end
+
+  # A link built from an arbitrary (or nil) data string.
+  def raw_link(data, path: nil, record_uid: 'RU')
+    described_class.new('recordUid' => record_uid, 'data' => data, 'path' => path)
+  end
+
+  # AES-256-GCM encrypt with a caller-chosen IV (iv + ciphertext + tag), matching the
+  # Crypto.decrypt_aes_gcm wire format. Used to force a JSON-like leading byte.
+  def encrypt_gcm_with_iv(plaintext, key, iv)
+    cipher = OpenSSL::Cipher.new('AES-256-GCM')
+    cipher.encrypt
+    cipher.iv = iv
+    cipher.key = key
+    encrypted = cipher.update(plaintext) + cipher.final
+    iv + encrypted + cipher.auth_tag(16)
+  end
+
+  it 'reads boolean accessors from plain JSON; absent keys default to false' do
+    link = plain_link({ 'is_admin' => true, 'rotation' => true, 'connections' => false })
+
+    expect(link.admin_user?).to be true
+    expect(link.allows_rotation?).to be true
+    expect(link.allows_connections?).to be false
+
+    # Absent keys must default to false
+    expect(link.allows_port_forwards?).to be false
+    expect(link.launch_credential?).to be false
+    expect(link.iam_user?).to be false
+    expect(link.belongs_to?).to be false
+    expect(link.no_update_services?).to be false
+  end
+
+  it 'reads integer version, decoded data and the readable-JSON heuristic' do
+    link = plain_link({ 'version' => 3, 'is_admin' => false })
+    expect(link.get_link_data_version).to eq(3)
+    decoded = link.get_decoded_data
+    expect(decoded).not_to be_nil
+    expect(decoded).to start_with('{')
+    expect(link.has_readable_data?).to be true
+
+    # Non-JSON (but valid base64) decoded content is not "readable"
+    raw = raw_link(Base64.strict_encode64('not json at all'))
+    expect(raw.has_readable_data?).to be false
+    expect(raw.get_link_data_version).to be_nil
+
+    # Invalid base64 decodes to nil, never raises
+    bad = raw_link('!!! not base64 !!!')
+    expect(bad.get_decoded_data).to be_nil
+    expect(bad.get_link_data).to be_nil
+  end
+
+  it 'gates might_be_encrypted? to the known encrypted paths only' do
+    expect(plain_link({}, path: 'ai_settings').might_be_encrypted?).to be true
+    expect(plain_link({}, path: 'jit_settings').might_be_encrypted?).to be true
+    expect(plain_link({}, path: 'meta').might_be_encrypted?).to be false
+    expect(plain_link({}, path: 'something_else').might_be_encrypted?).to be false
+    expect(plain_link({}, path: nil).might_be_encrypted?).to be false
+  end
+
+  it 'round-trips AES-256-GCM decryption; wrong/absent key gives nil' do
+    key = random_key
+    payload = { 'enabled' => true, 'ttl' => 3600 }
+    link = encrypted_link(payload, key, path: 'jit_settings')
+
+    decrypted = link.get_decrypted_data(key)
+    expect(decrypted).not_to be_nil
+    expect(JSON.parse(decrypted)).to eq(payload)
+
+    expect(link.get_decrypted_data(nil)).to be_nil
+    expect(link.get_decrypted_data(random_key)).to be_nil
+  end
+
+  it 'auto-detects plain JSON vs encrypted data in get_link_data' do
+    plain = plain_link({ 'aiEnabled' => true }, path: 'ai_settings')
+    data = plain.get_link_data
+    expect(data).not_to be_nil
+    expect(data['aiEnabled']).to be true
+
+    key = random_key
+    enc = encrypted_link({ 'enabled' => true }, key, path: 'jit_settings')
+    expect(enc.get_link_data).to be_nil
+    data = enc.get_link_data(key)
+    expect(data).not_to be_nil
+    expect(data['enabled']).to be true
+  end
+
+  it 'gates settings accessors to the matching path' do
+    key = random_key
+    ai = plain_link({ 'aiEnabled' => true }, path: 'ai_settings')
+    jit = plain_link({ 'enabled' => true }, path: 'jit_settings')
+
+    expect(ai.get_ai_settings_data(key)).not_to be_nil
+    expect(ai.get_jit_settings_data(key)).to be_nil
+    expect(jit.get_jit_settings_data(key)).not_to be_nil
+    expect(jit.get_ai_settings_data(key)).to be_nil
+
+    expect(ai.get_settings_for_path('ai_settings')).not_to be_nil
+    expect(ai.get_settings_for_path('other')).to be_nil
+  end
+
+  it 'builds typed links via KeeperRecord#get_links while leaving raw links unchanged' do
+    links_data = [
+      # meta self-link (plain JSON, live shape)
+      { 'recordUid' => 'mainUid', 'path' => 'meta',
+        'data' => Base64.strict_encode64(JSON.generate('allowedSettings' => { 'rotation' => true }, 'version' => 1)) },
+      # credential link to another record
+      { 'recordUid' => 'linkedUid', 'path' => nil,
+        'data' => Base64.strict_encode64(JSON.generate('is_admin' => true, 'is_launch_credential' => true)) },
+      # pure reference link (no data)
+      { 'recordUid' => 'referencedUid', 'data' => nil, 'path' => nil },
+      # malformed entry without recordUid is kept raw but skipped by get_links
+      { 'data' => nil, 'path' => nil }
+    ]
+    record = KeeperSecretsManager::Dto::KeeperRecord.new(
+      'recordUid' => 'r', 'data' => { 'title' => 'Main Record', 'type' => 'login' }, 'links' => links_data
+    )
+
+    # The raw links field is unchanged (back-compat)
+    expect(record.links.length).to eq(4)
+    expect(record.links).to eq(links_data)
+
+    links = record.get_links
+    expect(links.length).to eq(3)
+    expect(links).to all(be_a(described_class))
+
+    meta = links[0]
+    expect(meta.record_uid).to eq('mainUid')
+    expect(meta.path).to eq('meta')
+    expect(meta.allows_rotation?).to be true
+    expect(meta.get_link_data_version).to eq(1)
+
+    cred = links[1]
+    expect(cred.record_uid).to eq('linkedUid')
+    expect(cred.admin_user?).to be true
+    expect(cred.launch_credential?).to be true
+
+    ref = links[2]
+    expect(ref.record_uid).to eq('referencedUid')
+    expect(ref.get_link_data).to be_nil
+  end
+
+  it 'does not coerce string-encoded values to bool/int' do
+    link = plain_link({ 'is_admin' => 'true', 'rotation' => 'false', 'version' => '3' })
+    expect(link.admin_user?).to be false
+    expect(link.allows_rotation?).to be false
+    expect(link.get_link_data_version).to be_nil
+
+    # Real JSON bool/number ARE read
+    typed = plain_link({ 'is_admin' => true, 'version' => 3 })
+    expect(typed.admin_user?).to be true
+    expect(typed.get_link_data_version).to eq(3)
+
+    # A boolean must not count as an integer version
+    bool_version = plain_link({ 'version' => true })
+    expect(bool_version.get_link_data_version).to be_nil
+  end
+
+  it 'detects encrypted data by content, not by path naming' do
+    key = random_key
+    ciphertext = KeeperSecretsManager::Crypto.encrypt_aes_gcm('some secret bytes', key)
+    enc = raw_link(Base64.strict_encode64(ciphertext))
+    expect(enc.has_encrypted_data?).to be true
+
+    text = raw_link(Base64.strict_encode64('just plain readable text, not json'))
+    expect(text.has_encrypted_data?).to be false
+
+    expect(plain_link({ 'a' => 1 }).has_encrypted_data?).to be false
+
+    no_data = raw_link(nil)
+    expect(no_data.has_encrypted_data?).to be false
+  end
+
+  it 'decrypts an encrypted payload for a matching path via get_settings_for_path' do
+    key = random_key
+    link = encrypted_link({ 'customSetting' => 42 }, key, path: 'custom_settings')
+
+    data = link.get_settings_for_path('custom_settings', key)
+    expect(data).not_to be_nil
+    expect(data['customSetting']).to eq(42)
+    expect(link.get_settings_for_path('other', key)).to be_nil
+  end
+
+  it 'reads meta self-links with the allowedSettings fallback and top-level fields' do
+    link = plain_link({
+                        'allowedSettings' => {
+                          'rotation' => true, 'connections' => true, 'portForwards' => true,
+                          'sessionRecording' => true, 'typescriptRecording' => false,
+                          'aiEnabled' => true, 'aiSessionTerminate' => true, 'remoteBrowserIsolation' => true
+                        },
+                        'rotateOnTermination' => false, 'version' => 1, 'no_update_services' => true
+                      }, path: 'meta')
+
+    # Permission booleans read from allowedSettings when absent at the top level
+    expect(link.allows_rotation?).to be true
+    expect(link.allows_connections?).to be true
+    expect(link.allows_port_forwards?).to be true
+    expect(link.allows_session_recording?).to be true
+    expect(link.allows_typescript_recording?).to be false
+    expect(link.allows_remote_browser_isolation?).to be true
+    expect(link.ai_enabled?).to be true
+    expect(link.ai_session_terminate?).to be true
+
+    # Top-level fields
+    expect(link.rotates_on_termination?).to be false
+    expect(link.get_link_data_version).to eq(1)
+    expect(link.no_update_services?).to be true
+
+    # Dict accessors
+    expect(link.get_allowed_settings['rotation']).to be true
+    meta = link.get_meta_data
+    expect(meta).not_to be_nil
+    expect(meta['version']).to eq(1)
+    expect(plain_link({}, path: nil).get_meta_data).to be_nil
+  end
+
+  it 'reads credential links: user flags and the nested rotation_settings' do
+    link = plain_link({
+                        'is_admin' => true, 'is_iam_user' => false, 'belongs_to' => true,
+                        'is_launch_credential' => true,
+                        'rotation_settings' => {
+                          'schedule' => '', 'pwd_complexity' => 'ZmFrZS1jb21wbGV4aXR5',
+                          'disabled' => false, 'noop' => false, 'saas_record_uid_list' => []
+                        }
+                      })
+
+    expect(link.admin_user?).to be true
+    expect(link.iam_user?).to be false
+    expect(link.belongs_to?).to be true
+    expect(link.launch_credential?).to be true
+
+    rotation_settings = link.get_rotation_settings
+    expect(rotation_settings).not_to be_nil
+    expect(rotation_settings['schedule']).to eq('')
+    expect(rotation_settings['disabled']).to be false
+    expect(rotation_settings['saas_record_uid_list']).to eq([])
+
+    expect(plain_link({ 'is_admin' => true }).get_rotation_settings).to be_nil
+  end
+
+  it 'answers all accessors safely for a data-less reference link' do
+    link = raw_link(nil, record_uid: 'RU_ref')
+
+    expect(link.record_uid).to eq('RU_ref')
+    expect(link.admin_user?).to be false
+    expect(link.allows_rotation?).to be false
+    expect(link.get_link_data_version).to be_nil
+    expect(link.get_decoded_data).to be_nil
+    expect(link.get_decrypted_data(random_key)).to be_nil
+    expect(link.get_link_data).to be_nil
+    expect(link.get_allowed_settings).to eq({})
+    expect(link.get_rotation_settings).to be_nil
+    expect(link.has_readable_data?).to be false
+    expect(link.has_encrypted_data?).to be false
+  end
+
+  it 'decrypts ai_settings links to the riskLevels payload (lossless)' do
+    key = random_key
+    payload = {
+      'version' => 'v1.0.0',
+      'riskLevels' => {
+        'critical' => { 'tags' => { 'allow' => [], 'deny' => [] }, 'aiSessionTerminate' => true },
+        'high' => { 'tags' => { 'allow' => [], 'deny' => [] }, 'aiSessionTerminate' => true },
+        'medium' => { 'tags' => { 'allow' => [], 'deny' => [] }, 'aiSessionTerminate' => true },
+        'low' => { 'tags' => { 'allow' => [] }, 'aiSessionTerminate' => false }
+      }
+    }
+    link = encrypted_link(payload, key, path: 'ai_settings')
+
+    data = link.get_ai_settings_data(key)
+    expect(data).not_to be_nil
+    expect(data).to eq(payload)
+
+    # The live version field is a string here, so the integer accessor yields nil
+    expect(link.get_link_data_version).to be_nil
+  end
+
+  it 'decrypts jit_settings links to the elevation payload' do
+    key = random_key
+    payload = {
+      'createEphemeral' => true, 'elevate' => true, 'elevationMethod' => 'group',
+      'elevationString' => 'arn:aws', 'baseDistinguishedName' => ''
+    }
+    link = encrypted_link(payload, key, path: 'jit_settings')
+
+    data = link.get_jit_settings_data(key)
+    expect(data).not_to be_nil
+    expect(data).to eq(payload)
+  end
+
+  it 'preserves unknown link keys in raw and unknown payload fields in get_link_data' do
+    payload = { 'is_admin' => true, 'futureField' => { 'nested' => [1, 2, 3] } }
+    link_dict = {
+      'recordUid' => 'RU',
+      'data' => Base64.strict_encode64(JSON.generate(payload)),
+      'path' => nil,
+      'futureLinkKey' => 'kept'
+    }
+    link = described_class.new(link_dict)
+
+    expect(link.raw).to eq(link_dict)
+    expect(link.raw['futureLinkKey']).to eq('kept')
+
+    data = link.get_link_data
+    expect(data['futureField']).to eq('nested' => [1, 2, 3])
+  end
+
+  it 'lets a top-level boolean win over the allowedSettings fallback' do
+    link = plain_link({ 'rotation' => false, 'allowedSettings' => { 'rotation' => true } })
+    expect(link.allows_rotation?).to be false
+
+    only_nested = plain_link({ 'allowedSettings' => { 'rotation' => true } })
+    expect(only_nested.allows_rotation?).to be true
+  end
+
+  it 'falls through to decryption when ciphertext coincidentally starts with a JSON marker' do
+    key = random_key
+    payload = { 'createEphemeral' => true, 'elevate' => true }
+
+    ['{', '['].each do |marker|
+      iv = marker.b + KeeperSecretsManager::Crypto.generate_random_bytes(11)
+      ciphertext = encrypt_gcm_with_iv(JSON.generate(payload), key, iv)
+      link = raw_link(Base64.strict_encode64(ciphertext), path: 'jit_settings')
+
+      decoded = link.get_decoded_data
+      expect(decoded[0]).to eq(marker)
+
+      expect(link.get_link_data(key)).to eq(payload)
+      expect(link.get_jit_settings_data(key)).to eq(payload)
+      expect(link.get_settings_for_path('jit_settings', key)).to eq(payload)
+      expect(link.get_link_data(nil)).to be_nil
+    end
+
+    # The plain-JSON fast path is unaffected.
+    expect(plain_link({ 'a' => 1 }).get_link_data).to eq('a' => 1)
+  end
+
+  describe 'request_links transport plumbing' do
+    it 'defaults QueryOptions#request_links to nil and stores an explicit value' do
+      expect(KeeperSecretsManager::Dto::QueryOptions.new.request_links).to be_nil
+      expect(KeeperSecretsManager::Dto::QueryOptions.new(request_links: true).request_links).to be true
+    end
+
+    it 'serializes GetPayload#request_links to requestLinks only when set' do
+      payload = KeeperSecretsManager::Dto::GetPayload.new
+      expect(payload.to_h).not_to include('requestLinks')
+
+      payload.request_links = true
+      expect(payload.to_h).to include('requestLinks' => true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the typed linked-credential accessor layer to the Ruby SDK (**KSM-1013**), completing the cross-SDK parity epic (**KSM-1007**) for Ruby. Mirrors the Python reference implementation (**KSM-992**, #1036).

The `request_links` transport plumbing and the raw `KeeperRecord#links` field already existed on this release branch (KSM-687); this PR adds the developer-facing accessor layer on top — **purely additive**, no protocol changes, and the raw `record.links` list is unchanged.

## Changes

- **`KeeperRecordLink`** (`lib/keeper_secrets_manager/dto.rb`) — wraps each raw `links` entry with never-raising typed accessors (parse/decode/decrypt failures yield `nil`/`false`):
  - **Permission booleans** with an `allowedSettings` fallback (top-level wins): `admin_user?`, `launch_credential?`, `iam_user?`, `belongs_to?`, `no_update_services?`, `allows_rotation?`, `allows_connections?`, `allows_port_forwards?`, `allows_session_recording?`, `allows_typescript_recording?`, `allows_remote_browser_isolation?`, `ai_enabled?`, `ai_session_terminate?`, `rotates_on_termination?`
  - **Data accessors**: `get_link_data_version`, `get_decoded_data`, `has_readable_data?`, `might_be_encrypted?`, `has_encrypted_data?`, `get_decrypted_data(record_key)` (AES-256-GCM), `get_link_data(record_key)` (plain-vs-encrypted auto-detection, preserves unknown fields)
  - **Path-gated settings accessors**: `get_meta_data`, `get_ai_settings_data`, `get_jit_settings_data`, `get_settings_for_path`
  - **Hash accessors**: `get_allowed_settings`, `get_rotation_settings`
- **`KeeperRecord#get_links`** — returns typed `KeeperRecordLink` objects; raw `record.links` untouched.
- **`get_secrets(..., request_links:)`** — convenience keyword so links can be requested without building a `QueryOptions` by hand.
- **Docs** — CHANGELOG entry and a README "Linked Credentials (PAM)" usage section.

## Naming

Ruby predicate accessors use a trailing `?` and drop the redundant `is_` prefix per Ruby convention, so the Python reference's `is_admin_user`/`is_launch_credential`/`is_iam_user` are `admin_user?`/`launch_credential?`/`iam_user?` here. The KSM-1013 description has been updated to match.

## Testing

- New `spec/keeper_secrets_manager/unit/record_link_spec.rb`: **20 examples** mirroring the Python `tests/record_link_test.py` suite (18 cases: allowedSettings fallback + top-level precedence, strict typing, AES-256-GCM round-trip and wrong/absent-key handling, path gating, data-less reference links, losslessness, JSON-like-ciphertext decrypt fall-through) plus `request_links` transport assertions.
- Full Ruby unit suite: **602 examples, 0 failures**.

Ticket: KSM-1013 · Epic: KSM-1007 · Reference: KSM-992 (#1036)
