### PR TITLE
fix(javascript): KSM-748 use folder key for shared-folder records in flat array

### DIFF
--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -883,13 +883,34 @@ const fetchAndDecryptSecrets = async (options: SecretManagerOptions, queryOption
         await storage.delete(KEY_CLIENT_KEY)
         await storage.saveString(KEY_OWNER_PUBLIC_KEY, response.appOwnerPublicKey!)
     }
+    const folderKeyIds = new Set<string>()
+    if (response.folders) {
+        for (const folder of response.folders) {
+            try {
+                if (!folder.folderKey) continue
+                await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true)
+                folderKeyIds.add(folder.folderUid)
+            } catch (e: Error | any) {
+                // ignored here; the folders loop below re-attempts the same unwrap and logs the failure
+            }
+        }
+    }
     if (response.records) {
         for (const record of response.records) {
             try {
                 if (record.recordKey) {
-                    await platform.unwrap(platform.base64ToBytes(record.recordKey), record.recordUid, KEY_APP_KEY, storage, true)
+                    // Records created outside the SDK in a shared folder arrive in the flat
+                    // response.records[] with innerFolderUid set; their recordKey is wrapped
+                    // with the folder key, not the app key.
+                    const unwrappingKeyId = record.innerFolderUid && folderKeyIds.has(record.innerFolderUid)
+                        ? record.innerFolderUid
+                        : KEY_APP_KEY
+                    await platform.unwrap(platform.base64ToBytes(record.recordKey), record.recordUid, unwrappingKeyId, storage, true)
                 }
                 const decryptedRecord = await decryptRecord(record, storage)
+                if (record.innerFolderUid && folderKeyIds.has(record.innerFolderUid)) {
+                    decryptedRecord.folderUid = record.innerFolderUid
+                }
                 records.push(decryptedRecord)
             } catch (e: Error | any) {
                 console.error(`Record ${record.recordUid} skipped due to error: ${e.constructor.name}, ${e.message}`)

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -405,3 +405,95 @@ test('getFolders skips an undecryptable folder and returns the good one', async 
     expect(folders[0].folderUid).toBe('good-uid')
     expect(folders[0].name).toBe('Good Folder')
 })
+
+test('flat record with innerFolderUid decrypts recordKey using the folder key, not the app key', async () => {
+    const transmissionKey = new Uint8Array(32).fill(1)
+    const appKey = new Uint8Array(32).fill(2)
+    const folderKey = new Uint8Array(32).fill(3)
+    const recordKey = new Uint8Array(32).fill(4)
+    const folderUid = 'folder-uid-1'
+    const recordUid = 'record-uid-1'
+
+    const wrappedFolderKey = await platform.encryptWithKey(folderKey, appKey)
+    const wrappedRecordKey = await platform.encryptWithKey(recordKey, folderKey)
+    const recordData = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify({ title: 'Shared Record', type: 'login', fields: [], custom: [] })), recordKey)
+
+    const serverResponse = {
+        folders: [
+            { folderUid, folderKey: platform.bytesToBase64(wrappedFolderKey), data: '', records: [] }
+        ],
+        records: [
+            {
+                recordUid,
+                recordKey: platform.bytesToBase64(wrappedRecordKey),
+                data: platform.bytesToBase64(recordData),
+                revision: 1,
+                files: [],
+                innerFolderUid: folderUid
+            }
+        ],
+        expiresOn: 0,
+        warnings: []
+    }
+    const encryptedResponse = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify(serverResponse)), transmissionKey)
+
+    platform.getRandomBytes = () => transmissionKey
+    const queryFn = (): Promise<KeeperHttpResponse> => Promise.resolve({ data: encryptedResponse, statusCode: 200, headers: [] })
+
+    const kvs = inMemoryStorage({})
+    await initializeStorage(kvs, 'US:FAKE_CLIENT_KEY')
+    await kvs.saveBytes('appKey', appKey)
+
+    const secrets = await getSecrets({ storage: kvs, queryFunction: queryFn })
+
+    // Bug: the flat-records loop always unwraps recordKey with KEY_APP_KEY, ignoring
+    // innerFolderUid. Since recordKey here is wrapped with the folder key, unwrapping
+    // with the app key throws, the record is caught and silently skipped, and
+    // secrets.records comes back empty instead of containing the decrypted record.
+    expect(secrets.records.length).toBe(1)
+    expect(secrets.records[0].data.title).toBe('Shared Record')
+    expect(secrets.records[0].folderUid).toBe(folderUid)
+})
+
+test('flat record with innerFolderUid falls back to the app key when no matching folder is returned', async () => {
+    const transmissionKey = new Uint8Array(32).fill(5)
+    const appKey = new Uint8Array(32).fill(6)
+    const recordKey = new Uint8Array(32).fill(7)
+    const recordUid = 'record-uid-2'
+
+    const wrappedRecordKey = await platform.encryptWithKey(recordKey, appKey)
+    const recordData = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify({ title: 'Orphaned Record', type: 'login', fields: [], custom: [] })), recordKey)
+
+    const serverResponse = {
+        folders: [],
+        records: [
+            {
+                recordUid,
+                recordKey: platform.bytesToBase64(wrappedRecordKey),
+                data: platform.bytesToBase64(recordData),
+                revision: 1,
+                files: [],
+                innerFolderUid: 'folder-uid-not-in-response'
+            }
+        ],
+        expiresOn: 0,
+        warnings: []
+    }
+    const encryptedResponse = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify(serverResponse)), transmissionKey)
+
+    platform.getRandomBytes = () => transmissionKey
+    const queryFn = (): Promise<KeeperHttpResponse> => Promise.resolve({ data: encryptedResponse, statusCode: 200, headers: [] })
+
+    const kvs = inMemoryStorage({})
+    await initializeStorage(kvs, 'US:FAKE_CLIENT_KEY')
+    await kvs.saveBytes('appKey', appKey)
+
+    const secrets = await getSecrets({ storage: kvs, queryFunction: queryFn })
+
+    expect(secrets.records.length).toBe(1)
+    expect(secrets.records[0].data.title).toBe('Orphaned Record')
+})


### PR DESCRIPTION
## Summary
JavaScript SDK: records created via non-SDK clients inside a shared folder can arrive in the flat `response.records[]` array with `innerFolderUid` set. The `recordKey` for these is wrapped with the folder key, not the app key, but `fetchAndDecryptSecrets` always unwrapped with the app key, so the record silently failed to decrypt and was dropped.

## Changes

### Fixed
- Records in shared folders now decrypt correctly when returned in the flat `records[]` array instead of being silently skipped (KSM-748)

## Testing
```
cd sdk/javascript/packages/core && npm test
```
Two new regression tests in `test/keeper.test.ts`:
- confirms a flat record with `innerFolderUid` decrypts using the matching folder's key
- confirms a flat record whose `innerFolderUid` has no matching folder in the response still falls back to the app key

Also verified live against a real vault: a record created via Commander inside a shared folder, with that folder shared to a throwaway KSM Application, decrypted correctly through this code path with the fix in place.

## Security Impact
This SDK previously selected the wrong decryption key for a specific class of shared-folder records, causing them to fail decryption and be dropped rather than exposing data to the wrong party — no information disclosure, but a correctness/availability gap for legitimate shared-folder access. The fix selects the key based on `innerFolderUid` matching an entry in the folder-key map built from `response.folders`, mirroring the pattern already shipped in the Java SDK (KSM-753). No change to how keys are transmitted, wrapped, or stored.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-748