### PR TITLE
fix(python): KSMCache staticmethod consistency + helper core floor bump

### DIFF
--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1965,8 +1965,8 @@ class KSMCache:
     # current working directory.
     kms_cache_file_name = os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
 
-    @classmethod
-    def get_cache_file_path(cls):
+    @staticmethod
+    def get_cache_file_path():
         return os.path.join(os.environ.get("KSM_CACHE_DIR", ""), 'ksm_cache.bin')
 
     @staticmethod

--- a/sdk/python/helper/setup.py
+++ b/sdk/python/helper/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'keeper-secrets-manager-core>=17.3.0',
+    'keeper-secrets-manager-core>=17.4.0',
     'pyyaml>=6.0.1',
     'iso8601'
 ]


### PR DESCRIPTION
## Summary

Python SDK maintenance: aligns `KSMCache.get_cache_file_path` with the rest of the class, and raises the helper's minimum core version ahead of the 17.4.0 publish.

## Changes

### Maintenance
- `KSMCache.get_cache_file_path` was `@classmethod` but never referenced `cls` — converted to `@staticmethod` to match `save_cache`, `get_cached_data`, and `remove_cache_file` (KSM-1121)
- Helper `setup.py` core floor raised from `>=17.3.0` to `>=17.4.0`; required before publish since KSM-1119 and KSM-1127 both depend on behavior introduced in this release's core

## Testing

```bash
cd sdk/python/core && pytest tests/cache_test.py -v
```

All 4 cache tests pass.

## Breaking Changes

None.

## Related Issues

- Jira: KSM-1121