### PR TITLE
fix(ruby): KSM-1096 handle KeeperFile objects in download_thumbnail

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - **KSM-1095**: `update_secret` now calls `complete_transaction` after staging the update, so changes are committed to the server rather than remaining in a staged state indefinitely; works for both `KeeperRecord` objects and plain hash inputs
 - **KSM-1094**: `update_secret` no longer raises `NameError: undefined local variable 'record_uid'` when called with a `KeeperRecord` object; the revision refresh now correctly references `record.uid`
+- **KSM-1096**: `download_thumbnail` no longer raises `NoMethodError` when passed a `KeeperFile` object; `KeeperFile` now exposes a `file_key` attribute and the method dispatches on type before attempting hash access
 - **KSM-824**: `to_h` now always includes `custom` in the V3 API payload, even when the array is empty, matching Commander and Vault behavior
 - **KSM-906**: Added IL5 region mapping (`IL5` → `il5.keepersecurity.us`) to `KEEPER_SERVERS`
 - **KSM-987**: `url_safe_str_to_bytes` and `base64_to_bytes` in `Utils` now raise `Error` when passed `nil`; all Base64 decoding in `core.rb` routes through `Utils`

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -660,26 +660,24 @@ module KeeperSecretsManager
 
       # Download file thumbnail
       def download_thumbnail(file_data)
-        # Extract thumbnail metadata
-        file_uid = file_data['fileUid'] || file_data['uid'] || (file_data.respond_to?(:uid) ? file_data.uid : nil)
-        thumbnail_url = file_data['thumbnailUrl'] || file_data['thumbnail_url'] || (file_data.respond_to?(:thumbnail_url) ? file_data.thumbnail_url : nil)
+        if file_data.is_a?(Dto::KeeperFile)
+          file_uid      = file_data.uid
+          thumbnail_url = file_data.thumbnail_url
+          file_key_str  = file_data.file_key
+        else
+          file_uid      = file_data['fileUid'] || file_data['uid']
+          thumbnail_url = file_data['thumbnailUrl'] || file_data['thumbnail_url']
+          file_key_str  = file_data['fileKey'] || file_data['file_key']
+        end
 
         raise ArgumentError, 'File UID is required' unless file_uid
         raise Error, "No thumbnail URL available for file #{file_uid}" unless thumbnail_url
-
-        # The file key should already be decrypted (base64 encoded)
-        file_key_str = file_data['fileKey'] || file_data['file_key']
         raise Error, "File key not available for #{file_uid}" unless file_key_str
 
         file_key = Utils.base64_to_bytes(file_key_str)
-
-        # Download the encrypted thumbnail content
         encrypted_content = download_encrypted_file(thumbnail_url)
-
-        # Decrypt the thumbnail content with the file key
         decrypted_content = Crypto.decrypt_aes_gcm(encrypted_content, file_key)
 
-        # Return thumbnail data
         {
           'file_uid' => file_uid,
           'data' => decrypted_content,

--- a/sdk/ruby/lib/keeper_secrets_manager/dto.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/dto.rb
@@ -502,7 +502,7 @@ module KeeperSecretsManager
 
     # File attachment representation
     class KeeperFile
-      attr_accessor :uid, :name, :title, :mime_type, :size, :data, :url, :thumbnail_url, :last_modified
+      attr_accessor :uid, :name, :title, :mime_type, :size, :data, :url, :thumbnail_url, :last_modified, :file_key
 
       def initialize(attrs = {})
         @uid = attrs['fileUid'] || attrs['uid'] || attrs[:uid]
@@ -514,6 +514,7 @@ module KeeperSecretsManager
         @url = attrs['url'] || attrs[:url]
         @thumbnail_url = attrs['thumbnailUrl'] || attrs['thumbnail_url'] || attrs[:thumbnail_url]
         @last_modified = attrs['lastModified'] || attrs['last_modified'] || attrs[:last_modified]
+        @file_key = attrs['fileKey'] || attrs['file_key'] || attrs[:file_key]
       end
 
       def to_h

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
@@ -427,4 +427,48 @@ RSpec.describe KeeperSecretsManager::Core::SecretsManager do
       manager.update_secret(hash_record)
     end
   end
+
+  describe '#download_thumbnail' do
+    let(:manager) { described_class.new(config: mock_config) }
+    let(:thumbnail_url) { 'https://example.com/thumb.jpg' }
+    let(:file_key_bytes) { KeeperSecretsManager::Crypto.generate_encryption_key_bytes }
+    let(:file_key_b64) { KeeperSecretsManager::Utils.bytes_to_base64(file_key_bytes) }
+    let(:decrypted_thumb) { 'thumb-content' }
+
+    before do
+      allow(manager).to receive(:download_encrypted_file).and_return('encrypted-bytes')
+      allow(KeeperSecretsManager::Crypto).to receive(:decrypt_aes_gcm).and_return(decrypted_thumb)
+    end
+
+    it 'does not raise NoMethodError when passed a KeeperFile object' do
+      file = KeeperSecretsManager::Dto::KeeperFile.new(
+        'fileUid' => 'file-uid-1096',
+        'thumbnailUrl' => thumbnail_url,
+        'fileKey' => file_key_b64
+      )
+      expect { manager.download_thumbnail(file) }.not_to raise_error
+    end
+
+    it 'returns the correct uid and data when passed a KeeperFile object' do
+      file = KeeperSecretsManager::Dto::KeeperFile.new(
+        'fileUid' => 'file-uid-1096',
+        'thumbnailUrl' => thumbnail_url,
+        'fileKey' => file_key_b64
+      )
+      result = manager.download_thumbnail(file)
+      expect(result['file_uid']).to eq('file-uid-1096')
+      expect(result['data']).to eq(decrypted_thumb)
+    end
+
+    it 'still works with a plain hash' do
+      file_hash = {
+        'fileUid' => 'file-uid-hash',
+        'thumbnailUrl' => thumbnail_url,
+        'fileKey' => file_key_b64
+      }
+      result = manager.download_thumbnail(file_hash)
+      expect(result['file_uid']).to eq('file-uid-hash')
+      expect(result['data']).to eq(decrypted_thumb)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `download_thumbnail` called `file_data['fileUid']` without checking whether `file_data` supports `[]`, raising `NoMethodError` whenever a `KeeperFile` object was passed.
- Fixed by adding an `is_a?(Dto::KeeperFile)` branch that reads `uid`, `thumbnail_url`, and `file_key` via accessors, falling back to hash access for all other inputs.
- Added `file_key` attr_accessor to `KeeperFile` (populated from `'fileKey'`/`'file_key'`/`:file_key` in the constructor) so the decrypted key is accessible from the object.
- Added three regression tests: no error with a `KeeperFile` object, correct result shape with a `KeeperFile` object, existing hash path still works.

Jira: KSM-1096

## Breaking Changes

None.