### PR TITLE
test(cli): mock sys.platform in test_windows_safe_shlex_not_applied_on_non_windows (KSM-1166)

### DIFF
--- a/integration/keeper_secrets_manager_cli/tests/shell_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/shell_test.py
@@ -208,6 +208,7 @@ class ShellWindowsBackslashTest(ShellInvocationTestCase):
                 tokens = click_repl.shlex.split('secret get uid#tag extra')
         self.assertEqual(['secret', 'get', 'uid#tag', 'extra'], tokens)
 
+    @patch('sys.platform', 'linux')
     def test_windows_safe_shlex_not_applied_on_non_windows(self):
         with _windows_safe_shlex():
             self.assertIs(shlex, click_repl.shlex,


### PR DESCRIPTION
## Summary

CLI tests: `test_windows_safe_shlex_not_applied_on_non_windows` read the live `sys.platform` value, causing it to fail on any real Windows machine — `_windows_safe_shlex()` applies the patch on Windows, but the test asserted it did not.

## Changes

### Bug Fix
- Add `@patch('sys.platform', 'linux')` to `test_windows_safe_shlex_not_applied_on_non_windows` so the test is host-independent (KSM-1166)

## Testing

```bash
cd integration/keeper_secrets_manager_cli
PYTHONPATH=$PWD pytest tests/shell_test.py -v
```

Before this fix the test failed when run on Windows (`platform win32`). After the fix all 9 tests pass on Windows. Verified locally.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1166