### PR TITLE
fix(javascript): KSM-1035 one-sided throttle jitter and retry_after cap

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 17.6.0
+- KSM-1035 - Throttle backoff hardening: retry jitter is now one-sided (0 to +25%, so delays never fall below the computed floor), and a server-supplied `retry_after` is capped at 176s (the exponential ladder's last step) so it can no longer force an excessive or unbounded wait.
+
 ## 17.5.0
 - KSM-1029 - Fixed stale pinned server key error: when the server rejects a configured custom server public key, the diagnostic message now propagates to the caller instead of being swallowed by a bare catch.
 - KSM-880 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `postQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` is thrown once retries are exhausted. Existing key-rotation retry behavior is unchanged.

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -96,7 +96,7 @@ export const parseThrottle = (body: string): number | null => {
 /**
  * Computes the backoff delay (milliseconds) for a 0-based `attempt`: `retryAfter` seconds when
  * provided (> 0), otherwise exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22,
- * 44, 88, 176s). The `jitter` fraction (typically in [-0.25, 0.25)) is then applied.
+ * 44, 88, 176s). The `jitter` fraction (typically in [0, 0.25)) is then applied.
  */
 export const throttleDelay = (attempt: number, retryAfter: number, jitter: number = throttleJitter()): number => {
     const baseSec = retryAfter > 0 ? retryAfter : BASE_THROTTLE_DELAY_SEC * Math.pow(2, attempt)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -20,6 +20,7 @@ const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
 // request, so the counter only clears after 10s of silence).
 const MAX_THROTTLE_RETRIES = 5
 const BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
+const MAX_THROTTLE_DELAY_SEC = 176 // same ceiling the exponential branch reaches at the last retry (11 * 2**4)
 const CLIENT_ID_HASH_TAG = 'KEEPER_SECRETS_MANAGER_CLIENT_ID' // Tag for hashing the client key to client id
 
 let keeperPublicKeys: Record<number, Uint8Array>
@@ -62,14 +63,17 @@ export type SecretManagerOptions = {
 // utils.ts/platform code that throws them; re-exported here so the public API is unchanged.
 export {KeeperError, KeeperThrottleError} from './errors'
 
-// Returns a jitter multiplier in [-0.25, 0.25). Kept separate so concurrent clients
-// desynchronize their retries; unit tests exercise throttleDelay with a pinned jitter.
-export const throttleJitter = (): number => Math.random() * 0.5 - 0.25
+// Returns a jitter multiplier in [0, 0.25). One-sided so the delay never drops below the
+// computed floor (retrying too soon just re-triggers the throttle); kept separate so
+// concurrent clients desynchronize their retries. Unit tests exercise throttleDelay with a
+// pinned jitter.
+export const throttleJitter = (): number => Math.random() * 0.25
 
 /**
  * If `body` is a backend throttle error (`result_code`/`error` === "throttled") returns its
- * `retry_after` in seconds (>= 0); otherwise returns `null` so the caller falls through to
- * normal error handling. Non-JSON / non-object bodies return `null`.
+ * `retry_after` in seconds (>= 0, capped at MAX_THROTTLE_DELAY_SEC); otherwise returns `null`
+ * so the caller falls through to normal error handling. Non-JSON / non-object bodies return
+ * `null`.
  */
 export const parseThrottle = (body: string): number | null => {
     let obj: any
@@ -86,7 +90,7 @@ export const parseThrottle = (body: string): number | null => {
         return null
     }
     const retryAfter = Number(obj.retry_after)
-    return Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 0
+    return Number.isFinite(retryAfter) && retryAfter > 0 ? Math.min(retryAfter, MAX_THROTTLE_DELAY_SEC) : 0
 }
 
 /**

--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -60,8 +60,8 @@ describe('throttleDelay (unit)', () => {
         expect(throttleDelay(0, 0, 0)).toBe(11000)
         expect(throttleDelay(1, -5, 0)).toBe(22000)
     })
-    test('jitter bounds keep the first delay in [8.25s, 13.75s]', () => {
-        expect(throttleDelay(0, 0, -0.25)).toBe(8250)
+    test('jitter bounds keep the first delay in [11s, 13.75s)', () => {
+        expect(throttleDelay(0, 0, 0)).toBe(11000)
         expect(throttleDelay(0, 0, 0.25)).toBe(13750)
     })
 })

--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -9,6 +9,7 @@ import {
     KeeperThrottleError,
     parseThrottle,
     throttleDelay,
+    throttleJitter,
 } from '../'
 
 // A valid one-time token (same fixture the e2e suite uses) so initializeStorage produces a
@@ -65,6 +66,16 @@ describe('throttleDelay (unit)', () => {
     })
 })
 
+describe('throttleJitter (unit)', () => {
+    test('is one-sided: never pushes the delay below its floor', () => {
+        for (let i = 0; i < 200; i++) {
+            const jitter = throttleJitter()
+            expect(jitter).toBeGreaterThanOrEqual(0)
+            expect(jitter).toBeLessThan(0.25)
+        }
+    })
+})
+
 describe('parseThrottle (unit)', () => {
     test('throttled via error / result_code with retry_after variants', () => {
         expect(parseThrottle('{"error":"throttled"}')).toBe(0)
@@ -76,6 +87,13 @@ describe('parseThrottle (unit)', () => {
         expect(parseThrottle('{"error":"key"}')).toBeNull()
         expect(parseThrottle('not json')).toBeNull()
         expect(parseThrottle('')).toBeNull()
+    })
+    test('retry_after beyond the exponential ceiling is capped at 176s', () => {
+        // 176s = BASE_THROTTLE_DELAY_SEC * 2**(MAX_THROTTLE_RETRIES - 1) = 11 * 2**4, the same
+        // ceiling the exponential branch already reaches on the last retry attempt.
+        expect(parseThrottle('{"error":"throttled","retry_after":500}')).toBe(176)
+        expect(parseThrottle('{"error":"throttled","retry_after":176}')).toBe(176)
+        expect(parseThrottle('{"error":"throttled","retry_after":175}')).toBe(175)
     })
 })
 
@@ -118,8 +136,8 @@ describe('throttle retry (e2e via getSecrets)', () => {
             call++ === 0 ? throttle403(3) : throttle403()
         )
         await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
-        // retry_after = 3s with +/-25% jitter -> [2.25s, 3.75s]
-        expect(sleeps[0]).toBeGreaterThanOrEqual(2250)
+        // retry_after = 3s with one-sided [0, +25%) jitter -> [3s, 3.75s]; never below the 3s floor
+        expect(sleeps[0]).toBeGreaterThanOrEqual(3000)
         expect(sleeps[0]).toBeLessThanOrEqual(3750)
     })
 


### PR DESCRIPTION
## Summary
JavaScript SDK: applies the throttle-backoff hardening already shipped for Ruby (KSM-883) to the JS retry loop, tightening the jitter to one-sided and capping a server-supplied `retry_after`.

## Changes

### Fixed
- `throttleJitter()` narrowed from `[-0.25, 0.25)` to `[0, 0.25)`. The old symmetric jitter could shave up to 25% off the computed backoff floor, so a retry could fire before the server's throttle window cleared and immediately re-trigger the same throttle (KSM-1035)
- `parseThrottle()` now caps a server-supplied `retry_after` at `MAX_THROTTLE_DELAY_SEC` (176s) — the same ceiling the exponential backoff branch already reaches on its last retry attempt, so a server-supplied value can no longer exceed what the client would otherwise wait

## Testing
```
cd sdk/javascript/packages/core && npm test
```
`test/throttle.test.ts`:
- new: `throttleJitter` never returns a negative value across 200 samples
- new: `parseThrottle` clamps `retry_after` at 176s
- tightened the existing `honors retry_after from the response body` e2e assertion's lower bound from 2250ms to 3000ms, since jitter can no longer subtract time

## Security Impact
None — this is timing/backoff logic only; no change to how secrets are transmitted, encrypted, or stored.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1035