### PR TITLE
fix(javascript): KSM-1128 bound server-key-rotation retries in postQuery

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -6,6 +6,7 @@
 - KSM-1084 - Fixed `deleteSecret()` and `deleteFolder()` silently reporting success when the server rejected some UIDs. The SDK now surfaces per-item error messages from the server to the caller.
 - KSM-748 - Fixed `getSecrets()` silently dropping records created by Commander or the Vault UI inside shared folders. The SDK now uses the folder key to decrypt the record key for any flat record that has `innerFolderUid` set. This matches the behavior for records in `folders[].records[]`.
 - KSM-1035 - Fixed throttle retry jitter being two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s to prevent an arbitrarily long wait.
+- KSM-1128 - Bounded the server key-rotation retry in `postQuery`. When the server sends `{"error":"key"}`, the code retries at most 3 times before throwing a typed `KeeperError`, instead of retrying forever. Before storing a suggested `key_id`, the code validates its shape (positive integer) and its membership in the bundled key table (keys 7-18). An unsupported key id can no longer corrupt the configuration. The pinned custom-key path does not change.
 - Maintenance: Updated `minimatch`, `@babel/core`, and `handlebars` dev dependencies.
 
 ## 17.5.0

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -19,6 +19,10 @@ const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
 // request, so the counter only clears after 10s of silence).
 const MAX_THROTTLE_RETRIES = 5
+// Bounds the server-key-rotation retry (postQuery's `error === 'key'` branch, no custom key
+// pinned): one legitimate rotation should resolve it, so this only needs to tolerate a little
+// slack, not act as a real retry budget.
+const MAX_KEY_ROTATION_RETRIES = 3
 const BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
 const MAX_THROTTLE_DELAY_SEC = 176 // same ceiling the exponential branch reaches at the last retry (11 * 2**4)
 const CLIENT_ID_HASH_TAG = 'KEEPER_SECRETS_MANAGER_CLIENT_ID' // Tag for hashing the client key to client id
@@ -788,6 +792,7 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
     const url = `https://${hostName}/api/rest/sm/v1/${path}`
     const sleep = options.throttleSleep || ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
     let throttleAttempt = 0
+    let keyRotationAttempt = 0
     while (true) {
         const transmissionKey = await generateTransmissionKey(options.storage)
         const encryptedPayload = await encryptAndSignPayload(options.storage, transmissionKey, payload)
@@ -820,7 +825,11 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                         const currentKeyId = await options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
                         throw new Error(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${errorObj.key_id}. Please update your IL5 KSM configuration.`)
                     }
+                    if (keyRotationAttempt >= MAX_KEY_ROTATION_RETRIES) {
+                        throw new Error(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; suggested key id ${errorObj.key_id} was not accepted`)
+                    }
                     await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, errorObj.key_id!.toString())
+                    keyRotationAttempt++
                     continue
                 }
             } else {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -821,13 +821,13 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                 try { errorObj = JSON.parse(errorMessage) } catch {}
                 if (errorObj?.error === 'key') {
                     const suggestedKeyId = errorObj.key_id
-                    if (typeof suggestedKeyId !== 'number' || !Number.isInteger(suggestedKeyId) || suggestedKeyId <= 0) {
-                        throw new KeeperError(`Server key error response contains invalid key_id: ${JSON.stringify(suggestedKeyId)}`)
-                    }
                     const customKey = await options.storage.getString(KEY_SERVER_PUBLIC_KEY)
                     if (customKey) {
                         const currentKeyId = await options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
                         throw new KeeperError(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${suggestedKeyId}. Please update your IL5 KSM configuration.`)
+                    }
+                    if (typeof suggestedKeyId !== 'number' || !Number.isInteger(suggestedKeyId) || suggestedKeyId <= 0) {
+                        throw new KeeperError(`Server key error response contains invalid key_id: ${JSON.stringify(suggestedKeyId)}`)
                     }
                     if (!(suggestedKeyId in keeperPublicKeys)) {
                         throw new KeeperError(`Server suggested unsupported key id ${suggestedKeyId}; this SDK version supports key ids 7-18`)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -829,8 +829,11 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                         const currentKeyId = await options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
                         throw new KeeperError(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${suggestedKeyId}. Please update your IL5 KSM configuration.`)
                     }
+                    if (!(suggestedKeyId in keeperPublicKeys)) {
+                        throw new KeeperError(`Server suggested unsupported key id ${suggestedKeyId}; this SDK version supports key ids 7-18`)
+                    }
                     if (keyRotationAttempt >= MAX_KEY_ROTATION_RETRIES) {
-                        throw new KeeperError(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; suggested key id ${suggestedKeyId} was not accepted`)
+                        throw new KeeperError(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; transmission key id ${transmissionKey.publicKeyId} was not accepted`)
                     }
                     await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, suggestedKeyId.toString())
                     keyRotationAttempt++

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -1,7 +1,7 @@
 import {EncryptedPayload, KeeperHttpResponse, KeyValueStorage, platform, TransmissionKey} from './platform'
 import {webSafe64FromBytes, webSafe64ToBytes, tryParseInt} from './utils'
 import {parseNotation} from './notation'
-import {KeeperThrottleError} from './errors'
+import {KeeperError, KeeperThrottleError} from './errors'
 
 export {KeyValueStorage} from './platform'
 
@@ -820,15 +820,19 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                 let errorObj: KeeperApiError | null = null
                 try { errorObj = JSON.parse(errorMessage) } catch {}
                 if (errorObj?.error === 'key') {
+                    const suggestedKeyId = errorObj.key_id
+                    if (typeof suggestedKeyId !== 'number' || !Number.isInteger(suggestedKeyId) || suggestedKeyId <= 0) {
+                        throw new KeeperError(`Server key error response contains invalid key_id: ${JSON.stringify(suggestedKeyId)}`)
+                    }
                     const customKey = await options.storage.getString(KEY_SERVER_PUBLIC_KEY)
                     if (customKey) {
                         const currentKeyId = await options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
-                        throw new Error(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${errorObj.key_id}. Please update your IL5 KSM configuration.`)
+                        throw new KeeperError(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${suggestedKeyId}. Please update your IL5 KSM configuration.`)
                     }
                     if (keyRotationAttempt >= MAX_KEY_ROTATION_RETRIES) {
-                        throw new Error(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; suggested key id ${errorObj.key_id} was not accepted`)
+                        throw new KeeperError(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; suggested key id ${suggestedKeyId} was not accepted`)
                     }
-                    await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, errorObj.key_id!.toString())
+                    await options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, suggestedKeyId.toString())
                     keyRotationAttempt++
                     continue
                 }

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -824,13 +824,14 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
                     const customKey = await options.storage.getString(KEY_SERVER_PUBLIC_KEY)
                     if (customKey) {
                         const currentKeyId = await options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
-                        throw new KeeperError(`Server rejected the custom server public key (id ${currentKeyId}). The server suggested key id ${suggestedKeyId}. Please update your IL5 KSM configuration.`)
+                        throw new KeeperError(`Server rejected the custom server public key (id ${currentKeyId ?? transmissionKey.publicKeyId}). The server suggested key id ${suggestedKeyId}. Please update your IL5 KSM configuration.`)
                     }
                     if (typeof suggestedKeyId !== 'number' || !Number.isInteger(suggestedKeyId) || suggestedKeyId <= 0) {
                         throw new KeeperError(`Server key error response contains invalid key_id: ${JSON.stringify(suggestedKeyId)}`)
                     }
                     if (!(suggestedKeyId in keeperPublicKeys)) {
-                        throw new KeeperError(`Server suggested unsupported key id ${suggestedKeyId}; this SDK version supports key ids 7-18`)
+                        const supported = Object.keys(keeperPublicKeys)
+                        throw new KeeperError(`Server suggested unsupported key id ${suggestedKeyId}; this SDK version supports key ids ${supported[0]}-${supported[supported.length - 1]}`)
                     }
                     if (keyRotationAttempt >= MAX_KEY_ROTATION_RETRIES) {
                         throw new KeeperError(`Server key rotation exhausted ${MAX_KEY_ROTATION_RETRIES} retries; transmission key id ${transmissionKey.publicKeyId} was not accepted`)

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -321,7 +321,7 @@ test('IL5 dynamic key - rotation suppression: server key_id hint ignored when se
     expect(await storage.getString('serverPublicKeyId')).toBe('20')
 })
 
-test('IL5 dynamic key - server key rotation retries are bounded, not infinite', async () => {
+test('key rotation - retries are bounded, not infinite', async () => {
     const storage = inMemoryStorage({})
     await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     let calls = 0
@@ -341,7 +341,7 @@ test('IL5 dynamic key - server key rotation retries are bounded, not infinite', 
     expect(calls).toBe(4)
 })
 
-test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
+test('key rotation - suggested key id is adopted and persisted', async () => {
     const storage = inMemoryStorage({})
     await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     let calls = 0
@@ -369,7 +369,7 @@ test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
     expect(await storage.getString('serverPublicKeyId')).toBe('8')
 })
 
-test('IL5 dynamic key - unsupported suggested key id is rejected, not persisted', async () => {
+test('key rotation - unsupported suggested key id is rejected, not persisted', async () => {
     const storage = inMemoryStorage({})
     await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     let calls = 0

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -321,27 +321,38 @@ test('IL5 dynamic key - server key rotation retries are bounded, not infinite', 
     const storage = inMemoryStorage({})
     await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
     let calls = 0
+    const enc = new TextEncoder()
+    const keyError = { statusCode: 400, data: enc.encode(JSON.stringify({ error: 'key', key_id: 7 })), headers: [] }
     const options: SecretManagerOptions = {
         storage,
-        queryFunction: async () => {
-            calls++
-            // Safety net only: without a bound, this branch never throws a matching error on its
-            // own and the loop would otherwise run until the test times out.
-            if (calls > 50) {
-                throw new Error('TEST_GUARD_UNBOUNDED_LOOP')
-            }
-            // key_id 7 is a real supported key number so the loop keeps re-entering the
-            // key-rotation branch itself, rather than tripping over an unrelated "unsupported
-            // key number" error from generateTransmissionKey.
-            return {
-                statusCode: 400,
-                data: new TextEncoder().encode(JSON.stringify({ error: 'key', key_id: 7 })),
-                headers: []
-            }
-        }
+        // key_id 7 is a real supported key number so each retry re-enters the key-rotation branch
+        // rather than tripping over an unrelated "unsupported key number" error.
+        queryFunction: async () => { calls++; return keyError }
     }
     await expect(getSecrets(options)).rejects.toThrow(/key rotation exhausted/i)
-    expect(calls).toBeLessThanOrEqual(10)
+    // MAX_KEY_ROTATION_RETRIES = 3: initial attempt + 3 retries = 4 total calls.
+    expect(calls).toBe(4)
+})
+
+test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
+    let calls = 0
+    const enc = new TextEncoder()
+    const emptyResponse = enc.encode(JSON.stringify({ records: [], folders: [], expiresOn: 0, warnings: [] }))
+    const options: SecretManagerOptions = {
+        storage,
+        queryFunction: async (_url, tk) => {
+            calls++
+            if (calls === 1) {
+                return { statusCode: 400, data: enc.encode(JSON.stringify({ error: 'key', key_id: 7 })), headers: [] }
+            }
+            return { statusCode: 200, data: await platform.encryptWithKey(emptyResponse, tk.key), headers: [] }
+        }
+    }
+    const secrets = await getSecrets(options)
+    expect(secrets.records).toEqual([])
+    expect(calls).toBe(2)
 })
 
 test('stale pinned server key: diagnostic message propagates to caller, key preserved', async () => {

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -317,6 +317,33 @@ test('IL5 dynamic key - rotation suppression: server key_id hint ignored when se
     expect(await storage.getString('serverPublicKeyId')).toBe('20')
 })
 
+test('IL5 dynamic key - server key rotation retries are bounded, not infinite', async () => {
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
+    let calls = 0
+    const options: SecretManagerOptions = {
+        storage,
+        queryFunction: async () => {
+            calls++
+            // Safety net only: without a bound, this branch never throws a matching error on its
+            // own and the loop would otherwise run until the test times out.
+            if (calls > 50) {
+                throw new Error('TEST_GUARD_UNBOUNDED_LOOP')
+            }
+            // key_id 7 is a real supported key number so the loop keeps re-entering the
+            // key-rotation branch itself, rather than tripping over an unrelated "unsupported
+            // key number" error from generateTransmissionKey.
+            return {
+                statusCode: 400,
+                data: new TextEncoder().encode(JSON.stringify({ error: 'key', key_id: 7 })),
+                headers: []
+            }
+        }
+    }
+    await expect(getSecrets(options)).rejects.toThrow(/key rotation exhausted/i)
+    expect(calls).toBeLessThanOrEqual(10)
+})
+
 test('stale pinned server key: diagnostic message propagates to caller, key preserved', async () => {
     const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
     const storage = inMemoryStorage({})

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -10,6 +10,10 @@ import {
 
 import * as fs from 'fs'
 
+const FAKE_ONE_TIME_TOKEN = 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c'
+
+const keyErrorResponse = (keyId: number) => JSON.stringify({ error: 'key', key_id: keyId })
+
 test('Get secrets e2e', async () => {
 
     const responses: { transmissionKey: string, data: string, statusCode: number } [] = JSON.parse(fs.readFileSync('../../../fake_data.json').toString())
@@ -319,15 +323,18 @@ test('IL5 dynamic key - rotation suppression: server key_id hint ignored when se
 
 test('IL5 dynamic key - server key rotation retries are bounded, not infinite', async () => {
     const storage = inMemoryStorage({})
-    await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
+    await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     let calls = 0
     const enc = new TextEncoder()
-    const keyError = { statusCode: 400, data: enc.encode(JSON.stringify({ error: 'key', key_id: 7 })), headers: [] }
     const options: SecretManagerOptions = {
         storage,
-        // key_id 7 is a real supported key number so each retry re-enters the key-rotation branch
-        // rather than tripping over an unrelated "unsupported key number" error.
-        queryFunction: async () => { calls++; return keyError }
+        queryFunction: async () => {
+            calls++
+            if (calls > 50) {
+                throw new Error('runaway loop detected in key rotation retry')
+            }
+            return { statusCode: 400, data: enc.encode(keyErrorResponse(7)), headers: [] }
+        }
     }
     await expect(getSecrets(options)).rejects.toThrow(/key rotation exhausted/i)
     // MAX_KEY_ROTATION_RETRIES = 3: initial attempt + 3 retries = 4 total calls.
@@ -336,7 +343,7 @@ test('IL5 dynamic key - server key rotation retries are bounded, not infinite', 
 
 test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
     const storage = inMemoryStorage({})
-    await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
+    await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     let calls = 0
     const enc = new TextEncoder()
     const emptyResponse = enc.encode(JSON.stringify({ records: [], folders: [], expiresOn: 0, warnings: [] }))
@@ -344,31 +351,45 @@ test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
         storage,
         queryFunction: async (_url, tk) => {
             calls++
-            if (calls === 1) {
-                return { statusCode: 400, data: enc.encode(JSON.stringify({ error: 'key', key_id: 7 })), headers: [] }
+            if (calls > 50) {
+                throw new Error('runaway loop detected in key rotation retry')
             }
+            if (calls === 1) {
+                return { statusCode: 400, data: enc.encode(keyErrorResponse(8)), headers: [] }
+            }
+            // Verify the rotation was adopted: second request should use key_id 8.
+            expect(tk.publicKeyId).toBe(8)
             return { statusCode: 200, data: await platform.encryptWithKey(emptyResponse, tk.key), headers: [] }
         }
     }
     const secrets = await getSecrets(options)
     expect(secrets.records).toEqual([])
     expect(calls).toBe(2)
+    // Verify the suggested key_id 8 was persisted to storage.
+    expect(await storage.getString('serverPublicKeyId')).toBe('8')
 })
 
 test('stale pinned server key: diagnostic message propagates to caller, key preserved', async () => {
     const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
     const storage = inMemoryStorage({})
-    await initializeStorage(storage, 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c', 'fake.keepersecurity.com')
+    await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
     await storage.saveString('serverPublicKey', fakeKey)
     await storage.saveString('serverPublicKeyId', '20')
-    const keyError = JSON.stringify({ error: 'key', key_id: 7 })
+    let calls = 0
+    const enc = new TextEncoder()
     const options: SecretManagerOptions = {
         storage,
-        queryFunction: async () => ({
-            statusCode: 400,
-            data: new TextEncoder().encode(keyError),
-            headers: []
-        })
+        queryFunction: async () => {
+            calls++
+            if (calls > 50) {
+                throw new Error('runaway loop detected')
+            }
+            return {
+                statusCode: 400,
+                data: enc.encode(keyErrorResponse(7)),
+                headers: []
+            }
+        }
     }
     await expect(getSecrets(options)).rejects.toThrow(/Server rejected the custom server public key/)
     await expect(getSecrets(options)).rejects.toThrow(/Please update your IL5 KSM configuration/)

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -369,6 +369,27 @@ test('IL5 dynamic key - single key rotation succeeds on retry', async () => {
     expect(await storage.getString('serverPublicKeyId')).toBe('8')
 })
 
+test('IL5 dynamic key - unsupported suggested key id is rejected, not persisted', async () => {
+    const storage = inMemoryStorage({})
+    await initializeStorage(storage, FAKE_ONE_TIME_TOKEN, 'fake.keepersecurity.com')
+    let calls = 0
+    const enc = new TextEncoder()
+    const options: SecretManagerOptions = {
+        storage,
+        queryFunction: async () => {
+            calls++
+            if (calls > 50) {
+                throw new Error('runaway loop detected in key rotation retry')
+            }
+            return { statusCode: 400, data: enc.encode(keyErrorResponse(99)), headers: [] }
+        }
+    }
+    await expect(getSecrets(options)).rejects.toThrow(/unsupported key id 99/)
+    // Rejected before the retry loop persists anything: one request, config untouched.
+    expect(calls).toBe(1)
+    expect(await storage.getString('serverPublicKeyId')).toBeUndefined()
+})
+
 test('stale pinned server key: diagnostic message propagates to caller, key preserved', async () => {
     const fakeKey = 'BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM'
     const storage = inMemoryStorage({})


### PR DESCRIPTION
## Summary

JavaScript SDK: the \`postQuery\` key-rotation branch (\`{"error":"key"}\`, default path when no custom server public key is pinned) had no retry cap and no validation on the server-suggested \`key_id\`. A server that kept suggesting the same key would retry forever. A server that suggested an out-of-table id would persist it to storage and break every subsequent call.

## Changes

### Fixed
- Added a \`keyRotationAttempt\` counter bounded by \`MAX_KEY_ROTATION_RETRIES\` (3). After 3 rotation attempts the SDK throws a typed \`KeeperError\` instead of looping forever (KSM-1128).
- The server-suggested \`key_id\` is validated before use. The shape guard rejects any value that is not a positive integer. The membership guard rejects any id not present in the bundled key table (keys 7-18 as of this version). An unsupported id now throws a typed \`KeeperError\` and is never persisted to storage.
- When the server sends \`{"error":"key"}\` to a client with a pinned custom server public key, the existing custom-key diagnostic always fires regardless of what \`key_id\` contains. The shape and membership guards only run on the standard rotation path.

## Testing
\`\`\`
cd sdk/javascript/packages/core && npm test
\`\`\`
New tests in \`test/keeper.test.ts\`:
- \`key rotation - retries are bounded, not infinite\` — asserts the SDK throws after exactly \`MAX_KEY_ROTATION_RETRIES + 1\` calls rather than looping.
- \`key rotation - suggested key id is adopted and persisted\` — verifies that a valid suggested id is adopted and saved to storage (mutation-verified: deleting the \`saveString\` call fails this test).
- \`key rotation - unsupported suggested key id is rejected, not persisted\` — sends \`key_id: 99\`, asserts exactly 1 request, verifies \`serverPublicKeyId\` is never written to storage (mutation-verified: removing the membership check fails this test with the config-poisoning path itself).

## Security Impact
The membership check closes a configuration-poisoning vector: before this fix, a server could suggest an out-of-table \`key_id\` and the SDK would persist it, making the client unable to connect on every subsequent call. No change to how keys are transmitted, wrapped, or decrypted.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1128