### PR TITLE
fix(cli): clear shlex commenters in _win_split so '#' is not truncated (KSM-1165)

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -1456,6 +1456,8 @@ def _windows_safe_shlex():
     def _win_split(s, comments=False, posix=True):
         lex = _shlex.shlex(s, posix=True)
         lex.escape = ''
+        if not comments:
+            lex.commenters = ''
         lex.whitespace_split = True
         return list(lex)
 

--- a/integration/keeper_secrets_manager_cli/tests/shell_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/shell_test.py
@@ -197,6 +197,17 @@ class ShellWindowsBackslashTest(ShellInvocationTestCase):
                 tokens = click_repl.shlex.split(r'--ini-file C:\fake\path.ini profile list')
         self.assertEqual(['--ini-file', r'C:\fake\path.ini', 'profile', 'list'], tokens)
 
+    def test_windows_safe_shlex_preserves_hash_in_args(self):
+        """'#' must not be treated as a comment character on Windows.
+
+        shlex.shlex sets commenters='#' by default, so everything from '#' to
+        end-of-line is silently dropped unless commenters is cleared.
+        """
+        with patch('sys.platform', 'win32'):
+            with _windows_safe_shlex():
+                tokens = click_repl.shlex.split('secret get uid#tag extra')
+        self.assertEqual(['secret', 'get', 'uid#tag', 'extra'], tokens)
+
     def test_windows_safe_shlex_not_applied_on_non_windows(self):
         with _windows_safe_shlex():
             self.assertIs(shlex, click_repl.shlex,


### PR DESCRIPTION
## Summary

CLI (`ksm shell`): `_win_split` left `shlex.shlex.commenters` at its default value of `'#'`, causing everything after an unquoted `#` in a typed argument to be silently dropped on Windows — e.g. a password `p@ss#word` became `p@ss` before click ever saw it.

## Changes

### Bug Fix
- Clear `lex.commenters` in `_win_split` when `comments=False` (the default), mirroring the semantics of `shlex.split(comments=False)` (KSM-1165)

## Testing

```bash
cd integration/keeper_secrets_manager_cli
PYTHONPATH=$PWD pytest tests/shell_test.py -v
```

`test_windows_safe_shlex_preserves_hash_in_args` reproduces the bug against the unfixed code and passes with the fix applied. Verified on a real Windows machine where the test previously failed.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1165