### PR TITLE
fix(python/helper): add database and dbConnectionMethod to PamSettings connection schema

### DIFF
--- a/sdk/python/helper/README.md
+++ b/sdk/python/helper/README.md
@@ -8,6 +8,7 @@ For more information see our official documentation page https://docs.keeper.io/
 
 ### Version 1.1.3
 - KSM-1119 - Fixed `FieldType.__init__` crashing with `IndexError` when a complex field (address, name, host, paymentCard, etc.) is returned by the server with an empty value list. Attribute variables are now left as `None` instead of attempting to index into `[]`.
+- KSM-1127 - Fixed `PamSettings.connection` schema missing `database` and `dbConnectionMethod` fields. Both fields are now present in the `pamDatabase` connection schema, making them available for template generation and record construction.
 
 ### Version 1.0.7
 - Updated dependency: `keeper-secrets-manager-core>=17.1.0` (includes fixes for CVE-2026-23949 and CVE-2026-24049)

--- a/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
+++ b/sdk/python/helper/keeper_secrets_manager_helper/v3/field_type.py
@@ -887,7 +887,9 @@ class PamSettings(FieldType):
                             "security": {"value_type": str},
                             "ignoreCert": {"value_type": bool},
                             "resizeMethod": {"value_type": str},
-                            "colorScheme": {"value_type": str}
+                            "colorScheme": {"value_type": str},
+                            "database": {"value_type": str},
+                            "dbConnectionMethod": {"value_type": str},
                         }
                     },
                 }


### PR DESCRIPTION
## Summary

Python helper v3 schema was missing `database` and `dbConnectionMethod` from `PamSettings.connection` on `pamDatabase` records. Both fields are present in the Java SDK (`PamSettingsConnection`) and were added to the JavaScript SDK in the paired fix (KSM-1073). This brings the Python helper to parity.

## Changes

### Fixed
- Added `database` and `dbConnectionMethod` to `PamSettings.connection.connection` schema in `v3/field_type.py` (KSM-1127)

## Testing

```bash
cd sdk/python/helper && python -m pytest tests/ -v
```

63 tests pass.

## Breaking Changes

None.

## Related Issues

- Closes KSM-1127
- Paired with KSM-1073 (JavaScript, Code Merged)