### PR TITLE
fix(python): cache file permissions and live-response masking (KSM-1122, KSM-1123)

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1929,9 +1929,11 @@ class KSMCache:
 
     @staticmethod
     def save_cache(data):
-        cache_file = open(KSMCache.get_cache_file_path(), 'wb')
-        cache_file.write(data)
-        cache_file.close()
+        path = KSMCache.get_cache_file_path()
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, 'wb') as f:
+            f.write(data)
+        os.chmod(path, 0o600)
 
     @staticmethod
     def get_cached_data():

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1952,18 +1952,17 @@ class KSMCache:
     def caching_post_function(url, transmission_key, encrypted_payload_and_signature, verify_ssl_certs=True, proxy_url=None):
 
         try:
-
             ksm_rs = SecretsManager.post_function(url, transmission_key, encrypted_payload_and_signature, verify_ssl_certs, proxy_url)
-
-            if ksm_rs.status_code == 200:
-                KSMCache.save_cache(transmission_key.key + ksm_rs.data)
-                return ksm_rs
-        except:
+        except Exception:
             cached_data = KSMCache.get_cached_data()
-            cached_transmission_key = cached_data[:32]
-            transmission_key.key = cached_transmission_key
-            data = cached_data[32:len(cached_data)]
+            transmission_key.key = cached_data[:32]
+            ksm_rs = KSMHttpResponse(HTTPStatus.OK, cached_data[32:], None)
+            return ksm_rs
 
-            ksm_rs = KSMHttpResponse(HTTPStatus.OK, data, None)
+        if ksm_rs.status_code == 200:
+            try:
+                KSMCache.save_cache(transmission_key.key + ksm_rs.data)
+            except Exception:
+                pass
 
         return ksm_rs

--- a/sdk/python/core/tests/cache_test.py
+++ b/sdk/python/core/tests/cache_test.py
@@ -1,8 +1,11 @@
 import os
 import tempfile
 import unittest
+import unittest.mock
+from http import HTTPStatus
 
-from keeper_secrets_manager_core.core import KSMCache
+from keeper_secrets_manager_core.core import KSMCache, SecretsManager
+from keeper_secrets_manager_core.dto.payload import KSMHttpResponse, TransmissionKey
 
 
 class CacheTest(unittest.TestCase):
@@ -82,6 +85,25 @@ class CacheTest(unittest.TestCase):
                     os.environ.pop("KSM_CACHE_DIR", None)
                 else:
                     os.environ["KSM_CACHE_DIR"] = original
+
+
+    def test_caching_post_function_returns_live_response_when_save_cache_fails(self):
+        original_key = b'\xab' * 32
+        transmission_key = TransmissionKey(1, original_key, b'')
+        live_data = b"live-response-data"
+        live_response = KSMHttpResponse(HTTPStatus.OK, live_data, None)
+
+        with unittest.mock.patch.object(SecretsManager, 'post_function', return_value=live_response), \
+             unittest.mock.patch.object(KSMCache, 'save_cache', side_effect=FileNotFoundError("bad path")):
+            result = KSMCache.caching_post_function(
+                "https://fake.url", transmission_key, b"payload"
+            )
+
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        self.assertEqual(result.data, live_data,
+                         "live response data must be returned even when save_cache raises")
+        self.assertEqual(transmission_key.key, original_key,
+                         "transmission_key.key must not be overwritten when the live request succeeds")
 
 
 if __name__ == "__main__":

--- a/sdk/python/core/tests/cache_test.py
+++ b/sdk/python/core/tests/cache_test.py
@@ -40,5 +40,49 @@ class CacheTest(unittest.TestCase):
                     os.environ["KSM_CACHE_DIR"] = original
 
 
+    @unittest.skipIf(os.name == 'nt', "file permission bits are not meaningful on Windows")
+    def test_save_cache_creates_file_owner_readable_only(self):
+        original = os.environ.get("KSM_CACHE_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["KSM_CACHE_DIR"] = temp_dir
+            try:
+                KSMCache.save_cache(b"secret")
+                path = os.path.join(temp_dir, "ksm_cache.bin")
+                self.assertEqual(
+                    os.stat(path).st_mode & 0o777,
+                    0o600,
+                    "cache file must be owner-read/write only (0600); world-readable cache exposes the transmission key",
+                )
+            finally:
+                if original is None:
+                    os.environ.pop("KSM_CACHE_DIR", None)
+                else:
+                    os.environ["KSM_CACHE_DIR"] = original
+
+    @unittest.skipIf(os.name == 'nt', "file permission bits are not meaningful on Windows")
+    def test_save_cache_fixes_permissions_on_existing_file(self):
+        original = os.environ.get("KSM_CACHE_DIR")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.environ["KSM_CACHE_DIR"] = temp_dir
+            try:
+                path = os.path.join(temp_dir, "ksm_cache.bin")
+                with open(path, 'wb') as f:
+                    f.write(b"old")
+                os.chmod(path, 0o644)
+
+                KSMCache.save_cache(b"new-secret")
+
+                self.assertEqual(
+                    os.stat(path).st_mode & 0o777,
+                    0o600,
+                    "save_cache must correct permissions even when overwriting an existing world-readable file",
+                )
+            finally:
+                if original is None:
+                    os.environ.pop("KSM_CACHE_DIR", None)
+                else:
+                    os.environ["KSM_CACHE_DIR"] = original
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Python SDK: two fixes to `KSMCache` landing in 17.4.0. `save_cache()` wrote the cache file world-readable (0644), exposing the cleartext transmission key to other users on the machine. Separately, a bare `except` in `caching_post_function` caught `save_cache` failures alongside HTTP failures, causing a bad cache path to discard a successful 200 response and surface a `FileNotFoundError` to the caller instead.

## Changes

### Fixed
- `save_cache()` now uses `os.open` with mode `0o600` and `os.chmod` on write, so both new and pre-existing files are locked to owner-only (KSM-1122)
- `caching_post_function` restructured so only the HTTP call is in the try block; `save_cache` failures are non-fatal and the live response is always returned on a 200 (KSM-1123)

## Testing

```bash
cd sdk/python/core && python -m pytest tests/cache_test.py -v
```

## Security Impact

KSM-1122: cache file contained the cleartext transmission key at mode 0644 — readable by any local user. Fixed by creating with `os.open(..., 0o600)` and enforcing with `os.chmod` on overwrite.

## Breaking Changes

None.

## Related Issues

- Jira: KSM-1122, KSM-1123