### PR TITLE
fix(ruby): KSM-1095 auto-finalize staged transaction in update_secret

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [17.2.0]
 
 ### Fixed
+- **KSM-1095**: `update_secret` now calls `complete_transaction` after staging the update, so changes are committed to the server rather than remaining in a staged state indefinitely; works for both `KeeperRecord` objects and plain hash inputs
 - **KSM-1094**: `update_secret` no longer raises `NameError: undefined local variable 'record_uid'` when called with a `KeeperRecord` object; the revision refresh now correctly references `record.uid`
 - **KSM-824**: `to_h` now always includes `custom` in the V3 API payload, even when the array is empty, matching Commander and Vault behavior
 - **KSM-906**: Added IL5 region mapping (`IL5` → `il5.keepersecurity.us`) to `KEEPER_SERVERS`

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -315,9 +315,9 @@ module KeeperSecretsManager
         update_options = Dto::UpdateOptions.new(transaction_type: transaction_type)
         update_secret_with_options(record, update_options)
 
-        # Update local record's revision to reflect server state
-        # Since the server doesn't return the new revision in the response,
-        # we need to refetch the record to get the actual revision
+        uid = record.is_a?(Dto::KeeperRecord) ? record.uid : (record['uid'] || record[:uid])
+        complete_transaction(uid) if uid
+
         if record.is_a?(Dto::KeeperRecord)
           updated_record = get_secrets([record.uid]).first
           if updated_record

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
@@ -414,5 +414,17 @@ RSpec.describe KeeperSecretsManager::Core::SecretsManager do
       expect(manager).to receive(:get_secrets).with(['test-uid-1094']).and_return([])
       manager.update_secret(record)
     end
+
+    it 'calls complete_transaction with the record uid to finalize the staged update' do
+      expect(manager).to receive(:complete_transaction).with('test-uid-1094')
+      manager.update_secret(record)
+    end
+
+    it 'calls complete_transaction when record is a plain hash' do
+      hash_record = { 'uid' => 'hash-uid-1095' }
+      allow(manager).to receive(:update_secret_with_options)
+      expect(manager).to receive(:complete_transaction).with('hash-uid-1095')
+      manager.update_secret(hash_record)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `update_secret` staged the record update via `update_secret_with_options` but never called `complete_transaction`, leaving changes in a staged state the server never committed. Updates appeared to succeed but were silently discarded.
- Fixed by extracting the record UID (from `KeeperRecord` object or plain hash) and calling `complete_transaction(uid)` immediately after staging.
- Added two regression tests: one for the `KeeperRecord` path, one for the plain hash path.

Jira: KSM-1095

## Breaking Changes

None.