### PR TITLE
chore(java): humanize comments in core SDK on the release branch

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -56,12 +56,12 @@ internal fun bytesToBase64(data: ByteArray): String {
 }
 
 internal fun base64ToBytes(data: String): ByteArray {
-    if (data.isEmpty()) throw SecretsManagerException("Base64-encoded value is empty") // KSM-985
+    if (data.isEmpty()) throw SecretsManagerException("Base64-encoded value is empty")
     return Base64.getDecoder().decode(data)
 }
 
 internal fun webSafe64ToBytes(data: String): ByteArray {
-    if (data.isEmpty()) throw SecretsManagerException("Base64url-encoded value is empty") // KSM-985
+    if (data.isEmpty()) throw SecretsManagerException("Base64url-encoded value is empty")
     return Base64.getUrlDecoder().decode(data)
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -14,7 +14,7 @@ import kotlin.collections.HashMap
 
 fun saveCachedValue(data: ByteArray) {
     val file = File("cache.dat")
-    FileOutputStream(file).use { fos -> fos.write(data) } // KSM-855: .use{} closes on exception
+    FileOutputStream(file).use { fos -> fos.write(data) } // .use{} closes on exception even if the operation throws
 
     // Set file permissions to 0600 (owner read/write only)
     try {
@@ -32,7 +32,7 @@ fun saveCachedValue(data: ByteArray) {
 
 fun getCachedValue(): ByteArray {
     try {
-        return FileInputStream("cache.dat").use { it.readBytes() } // KSM-855: .use{} closes on exception
+        return FileInputStream("cache.dat").use { it.readBytes() } // .use{} closes on exception even if the operation throws
     } catch (e: Exception) {
         throw SecretsManagerException("Cached value does not exist")
     }
@@ -115,7 +115,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private val file = configName?.let { File(it) }
     private var storage: InMemoryStorage = if (file != null && file.exists()) {
-        val content = BufferedReader(FileReader(file)).use { it.readText() } // KSM-855: was never closed
+        val content = BufferedReader(FileReader(file)).use { it.readText() } // previously never closed on exception; .use{} guarantees it
         InMemoryStorage(content)
     } else {
         InMemoryStorage()
@@ -135,7 +135,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
         config.serverPublicKey = storage.getString(KEY_SERVER_PUBLIC_KEY)
         val json = prettyJson.encodeToString(config)
-        BufferedWriter(FileWriter(file)).use { it.write(json) } // KSM-855: .use{} closes on exception
+        BufferedWriter(FileWriter(file)).use { it.write(json) } // .use{} closes on exception even if the operation throws
 
         // Set file permissions to 0600 (owner read/write only)
         try {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/RecordData.kt
@@ -20,7 +20,7 @@ data class KeeperRecordData @JvmOverloads constructor(
     var title: String,
     val type: String,
     val fields: MutableList<KeeperRecordField>,
-    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(), // KSM-823: always serialize "custom":[] even when empty
+    @EncodeDefault var custom: MutableList<KeeperRecordField> = mutableListOf(), // always serialize "custom":[] even when empty
     var notes: String? = null
 ) {
     inline fun <reified T> getField(): T? {
@@ -59,8 +59,8 @@ data class KeeperFileData @JvmOverloads constructor(
     val name: String,
     val type: String? = null,
     val size: Long,
-    @Serializable(with = FlexibleLongSerializer::class) // KSM-673: iOS/Android clients send fractional epoch seconds
-    val lastModified: Long = 0 // KSM-854: non-SDK clients omit this field; default 0 matches .NET behavior
+    @Serializable(with = FlexibleLongSerializer::class) // iOS/Android clients send fractional epoch seconds
+    val lastModified: Long = 0 // non-SDK clients omit this field; default 0 matches .NET behavior
 )
 
 @Serializable

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -30,7 +30,7 @@ import javax.net.ssl.*
 
 const val KEEPER_CLIENT_VERSION = "mj17.3.0"
 
-// Throttle retry (KSM-876 / KSM-878). The backend throttles HTTP 403 {"error":"throttled"}
+// Throttle retry. The backend throttles HTTP 403 {"error":"throttled"}
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
 // request, so the counter only clears after 10s of silence).
 const val MAX_THROTTLE_RETRIES = 5
@@ -238,7 +238,7 @@ private data class SecretsManagerResponseRecord(
  *   `is_launch_credential`, `is_iam_user`, `belongs_to` and `rotation_settings`; or no data at all
  *   (a pure record reference).
  * - path "ai_settings" / "jit_settings" (self-links): data is AES-256-GCM encrypted under the
- *   owning record's key — see [getDecryptedData].
+ *   owning record's key; see [getDecryptedData].
  *
  * Accessors never throw: parse, decode or decryption failures yield null/false. [getLinkData]
  * returns the complete parsed payload with nested objects and arrays preserved, so fields unknown
@@ -296,7 +296,7 @@ data class KeeperRecordLink(
      * Get a strict boolean value from the parsed JSON data; missing or non-boolean values are false.
      *
      * When [checkAllowedSettings] is true the nested `allowedSettings` object is consulted if the
-     * key is absent at the top level — a top-level boolean wins. The backend nests permission flags
+     * key is absent at the top level; a top-level boolean wins. The backend nests permission flags
      * under `allowedSettings` in `path:"meta"` links.
      */
     private fun getBooleanValue(key: String, checkAllowedSettings: Boolean = false): Boolean {
@@ -476,9 +476,8 @@ data class KeeperRecordLink(
     }
     
     /**
-     * Check if this link contains encrypted data by examining the actual content
-     * This method inspects the data to determine if it's encrypted, rather than
-     * relying on path naming conventions
+     * Check if this link contains encrypted data by examining the actual content, rather than
+     * relying on path naming conventions (see [mightBeEncrypted]).
      * @return true if the data appears to be encrypted
      */
     fun hasEncryptedData(): Boolean {
@@ -494,9 +493,8 @@ data class KeeperRecordLink(
     }
     
     /**
-     * Decrypt the link data using the provided record key
-     * This method attempts decryption only if the data appears to be encrypted
-     * 
+     * Decrypt the link data using the provided record key.
+     *
      * @param recordKey The record's encryption key
      * @return Decrypted string data, or null if decryption fails
      */
@@ -520,12 +518,11 @@ data class KeeperRecordLink(
     }
     
     /**
-     * Get link data - automatically handles both encrypted and plain JSON
-     * 
-     * This method is designed to be forward-compatible as Keeper evolves
-     * the data structures. Returns a Map to preserve all fields, even ones
-     * this SDK version doesn't know about yet.
-     * 
+     * Get link data - automatically handles both encrypted and plain JSON.
+     *
+     * Forward-compatible as Keeper evolves the data structures: returns a Map to preserve all
+     * fields, even ones this SDK version doesn't know about yet.
+     *
      * @param recordKey Optional key for decrypting encrypted link data
      * @return Parsed data as a Map, or null if parsing fails
      */
@@ -584,11 +581,7 @@ data class KeeperRecordLink(
         val sampleSize = minOf(str.length, 100)
         return (printableCount.toFloat() / sampleSize) > 0.9f
     }
-    
-    // ============================================================================
-    // Convenience Methods for Settings Access
-    // ============================================================================
-    
+
     /**
      * Get AI settings data from this link
      * 
@@ -630,12 +623,8 @@ data class KeeperRecordLink(
     }
     
     /**
-     * Get settings data for any path
-     * 
-     * This method works for current and future settings paths.
-     * It automatically detects whether the data is encrypted and
-     * handles it appropriately.
-     * 
+     * Get settings data for any current or future settings path.
+     *
      * @param settingsPath The path to check (e.g., "ai_settings", "security_settings")
      * @param recordKey The record's encryption key (required for encrypted data)
      * @return Settings data as a Map, or null if path doesn't match or parsing fails
@@ -647,7 +636,7 @@ data class KeeperRecordLink(
     }
 
     /**
-     * Get PAM settings data from this link — only when [path] == "meta".
+     * Get PAM settings data from this link; only valid when [path] == "meta".
      *
      * Meta links are self-links (recordUid == owning record) carrying the record's own PAM settings:
      * `allowedSettings`, `rotateOnTermination`, `version`, `no_update_services`. Plain JSON today;
@@ -662,7 +651,7 @@ private data class SecretsManagerResponseFile(
     val fileUid: String,
     val fileKey: String,
     val data: String,
-    val url: String?, // KSM-765: server may omit url; nullable prevents NPE on deserialization
+    val url: String?, // server may omit url; nullable prevents NPE on deserialization
     val thumbnailUrl: String?
 )
 
@@ -783,7 +772,7 @@ data class KeeperFile(
     val fileKey: ByteArray,
     val fileUid: String,
     val data: KeeperFileData,
-    val url: String?, // KSM-765: nullable; server may omit url for files without a download URL
+    val url: String?, // nullable; server may omit url for files without a download URL
     val thumbnailUrl: String?
 )
 
@@ -1194,7 +1183,7 @@ fun downloadThumbnail(file: KeeperFile): ByteArray {
 }
 
 private fun downloadFile(file: KeeperFile, url: String): ByteArray {
-    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
     try {
         connection.requestMethod = "GET"
         val statusCode = connection.responseCode
@@ -1217,7 +1206,7 @@ private fun uploadFile(url: String, parameters: String, fileData: ByteArray): Ke
     val boundary = String.format("----------%x", Instant.now().epochSecond)
     val boundaryBytes: ByteArray = stringToBytes("\r\n--$boundary")
     val paramJson = Json.parseToJsonElement(parameters) as JsonObject
-    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
     try {
         connection.requestMethod = "POST"
         connection.useCaches = false
@@ -1271,7 +1260,7 @@ private fun fetchAndDecryptSecrets(
     } else {
         appKey = storage.getBytes(KEY_APP_KEY) ?: throw SecretsManagerException("App key is missing from the storage")
     }
-    // KSM-753: records created via non-SDK clients in shared folders appear in response.records[]
+    // Records created via non-SDK clients in shared folders appear in response.records[]
     // with innerFolderUid set; their recordKey is encrypted with the folder key, not the app key.
     val folderKeyMap: Map<String, ByteArray> = response.folders
         ?.mapNotNull { f ->
@@ -1699,7 +1688,7 @@ fun postFunction(
 ): KeeperHttpResponse {
     var statusCode: Int
     var data: ByteArray
-    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection // KSM-855
+    val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
     try {
         if (allowUnverifiedCertificate) {
             connection.sslSocketFactory = trustAllSocketFactory()
@@ -1780,7 +1769,7 @@ private inline fun <reified T> encryptAndSignPayload(
 @ExperimentalSerializationApi
 // Returns the throttle retry_after (>= 0) when [body] is a backend throttle error
 // (result_code/error == "throttled"), otherwise null so the caller falls through to normal
-// error handling. Non-JSON / non-object bodies return null. (KSM-876 / KSM-878)
+// error handling. Non-JSON / non-object bodies return null.
 internal fun parseThrottle(body: String): Double? {
     val obj = try {
         nonStrictJson.parseToJsonElement(body).jsonObject
@@ -1802,7 +1791,7 @@ internal fun throttleDelayMillis(attempt: Int, retryAfter: Double, jitter: Doubl
     return (sec * 1000).toLong()
 }
 
-// Random jitter multiplier in [0, 0.25) — one-sided so a delay is only ever padded, never
+// Random jitter multiplier in [0, 0.25); one-sided so a delay is only ever padded, never
 // undercuts the server-requested (or exponential-backoff) floor. Kept separate so unit tests
 // exercise throttleDelayMillis with a pinned jitter instead.
 internal fun throttleJitter(): Double = Random.nextDouble(0.0, 0.25)
@@ -1827,7 +1816,7 @@ private inline fun <reified T> postQuery(
         }
         if (response.statusCode != HTTP_OK) {
             val errorMessage = String(response.data)
-            // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-878). Checked before
+            // Throttle retry with exponential backoff + jitter. Checked before
             // key-rotation so that path (incl. the IL5 custom-key suppression) is untouched, and
             // gated on the 403 status so a non-403 response carrying a {"error":"throttled"} body
             // is not mistaken for a throttle and retried.

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/IL5EdgeCaseTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/IL5EdgeCaseTest.kt
@@ -17,7 +17,7 @@ internal class IL5EdgeCaseTest {
 
     @Test
     fun localConfigStoragePersistsServerPublicKey() {
-        // Delete immediately — we only want the unique path, not an empty file that would fail JSON parse.
+        // Delete immediately; we only want the unique path, not an empty file that would fail JSON parse.
         val configFile = File.createTempFile("ksm-test-", ".json").also { it.delete() }
         try {
             initializeStorage(LocalConfigStorage(configFile.absolutePath), "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/KeeperRecordLinkTest.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertTrue
 /**
  * Unit tests for the [KeeperRecordLink] typed accessor layer.
  *
- * Mirrors the Python reference suite `sdk/python/core/tests/record_link_test.py` (KSM-992, PR #1036)
- * so the Java accessors match the live-verified backend payload shapes: permission booleans with an
+ * Mirrors the Python reference suite `sdk/python/core/tests/record_link_test.py` so the Java
+ * accessors match the live-verified backend payload shapes: permission booleans with an
  * `allowedSettings` fallback (top-level wins), the new credential/meta accessors, lossless
  * `getLinkData()`, and the encrypted ai/jit settings.
  */
@@ -168,7 +168,7 @@ class KeeperRecordLinkTest {
             path = "meta"
         )
 
-        // Permission booleans are absent at the top level — read via the allowedSettings fallback.
+        // Permission booleans are absent at the top level; read via the allowedSettings fallback.
         assertTrue(meta.allowsRotation())
         assertTrue(meta.allowsConnections())
         assertTrue(meta.allowsPortForwards())

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/RecordDataPamFieldsTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/RecordDataPamFieldsTest.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.*
 
 /**
- * Test suite for PAM connection settings fields added in KSM-738 (VAUL-7662).
+ * Test suite for PAM connection settings fields.
  * Tests serialization/deserialization of new fields in:
  * - PamRbiConnection (6 new fields: audio/clipboard controls)
  * - PamSettingsPortForward (2 new fields: local port configuration)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -127,7 +127,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIL5OttFourSegmentParsing() {
-        // KSM-902: 4-segment OTT IL5:clientKey:keyId:serverPublicKey stores key and ID in storage
+        // 4-segment OTT IL5:clientKey:keyId:serverPublicKey stores key and ID in storage
         val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
         val storage = InMemoryStorage()
         initializeStorage(storage, "IL5:FAKE_CLIENT_KEY:20:$fakeServerPublicKey")
@@ -149,7 +149,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIL5ConstructorParamPersistsToStorage() {
-        // KSM-902: serverPublicKey constructor param is saved to storage so generateTransmissionKey can use it
+        // serverPublicKey constructor param is saved to storage so generateTransmissionKey can use it
         val fakeServerPublicKey = "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM"
         val storage = InMemoryStorage()
         SecretsManagerOptions(storage, serverPublicKey = fakeServerPublicKey)
@@ -158,7 +158,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIL5ConfigFieldOverridesEmbeddedTable() {
-        // KSM-902: KEY_SERVER_PUBLIC_KEY in storage must be used instead of the embedded key table.
+        // KEY_SERVER_PUBLIC_KEY in storage must be used instead of the embedded key table.
         // Key ID 999 is not in the embedded table. With a custom key in storage, generateTransmissionKey
         // must use the storage key. If it falls through to the table, it throws
         // "Key number 999 is not supported" and the post function is never called.
@@ -182,7 +182,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testRecordCreateEmptyCustomSerialized() {
-        // KSM-823: RecordCreate with no custom fields must include "custom": [] in JSON payload
+        // RecordCreate with no custom fields must include "custom": [] in JSON payload
         val recordData = KeeperRecordData(
             title = "Test Record",
             type = "login",
@@ -195,7 +195,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileDataMissingLastModified() {
-        // GH-973 / KSM-854: lastModified entirely absent — must deserialize without throwing
+        // lastModified entirely absent; must deserialize without throwing
         val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""
         val result = Json.decodeFromString<KeeperFileData>(json)
         assertEquals(0L, result.lastModified)
@@ -212,7 +212,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileDataFractionalLastModified() {
-        // Regression guard for KSM-673: fractional lastModified (iOS client format)
+        // Regression guard: fractional lastModified (iOS client format)
         val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1760646182.790214}"""
         val result = Json.decodeFromString<KeeperFileData>(json)
         assertEquals(1760646182L, result.lastModified)
@@ -220,7 +220,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileNullUrl() {
-        // KSM-765: KeeperFile.url must be nullable; server may omit url for files without a download link
+        // KeeperFile.url must be nullable; server may omit url for files without a download link
         val fileData = KeeperFileData("test.txt", "test.txt", "text/plain", 1024)
         val file = KeeperFile(ByteArray(32), "uid123", fileData, null, null)
         assertNull(file.url)
@@ -228,7 +228,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testBase64EmptyStringThrowsTypedException() {
-        // KSM-985: empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64
+        // Empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64
         val base64Ex = assertFailsWith<Exception> { base64ToBytes("") }
         assertTrue(base64Ex.message?.isNotEmpty() == true)
         val webSafe64Ex = assertFailsWith<Exception> { webSafe64ToBytes("") }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ThrottleTest.kt
@@ -5,7 +5,7 @@ import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_OK
 import kotlin.test.*
 
-// Throttle retry with exponential backoff (KSM-876 / KSM-878). Unit tests exercise the internal
+// Throttle retry with exponential backoff. Unit tests exercise the internal
 // helpers; e2e tests drive getSecrets through postQuery with a mocked queryFunction returning
 // HTTP 403 {"error":"throttled"} responses and a recording throttleSleepMillis so retries never
 // actually wait.


### PR DESCRIPTION
## Summary
Cleanup pass on the Java/Kotlin SDK **core** package for this release branch: removes a section-header decorator, em dashes, four parrot-comment docstring restatements, and inline Jira ticket references from comments. No behavior change. Scoped to `sdk/java/core` only — the storage packages release on their own branches.

## Changes

### Maintenance
- Deleted a section-header decorator (`// ==== Convenience Methods for Settings Access ====`) in `SecretsManager.kt`
- Replaced em dashes with standard punctuation across `SecretsManager.kt` and 2 test files
- Simplified 4 docstrings in `SecretsManager.kt` that restated the function name/signature (`hasEncryptedData`, `getDecryptedData`, `getLinkData`, `getSettingsForPath`) instead of adding information; kept the genuine forward-compatibility rationale where present
- Stripped inline `KSM-XXX`/`GH-XXX`/`VAUL-XXX` references from ~20 comments across `SecretsManager.kt`, `CryptoUtils.kt`, `LocalConfigStorage.kt`, `RecordData.kt`, and 4 test files; kept the substantive explanation in each (e.g. `// KSM-855: .use{} closes on exception` → `// .use{} closes on exception even if the operation throws`)

## Testing
```
cd sdk/java/core && ./gradlew test
```
BUILD SUCCESSFUL, all tests passing.

## Breaking Changes
None.

## Related Issues
None — codebase hygiene, no ticket.