### PR TITLE
fix(ruby): KSM-1094 fix record_uid NameError in update_secret

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [17.2.0]
 
 ### Fixed
+- **KSM-1094**: `update_secret` no longer raises `NameError: undefined local variable 'record_uid'` when called with a `KeeperRecord` object; the revision refresh now correctly references `record.uid`
 - **KSM-824**: `to_h` now always includes `custom` in the V3 API payload, even when the array is empty, matching Commander and Vault behavior
 - **KSM-906**: Added IL5 region mapping (`IL5` → `il5.keepersecurity.us`) to `KEEPER_SERVERS`
 - **KSM-987**: `url_safe_str_to_bytes` and `base64_to_bytes` in `Utils` now raise `Error` when passed `nil`; all Base64 decoding in `core.rb` routes through `Utils`

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -319,7 +319,7 @@ module KeeperSecretsManager
         # Since the server doesn't return the new revision in the response,
         # we need to refetch the record to get the actual revision
         if record.is_a?(Dto::KeeperRecord)
-          updated_record = get_secrets([record_uid]).first
+          updated_record = get_secrets([record.uid]).first
           if updated_record
             record.revision = updated_record.revision
             @logger&.debug("update_secret: updated local revision to #{record.revision}")

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
@@ -390,4 +390,29 @@ RSpec.describe KeeperSecretsManager::Core::SecretsManager do
       expect(described_class::INFLATE_REF_TYPES['cardRef']).to include('paymentCard')
     end
   end
+
+  describe '#update_secret' do
+    let(:manager) { described_class.new(config: mock_config) }
+    let(:record) do
+      KeeperSecretsManager::Dto::KeeperRecord.new(
+        'recordUid' => 'test-uid-1094',
+        'data' => { 'title' => 'Test', 'type' => 'login', 'fields' => [], 'custom' => [] }
+      )
+    end
+
+    before do
+      allow(manager).to receive(:update_secret_with_options)
+      allow(manager).to receive(:complete_transaction)
+      allow(manager).to receive(:get_secrets).and_return([])
+    end
+
+    it 'does not raise NameError when called with a KeeperRecord' do
+      expect { manager.update_secret(record) }.not_to raise_error
+    end
+
+    it 'passes the record uid to get_secrets when refreshing the revision' do
+      expect(manager).to receive(:get_secrets).with(['test-uid-1094']).and_return([])
+      manager.update_secret(record)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `update_secret` referenced `record_uid` at `core.rb:322`, a variable defined only in `update_secret_with_options`. Every call with a `KeeperRecord` raised `NameError` before reaching the server.
- Fixed by changing `record_uid` → `record.uid` at the one call site.
- Added two regression tests: one confirming no error is raised, one confirming the correct UID is passed to `get_secrets` for the revision refresh.

Jira: KSM-1094

## Breaking Changes

None.