### PR TITLE
fix(cli): preserve backslash paths in ksm shell on Windows (KSM-1162)

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -10,6 +10,7 @@
 # Contact: ops@keepersecurity.com
 #
 
+import contextlib
 import difflib
 import os
 import sys
@@ -1434,6 +1435,41 @@ def _stdout_can_encode(text):
     return True
 
 
+@contextlib.contextmanager
+def _windows_safe_shlex():
+    """Patch click_repl's shlex tokenizer on Windows so backslash paths survive.
+
+    click_repl 0.2.0 calls shlex.split() in POSIX mode, where backslash is an
+    escape character. A Windows path like C:\\dir\\file.ini becomes C:dirfile.ini
+    before click ever sees it. This context manager replaces click_repl's shlex
+    reference for the duration of the shell REPL with a tokenizer that treats
+    backslashes as literal characters and still strips quotes in the normal way.
+    Non-Windows platforms are unaffected.
+    """
+    import click_repl as _cr
+    import shlex as _shlex
+
+    if sys.platform != 'win32':
+        yield
+        return
+
+    def _win_split(s, comments=False, posix=True):
+        lex = _shlex.shlex(s, posix=True)
+        lex.escape = ''
+        lex.whitespace_split = True
+        return list(lex)
+
+    _orig = _cr.shlex
+    _cr.shlex = type('_WinShlex', (), {
+        'split': staticmethod(_win_split),
+        '__getattr__': lambda self, name: getattr(_shlex, name),
+    })()
+    try:
+        yield
+    finally:
+        _cr.shlex = _orig
+
+
 @click.command(
     name='shell',
     cls=HelpColorsCommand,
@@ -1480,9 +1516,10 @@ def shell_command(app):
     print("\nRunning in shell mode. Type 'quit' to exit.\n")
 
     KsmCliException.in_a_shell = True
-    repl(click.get_current_context(), prompt_kwargs={
-        "message": u'\nKSM Shell (? for help) > '
-    })
+    with _windows_safe_shlex():
+        repl(click.get_current_context(), prompt_kwargs={
+            "message": u'\nKSM Shell (? for help) > '
+        })
 
 
 @click.command(

--- a/integration/keeper_secrets_manager_cli/tests/shell_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/shell_test.py
@@ -1,15 +1,17 @@
 import os
+import shlex
 import tempfile
 import unittest
 import importlib.metadata
 from unittest.mock import patch
 
+import click_repl
 from conftest import CliRunner
 from keeper_secrets_manager_core.core import SecretsManager
 from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
 from keeper_secrets_manager_core import mock
 from keeper_secrets_manager_core.mock import MockConfig
-from keeper_secrets_manager_cli.__main__ import cli
+from keeper_secrets_manager_cli.__main__ import cli, _windows_safe_shlex
 from keeper_secrets_manager_cli.exception import KsmCliException
 
 
@@ -170,6 +172,85 @@ class ShellSessionGlobalsTest(ShellInvocationTestCase):
                       "inner explicit --ini-file must win for that line")
         self.assertIn('_default', result.output,
                       "the line after an inner override must revert to the session --ini-file")
+
+
+class ShellWindowsBackslashTest(ShellInvocationTestCase):
+    """ksm shell must pass backslash Windows paths to commands intact (KSM-1162).
+
+    click_repl 0.2.0 calls shlex.split() in POSIX mode, which treats backslash
+    as an escape character and corrupts Windows paths before click sees them.
+    On Windows, _windows_safe_shlex() replaces click_repl's tokenizer with one
+    that preserves backslashes while still stripping quotes normally.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._orig_cr_shlex = click_repl.shlex
+
+    def tearDown(self):
+        click_repl.shlex = self._orig_cr_shlex
+        super().tearDown()
+
+    def test_windows_safe_shlex_preserves_backslash_paths(self):
+        """_windows_safe_shlex() patches click_repl so backslash paths survive tokenization."""
+        with patch('sys.platform', 'win32'):
+            with _windows_safe_shlex():
+                tokens = click_repl.shlex.split(r'--ini-file C:\fake\path.ini profile list')
+        self.assertEqual(['--ini-file', r'C:\fake\path.ini', 'profile', 'list'], tokens)
+
+    def test_windows_safe_shlex_not_applied_on_non_windows(self):
+        """_windows_safe_shlex() is a no-op on non-Windows platforms."""
+        with _windows_safe_shlex():
+            self.assertIs(shlex, click_repl.shlex,
+                          "click_repl.shlex must be unchanged on non-Windows platforms")
+
+    def test_shell_backslash_path_error_shows_original_path(self):
+        """A backslash path typed inside ksm shell on Windows arrives at the command intact.
+
+        Without the fix, POSIX tokenization strips the backslashes and click
+        receives a corrupted path (C:fakepath.ini). With the fix, click receives
+        the original path (C:\\fake\\path.ini) and the FileNotFoundError message
+        confirms it.
+        """
+        with patch('sys.platform', 'win32'), \
+             patch('keeper_secrets_manager_cli.__main__.update_available', return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ['shell'],
+                input='--ini-file C:\\fake\\path.ini profile list\nquit\n'
+            )
+
+        self.assertIsInstance(
+            result.exception, FileNotFoundError,
+            f"expected FileNotFoundError from missing ini, got: {result.exception!r}"
+        )
+        self.assertIn(
+            r'C:\fake\path.ini', str(result.exception),
+            "error message must contain the original backslash path, not a POSIX-stripped version"
+        )
+
+    def test_shell_quoted_path_with_spaces_on_windows(self):
+        """Quoted paths with spaces survive tokenization on Windows.
+
+        posix=False alone keeps the quotes in the token (breaking click). The
+        fix uses posix=True + escape='' + whitespace_split=True, which strips
+        quotes normally while treating backslash as a literal character.
+        """
+        with patch('sys.platform', 'win32'), \
+             patch('keeper_secrets_manager_cli.__main__.update_available', return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ['shell'],
+                input='--ini-file "C:\\fake path\\keeper.ini" profile list\nquit\n'
+            )
+
+        self.assertIsInstance(result.exception, FileNotFoundError)
+        self.assertIn(
+            'C:\\fake path\\keeper.ini', str(result.exception),
+            "quoted path with spaces must arrive with quotes stripped and backslashes preserved"
+        )
 
 
 if __name__ == '__main__':

--- a/integration/keeper_secrets_manager_cli/tests/shell_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/shell_test.py
@@ -175,7 +175,7 @@ class ShellSessionGlobalsTest(ShellInvocationTestCase):
 
 
 class ShellWindowsBackslashTest(ShellInvocationTestCase):
-    """ksm shell must pass backslash Windows paths to commands intact (KSM-1162).
+    """ksm shell must pass backslash Windows paths to commands intact.
 
     click_repl 0.2.0 calls shlex.split() in POSIX mode, which treats backslash
     as an escape character and corrupts Windows paths before click sees them.
@@ -192,26 +192,18 @@ class ShellWindowsBackslashTest(ShellInvocationTestCase):
         super().tearDown()
 
     def test_windows_safe_shlex_preserves_backslash_paths(self):
-        """_windows_safe_shlex() patches click_repl so backslash paths survive tokenization."""
         with patch('sys.platform', 'win32'):
             with _windows_safe_shlex():
                 tokens = click_repl.shlex.split(r'--ini-file C:\fake\path.ini profile list')
         self.assertEqual(['--ini-file', r'C:\fake\path.ini', 'profile', 'list'], tokens)
 
     def test_windows_safe_shlex_not_applied_on_non_windows(self):
-        """_windows_safe_shlex() is a no-op on non-Windows platforms."""
         with _windows_safe_shlex():
             self.assertIs(shlex, click_repl.shlex,
                           "click_repl.shlex must be unchanged on non-Windows platforms")
 
     def test_shell_backslash_path_error_shows_original_path(self):
-        """A backslash path typed inside ksm shell on Windows arrives at the command intact.
-
-        Without the fix, POSIX tokenization strips the backslashes and click
-        receives a corrupted path (C:fakepath.ini). With the fix, click receives
-        the original path (C:\\fake\\path.ini) and the FileNotFoundError message
-        confirms it.
-        """
+        """A backslash path typed inside ksm shell on Windows arrives at the command intact."""
         with patch('sys.platform', 'win32'), \
              patch('keeper_secrets_manager_cli.__main__.update_available', return_value=None):
             runner = CliRunner()
@@ -233,9 +225,7 @@ class ShellWindowsBackslashTest(ShellInvocationTestCase):
     def test_shell_quoted_path_with_spaces_on_windows(self):
         """Quoted paths with spaces survive tokenization on Windows.
 
-        posix=False alone keeps the quotes in the token (breaking click). The
-        fix uses posix=True + escape='' + whitespace_split=True, which strips
-        quotes normally while treating backslash as a literal character.
+        posix=False alone keeps the quotes in the token value, breaking click parsing.
         """
         with patch('sys.platform', 'win32'), \
              patch('keeper_secrets_manager_cli.__main__.update_available', return_value=None):


### PR DESCRIPTION
## Summary

Backslash Windows paths typed as arguments inside `ksm shell` were corrupted before click saw them. `C:\dir\file.ini` became `C:dirfile.ini`, and paths with multiple separators could split into spurious extra tokens. Forward-slash paths were unaffected.

Root cause: click_repl 0.2.0 tokenizes typed lines with `shlex.split()` in POSIX mode, where backslash is an escape character.

## Changes

### Bug Fixes
- **Windows backslash path tokenization** (KSM-1162): adds `_windows_safe_shlex()`, a context manager that patches click_repl's tokenizer on Windows for the duration of the REPL loop. The replacement uses `posix=True, escape='', whitespace_split=True` so backslashes are literal characters while quoted paths (including those with spaces) still have quotes stripped normally. Non-Windows platforms are unaffected.

## Testing

```bash
cd integration/keeper_secrets_manager_cli
python -m pytest tests/shell_test.py -v
```

Four new tests cover: tokenizer unit behavior, no-op on non-Windows, full shell backslash path round-trip, and quoted path with spaces. All 166 CLI tests pass.

## Breaking Changes

None.

## Related Issues

- Closes KSM-1162
- The `--ini-file` failure became reachable in 1.5.0 after KSM-1157 made inner-line global options apply; the positional argument case (e.g. `add file -f C:\...`) was broken all along.