### PR TITLE
fix(python): always serialize custom as [] in RecordCreate.to_dict (KSM-1152)

### DIFF
--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -33,6 +33,13 @@ see the official docs link above.
 
 ## Change Log
 
+### 17.4.0
+* KSM-1080 - Fixed `get_folders()` crashing when any folder in the response contains a corrupted or missing key. Undecryptable folders are now skipped with a warning; the remaining folders are returned normally.
+* KSM-1085 - Fixed `delete_secret()` and `delete_folder()` silently succeeding on partial failures. Both methods now raise `KeeperError` listing the UIDs the server rejected, so callers know which records were not deleted.
+* KSM-1122 - Fixed the KSMCache cache file being created world-readable (mode 0644). The file contains the transmission key in cleartext; it is now written mode 0600 (owner read/write only). Existing files are corrected to 0600 on the next write.
+* KSM-1123 - Fixed `KSMCache` discarding a live HTTP 200 response when the cache write fails (e.g., the cache path points to a nonexistent directory). The live response is now always returned on success; cache write failures are non-fatal and do not affect the caller.
+* KSM-1152 - Fixed `RecordCreate.to_dict()` omitting `"custom"` from the serialized payload when no custom fields were set. The key is now always present as `[]`, matching the vault API's expectation.
+
 ### 17.3.0
 * KSM-992 - Added a typed `KeeperRecordLink` linked-credential accessor layer and `Record.get_links()`. Provides Java-parity accessors (`is_admin_user()`, `is_launch_credential()`, permission booleans such as `allows_rotation()`/`allows_connections()`, `get_link_data_version()`, `get_decoded_data()`, encryption detection, AES-256-GCM `get_decrypted_data()`, `get_link_data()`, and `get_ai_settings_data()`/`get_jit_settings_data()`/`get_settings_for_path()`) plus accessors for the current link payload shape verified against the live backend: `meta` self-links (`get_meta_data()`, `get_allowed_settings()`), `is_iam_user()`, `belongs_to()`, `no_update_services()`, `ai_enabled()`, `ai_session_terminate()` and `get_rotation_settings()`. Permission booleans read both top-level keys and the nested `allowedSettings`. Purely additive — the raw `record.links` list is unchanged, and each typed link keeps the untouched original dict in `.raw`.
 * KSM-877 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, requests are retried up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` (subclass of `KeeperError`) is raised once retries are exhausted. Existing key-rotation retry behavior is unchanged.

--- a/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
+++ b/sdk/python/core/keeper_secrets_manager_core/dto/dtos.py
@@ -871,13 +871,11 @@ class RecordCreate:
             'type': self.record_type,
             'title': self.title,
             'fields': self.fields,
+            'custom': self.custom if self.custom is not None else [],
         }
 
         if self.notes:
             rec_dict['notes'] = self.notes
-
-        if self.custom is not None:
-            rec_dict['custom'] = self.custom
 
         return helpers.obj_to_dict(rec_dict)
 

--- a/sdk/python/core/tests/create_records_test.py
+++ b/sdk/python/core/tests/create_records_test.py
@@ -59,7 +59,6 @@ class RecordTest(unittest.TestCase):
         self.assertEqual("CUSTOM TYPE", login_record_create_dict.get('type'), "type didn't match")
 
     def test_empty_custom_list_serialized(self):
-        # KSM-819: empty list is falsy in Python — must use `is not None` check
         rc = RecordCreate('login', 'Test')
         rc.fields = []
         rc.custom = []
@@ -67,9 +66,11 @@ class RecordTest(unittest.TestCase):
         self.assertIn('custom', d, "empty custom list must appear in serialized dict")
         self.assertEqual([], d['custom'])
 
-    def test_none_custom_omitted(self):
+    def test_unset_custom_serializes_as_empty_list(self):
         rc = RecordCreate('login', 'Test')
         rc.fields = []
-        rc.custom = None
         d = rc.to_dict()
-        self.assertNotIn('custom', d, "None custom must be omitted from serialized dict")
+        self.assertIn('custom', d,
+                      "custom must always appear in serialized dict even when never set")
+        self.assertEqual([], d['custom'],
+                         "unset custom must serialize as empty list, not be omitted")


### PR DESCRIPTION
## Summary

Python SDK: `RecordCreate.to_dict()` omitted the `custom` key entirely when `custom` was never assigned. KSM-819 fixed the empty-list case (`custom=[]`) by switching from a truthiness check to `is not None`, but left the never-set case (`custom=None`) still dropping the key. The vault API requires `custom` to be present in every create payload.

## Changes

### Fixed
- `to_dict()` now always emits `'custom'`, defaulting to `[]` when the attribute was never set (KSM-1152)
- Replaced the `test_none_custom_omitted` test from KSM-819 (which locked in the buggy behavior) with `test_unset_custom_serializes_as_empty_list`

## Testing

```bash
cd sdk/python/core && python -m pytest tests/create_records_test.py -v
```

## Breaking Changes

None. Callers that explicitly set `custom=None` will now see `'custom': []` in the serialized dict rather than no key — matching what the vault expects.

## Related Issues

- Jira: KSM-1152