### PR TITLE
fix(python): use folder key for flat records with innerFolderUid (KSM-747)

### DIFF
--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -34,6 +34,7 @@ see the official docs link above.
 ## Change Log
 
 ### 17.4.0
+* KSM-747 - Fixed records created by non-SDK clients (Commander, Vault UI) inside shared folders silently disappearing from `get_secrets()` results. When a record is returned in the flat `records[]` array with `innerFolderUid` set, the SDK now decrypts its key using the folder key rather than the app key, matching the behavior already applied to records in `folders[].records[]`.
 * KSM-1080 - Fixed `get_folders()` crashing when any folder in the response contains a corrupted or missing key. Undecryptable folders are now skipped with a warning; the remaining folders are returned normally.
 * KSM-1085 - Fixed `delete_secret()` and `delete_folder()` silently succeeding on partial failures. Both methods now raise `KeeperError` listing the UIDs the server rejected, so callers know which records were not deleted.
 * KSM-1122 - Fixed the KSMCache cache file being created world-readable (mode 0644). The file contains the transmission key in cleartext; it is now written mode 0600 (owner read/write only). Existing files are corrected to 0600 on the next write.

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -1017,10 +1017,25 @@ class SecretsManager:
 
         sm_response = SecretsManagerResponse()
 
+        folder_key_map = {}
+        if folders_resp:
+            for f in folders_resp:
+                uid = f.get('folderUid')
+                key_enc = f.get('folderKey')
+                if uid and key_enc:
+                    try:
+                        folder_key_map[uid] = CryptoUtils.decrypt_aes(
+                            base64_to_bytes(key_enc), secret_key
+                        )
+                    except Exception:
+                        pass
+
         if records_resp:
             for r in records_resp:
                 try:
-                    record = Record(r, secret_key)
+                    inner_folder_uid = r.get('innerFolderUid')
+                    decrypt_key = folder_key_map.get(inner_folder_uid, secret_key) if inner_folder_uid else secret_key
+                    record = Record(r, decrypt_key)
                     record.links = r.get('links') or []
                     records.append(record)
                 except Exception as err:

--- a/sdk/python/core/tests/shared_folder_test.py
+++ b/sdk/python/core/tests/shared_folder_test.py
@@ -1,0 +1,90 @@
+import base64
+import json
+import os
+import unittest
+
+from requests import Response as RequestResponse
+
+from keeper_secrets_manager_core import SecretsManager, mock
+from keeper_secrets_manager_core.mock import MockConfig
+from keeper_secrets_manager_core.storage import InMemoryKeyValueStorage
+from keeper_secrets_manager_core.configkeys import ConfigKeys
+from keeper_secrets_manager_core.crypto import CryptoUtils
+from keeper_secrets_manager_core.dto.payload import KSMHttpResponse
+from keeper_secrets_manager_core.utils import base64_to_bytes
+
+
+class SharedFolderDecryptionTest(unittest.TestCase):
+
+    def test_flat_record_with_inner_folder_uid_uses_folder_key(self):
+        """A flat record with innerFolderUid must be decrypted with the folder key, not the app key.
+
+        When a non-SDK client (Commander, Vault UI) creates a record inside a shared folder,
+        the backend returns it in response.records[] with innerFolderUid set and recordKey
+        encrypted with the folder key. Before KSM-747, the SDK always used the app key,
+        silently failing decryption and moving the record to bad_records.
+        """
+        secrets_manager = SecretsManager(config=InMemoryKeyValueStorage(MockConfig.make_config()))
+        app_key = base64_to_bytes(secrets_manager.config.get(ConfigKeys.KEY_APP_KEY))
+
+        folder_key = os.urandom(32)
+        record_key = os.urandom(32)
+        folder_uid = "testFolderUid12345678"
+        record_uid = "testRecordUid1234567"
+
+        record_data = json.dumps({
+            "type": "login",
+            "title": "Shared Folder Login",
+            "notes": "",
+            "fields": [{"type": "login", "value": ["user@example.com"]}],
+            "custom": []
+        }).encode()
+
+        raw_response = {
+            "encryptedAppKey": None,
+            "folders": [{
+                "folderUid": folder_uid,
+                "folderKey": base64.b64encode(
+                    CryptoUtils.encrypt_aes(folder_key, app_key)
+                ).decode(),
+                "records": []
+            }],
+            "records": [{
+                "recordUid": record_uid,
+                "recordKey": base64.b64encode(
+                    CryptoUtils.encrypt_aes(record_key, folder_key)
+                ).decode(),
+                "data": base64.b64encode(
+                    CryptoUtils.encrypt_aes(record_data, record_key)
+                ).decode(),
+                "isEditable": True,
+                "files": None,
+                "innerFolderUid": folder_uid
+            }]
+        }
+
+        def post_function(url, transmission_key, encrypted_payload, verify_ssl_certs=True, proxy_url=None):
+            content = CryptoUtils.encrypt_aes(
+                json.dumps(raw_response).encode(),
+                transmission_key.key
+            )
+            res = RequestResponse()
+            res._content = content
+            res.status_code = 200
+            res.reason = "OK"
+            return KSMHttpResponse(res.status_code, res.content, res)
+
+        secrets_manager.post_function = post_function
+
+        sm_response = secrets_manager.get_secrets(full_response=True)
+
+        self.assertEqual(1, len(sm_response.records),
+                         "Expected 1 record; got 0 (innerFolderUid path was not decrypted with folder key)")
+        self.assertEqual("Shared Folder Login", sm_response.records[0].title,
+                         "Record title mismatch after folder-key decryption")
+        self.assertEqual(0, len(sm_response.bad_records),
+                         "Record landed in bad_records; folder key was not used for decryption")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Records created by non-SDK clients (Commander, Vault UI) inside shared folders appear in `response.records[]` with `innerFolderUid` set and their record key encrypted with the folder key, not the app key. The SDK was always using the app key, silently failing AES-GCM authentication and moving every such record to `bad_records` with no user-visible error.

## Changes

### Fixed
- (KSM-747) `fetch_and_decrypt_secrets` now builds a `folder_key_map` from `folders_resp` before the records loop. Flat records with `innerFolderUid` present in the map are decrypted with the folder key; records without `innerFolderUid` continue using the app key unchanged.

## Testing

```bash
cd sdk/python/core && python -m pytest tests/shared_folder_test.py tests/ -v
```

`shared_folder_test.py` constructs a raw response with a folder key encrypted under the app key and a flat record whose record key is encrypted under the folder key. Before the fix: 0 records, 1 bad\_record. After: 1 record with correct title, 0 bad\_records.

## Breaking Changes

None.

## Related Issues

- Closes #KSM-747
- Jira: KSM-747