### PR TITLE
fix(python): KSM-1119 guard against IndexError in FieldType.__init__ for empty value list

### DIFF
--- a/sdk/python/helper/README.md
+++ b/sdk/python/helper/README.md
@@ -6,5 +6,8 @@ For more information see our official documentation page https://docs.keeper.io/
 
 ## Recent Changes
 
+### Version 1.1.3
+- KSM-1119 - Fixed `FieldType.__init__` crashing with `IndexError` when a complex field (address, name, host, paymentCard, etc.) is returned by the server with an empty value list. Attribute variables are now left as `None` instead of attempting to index into `[]`.
+
 ### Version 1.0.7
 - Updated dependency: `keeper-secrets-manager-core>=17.1.0` (includes fixes for CVE-2026-23949 and CVE-2026-24049)

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
@@ -227,7 +227,7 @@ class FieldType:
             # Default to the passed in args for attribute variables. However if the value args exists, then use that
             # to get the attribute values.
             attr_dict = kwargs
-            if self.value is not None:
+            if self.value:
                 attr_dict = self.value[0]
 
             # This will create and set the attribute variables.

--- a/sdk/python/helper/tests/v3/v3_field_type_test.py
+++ b/sdk/python/helper/tests/v3/v3_field_type_test.py
@@ -67,3 +67,13 @@ class FieldTypeTest(unittest.TestCase):
             self.fail("Should have gotten an exception get bad field class")
         except ImportError as _:
             pass
+
+    def test_complex_field_with_empty_value_list_does_not_crash(self):
+        address = Address(value=[])
+        self.assertEqual([], address.value)
+        self.assertIsNone(address.street1)
+
+    def test_complex_field_with_populated_value_list_still_works(self):
+        address = Address(value=[{"street1": "123 Main St", "city": "Anytown"}])
+        self.assertEqual("123 Main St", address.street1)
+        self.assertEqual("Anytown", address.city)


### PR DESCRIPTION
## Summary
Python Helper `FieldType.__init__` crashes with `IndexError: list index out of range` when any complex field (address, name, host, paymentCard, bankAccount, keyPair, securityQuestion, schedule, pamHostname, etc.) is returned by the server with `"value": []`. The `is not None` guard passes for an empty list, then `self.value[0]` raises. Fix: change the guard to a truthiness check so an empty list is treated identically to `None`.

## Changes

### Fixed
- `FieldType.__init__` no longer crashes when a complex field carries an empty value list (KSM-1119)

## Testing
```
cd sdk/python/helper && python -m pytest tests/ -v
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1119