### PR TITLE
Rust SDK: delete_secret returns per-item failure detail

### DIFF
--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [17.4.0]
+
+### Fixed
+
+- **KSM-1089 / KSM-1129**: `delete_secret` now returns full per-item detail (`recordUid`, `responseCode`, `errorMessage`) for every UID passed in, success or failure, matching `delete_folder`'s existing shape. Previously it collapsed the response down to a comma-joined `String` of only the *successful* UIDs; a failed UID's `responseCode`/`errorMessage` were logged but not returned, so callers had no programmatic way to detect a partial-delete failure.
+  - **Note**: this is a breaking change. `delete_secret`'s return type changes from `Result<String, KSMRError>` to `Result<Vec<HashMap<String, Value>>, KSMRError>`. Callers that treated the return value as a joined string of successful UIDs must update to inspect the `Vec<HashMap>` instead (e.g. filter on `responseCode == "ok"` to recover the old "successful UIDs" list). The now-unused `calculate_successful_deletes` helper has been removed.
+
 ## [17.3.0]
 
 ### Added

--- a/sdk/rust/docs/developer_docs.md
+++ b/sdk/rust/docs/developer_docs.md
@@ -724,12 +724,28 @@ Delete Secret
     let mut secrets_manager = SecretsManager::new(client_options)?;
 
     // delete a specific secret by UID
-    let secret_to_delete = secrets_manager.delete_secret(vec!["<RECORD UID>".to_string()])?;
+    let delete_results = secrets_manager.delete_secret(vec!["<RECORD UID>".to_string()])?;
+
+    for result in &delete_results {
+        let response_code = result.get("responseCode").and_then(|v| v.as_str()).unwrap_or("");
+        if response_code != "ok" {
+            println!("Failed to delete {:?}: {} {}",
+                result.get("recordUid"),
+                response_code,
+                result.get("errorMessage").and_then(|v| v.as_str()).unwrap_or(""));
+        }
+    }
 ```
 
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `record_uid` | `String` | Yes | None | The uid of the record to be deleted |
+
+#### Returns
+
+> Type: `Vec<HashMap<String, Value>>`
+
+One entry per requested UID, each with `recordUid`, `responseCode` (`"ok"` on success), and `errorMessage` (present on failure).
 
   
 

--- a/sdk/rust/src/core/core.rs
+++ b/sdk/rust/src/core/core.rs
@@ -2072,13 +2072,16 @@ impl SecretsManager {
     ///
     /// # Returns
     ///
-    /// * `Result<String, KSMRError>` - JSON response from the server or an error
+    /// * `Result<Vec<HashMap<String, Value>>, KSMRError>` - Server response for each record deletion
     ///
     /// # Errors
     ///
     /// * `HTTPError` - If the API request fails
     /// * `AuthenticationError` - If credentials are invalid
-    pub fn delete_secret(&mut self, record_uid: Vec<String>) -> Result<String, KSMRError> {
+    pub fn delete_secret(
+        &mut self,
+        record_uid: Vec<String>,
+    ) -> Result<Vec<HashMap<String, Value>>, KSMRError> {
         let config_clone = self.config.clone();
         let delete_payload = Self::delete_payload(config_clone, record_uid)?;
         let response = self.post_query("delete_secret".to_string(), &delete_payload)?;
@@ -2099,42 +2102,16 @@ impl SecretsManager {
                 )
             })?;
 
-        let simplified_records = records
-            .into_iter()
-            .map(|record| {
-                record
-                    .into_iter()
-                    .map(|(k, v)| (k, v.to_string()))
-                    .collect::<HashMap<String, String>>()
-            })
-            .collect();
+        for record in &records {
+            let response_code = record.get("responseCode").and_then(|v| v.as_str()).unwrap_or("");
+            if response_code != "ok" {
+                let record_uid = record.get("recordUid").and_then(|v| v.as_str()).unwrap_or("?");
+                let error_msg = record.get("errorMessage").and_then(|v| v.as_str()).unwrap_or("");
+                error!("Failed to delete secret {}: {} {}", record_uid, response_code, error_msg);
+            }
+        }
 
-        self.clone()
-            .calculate_successful_deletes(simplified_records)
-    }
-
-    pub fn calculate_successful_deletes(
-        self,
-        dict: Vec<HashMap<String, String>>,
-    ) -> Result<String, KSMRError> {
-        let deleted_secrets: Vec<String> = dict
-            .into_iter()
-            .filter_map(|dict_value| {
-                if dict_value.get("responseCode") == Some(&"\"ok\"".to_string()) {
-                    dict_value.get("recordUid").cloned()
-                } else {
-                    if let Some(record_uid) = dict_value.get("recordUid") {
-                        error!("Failed to delete secret {}: {} {}",
-                            record_uid,
-                            dict_value.get("responseCode").map(|s| s.trim_matches('"')).unwrap_or(""),
-                            dict_value.get("errorMessage").map(|s| s.trim_matches('"')).unwrap_or(""));
-                    }
-                    None
-                }
-            })
-            .collect();
-
-        Ok(deleted_secrets.join(", "))
+        Ok(records)
     }
     fn prepare_delete_folder_payload(
         storage: KvStoreType,

--- a/sdk/rust/tests/feature_validation_tests.rs
+++ b/sdk/rust/tests/feature_validation_tests.rs
@@ -802,4 +802,86 @@ mod feature_validation_tests {
         assert_eq!(folders[0].folder_uid, "good-uid");
         assert_eq!(folders[0].name, "Good Folder");
     }
+
+    /// delete_secret() must expose per-item failure detail to the caller,
+    /// not just log it.
+    ///
+    /// Before this fix, `delete_secret` collapsed the server's per-record
+    /// response down to a comma-joined `String` of only the *successful*
+    /// UIDs (`calculate_successful_deletes`), discarding `responseCode`/
+    /// `errorMessage` for any failed UID entirely except in a log line.
+    /// This drives `delete_secret` with a stubbed response containing one
+    /// successful and one failed record, and asserts the failure detail is
+    /// readable from the *returned value* itself.
+    ///
+    /// A pass proves the caller can programmatically detect and inspect a
+    /// partial-delete failure. A failure (or compile error, given the
+    /// return-type change) means the old string-only behavior persists.
+    #[test]
+    fn test_delete_secret_surfaces_per_item_failure_detail() {
+        let response = json!({
+            "records": [
+                { "recordUid": "good-uid", "responseCode": "ok" },
+                {
+                    "recordUid": "bad-uid",
+                    "responseCode": "fail_reason",
+                    "errorMessage": "Access denied"
+                }
+            ]
+        });
+        let response_bytes = response.to_string().into_bytes();
+
+        let storage = create_test_storage().expect("Failed to create storage");
+        let mut client_options = ClientOptions::new_client_options(storage);
+        client_options.set_custom_post_function(
+            move |_url: String,
+                  transmission_key: TransmissionKey,
+                  _payload: EncryptedPayload| {
+                let encrypted =
+                    CryptoUtils::encrypt_aes_gcm(&response_bytes, &transmission_key.key, None)?;
+                Ok(KsmHttpResponse {
+                    status_code: 200,
+                    data: encrypted,
+                    http_response: None,
+                })
+            },
+        );
+        let mut sm = SecretsManager::new(client_options).expect("Failed to create SecretsManager");
+
+        let result = sm.delete_secret(vec!["good-uid".to_string(), "bad-uid".to_string()]);
+        assert!(
+            result.is_ok(),
+            "delete_secret() must succeed when the server reports a per-item failure, got: {:?}",
+            result
+        );
+
+        let records = result.unwrap();
+        assert_eq!(
+            records.len(),
+            2,
+            "expected both records (success and failure) in the returned detail, got {:?}",
+            records
+        );
+
+        let bad = records
+            .iter()
+            .find(|r| r.get("recordUid").and_then(|v| v.as_str()) == Some("bad-uid"))
+            .expect("bad-uid must be present in the returned per-item detail");
+        assert_eq!(
+            bad.get("responseCode").and_then(|v| v.as_str()),
+            Some("fail_reason"),
+            "failed record's responseCode must be readable from the return value, not just logged"
+        );
+        assert_eq!(
+            bad.get("errorMessage").and_then(|v| v.as_str()),
+            Some("Access denied"),
+            "failed record's errorMessage must be readable from the return value, not just logged"
+        );
+
+        let good = records
+            .iter()
+            .find(|r| r.get("recordUid").and_then(|v| v.as_str()) == Some("good-uid"))
+            .expect("good-uid must be present in the returned per-item detail");
+        assert_eq!(good.get("responseCode").and_then(|v| v.as_str()), Some("ok"));
+    }
 }


### PR DESCRIPTION
## Summary
Rust SDK: `delete_secret` now returns structured per-item failure detail instead of a comma-joined string of successful UIDs, matching `delete_folder` and the equivalent method in every sibling SDK.

## Changes

### Fixed
- `delete_secret`'s return type changes from `Result<String, KSMRError>` to `Result<Vec<HashMap<String, Value>>, KSMRError>`, exposing `recordUid`/`responseCode`/`errorMessage` for every UID passed in, not just successes (KSM-1129, completes KSM-1089)
- Removed the now-unused `calculate_successful_deletes` helper
- Updated the `delete_secret` rustdoc and the `docs/developer_docs.md` example to match the new return type

## Testing
```
cd sdk/rust
cargo test
```

## Breaking Changes
`delete_secret`'s return type changes from `Result<String, KSMRError>` (comma-joined successful UIDs) to `Result<Vec<HashMap<String, Value>>, KSMRError>` (full per-item detail for every UID, success or failure). Callers that treated the return value as a joined string of successful UIDs must update to inspect the `Vec<HashMap>` instead (e.g. filter on `responseCode == "ok"` to recover the old list). Documented in `CHANGELOG.md` under `[17.4.0]`.

## Related Issues
- Jira: KSM-1129 (relates to KSM-1089)