### PR TITLE
fix(cli): disable click Windows argv expansion so secret values are stored byte-for-byte (KSM-1186)

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/__main__.py
@@ -1629,7 +1629,12 @@ def main():
         if "shell" in sys.argv:
             program_name = ""
 
-        cli(obj={"cli": None}, prog_name=program_name)
+        # KSM-1186: on Windows, click >= 8.0 expands every command-line argument
+        # before parsing (os.path.expanduser, then os.path.expandvars — which
+        # expands %VAR%/$VAR and collapses $$ to $ — then glob), so secret
+        # values passed as arguments were silently corrupted before storage.
+        # Secret values are not shell globs; disable the expansion.
+        cli(obj={"cli": None}, prog_name=program_name, windows_expand_args=False)
     except Exception as err:
         # Set KSM_DEBUG to get a stack trace. Secret env var.
         if os.environ.get("KSM_DEBUG") is not None:

--- a/integration/keeper_secrets_manager_cli/requirements.txt
+++ b/integration/keeper_secrets_manager_cli/requirements.txt
@@ -3,7 +3,7 @@ keeper-secrets-manager-helper>=1.1.0
 keeper-secrets-manager-storage>=1.0.2
 prompt-toolkit>=3.0
 jsonpath-rw-ext
-click>=8.0
+click>=8.0.1
 click_help_colors
 click-repl>=0.2.0,<0.3.0
 pyyaml

--- a/integration/keeper_secrets_manager_cli/setup.py
+++ b/integration/keeper_secrets_manager_cli/setup.py
@@ -15,8 +15,9 @@ install_requires = [
     'prompt-toolkit>=3.0',
     'jsonpath-rw-ext',
     # Context.get_parameter_source (used for shell session option inheritance)
-    # requires click 8.0+.
-    'click>=8.0',
+    # requires click 8.0+. The windows_expand_args opt-out passed in
+    # __main__.main() (KSM-1186) requires click 8.0.1+.
+    'click>=8.0.1',
     'click_help_colors',
     # KSM-818: click-repl 0.3.0 crashes with click>=8.2 (protected_args became read-only).
     # Pin to <0.3.0 until click-repl releases Click 8.2+ support (see click-repl PR #132).

--- a/integration/keeper_secrets_manager_cli/tests/windows_expand_args_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/windows_expand_args_test.py
@@ -1,0 +1,50 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+from keeper_secrets_manager_cli import __main__
+
+
+class WindowsExpandArgsTest(unittest.TestCase):
+
+    def test_main_disables_click_windows_arg_expansion(self):
+        """main() must invoke the click group with windows_expand_args=False.
+
+        click >= 8.0 expands every sys.argv argument on Windows before parsing
+        (BaseCommand.main -> _expand_args: os.path.expanduser, then
+        os.path.expandvars, then glob). ntpath.expandvars expands %VAR%/$VAR
+        and collapses $$ to $, so secret values passed as arguments were
+        silently corrupted before storage (KSM-1186):
+
+            'password=a$$b'   was stored as 'a$b'
+            'login=x%OS%y'    was stored as 'xWindows_NTy'
+
+        click 8.0.1 added the windows_expand_args parameter as the supported
+        opt-out; main() must pass it as False.
+
+        CliRunner.invoke() bypasses BaseCommand.main() entirely (it calls
+        Command.invoke via make_context), so the corruption cannot be observed
+        in-process — which is exactly how it evaded the unit suite. This test
+        therefore asserts the wiring of main() itself; end-to-end byte
+        fidelity is covered by the release regression suite, which drives the
+        packaged CLI in a real subprocess on Windows.
+        """
+        captured = {}
+
+        def fake_group_main(*args, **kwargs):
+            captured.update(kwargs)
+
+        with patch.object(__main__.cli, "main", side_effect=fake_group_main):
+            with patch.object(sys, "argv", ["ksm", "version"]):
+                __main__.main()
+
+        self.assertIn("windows_expand_args", captured,
+                      "main() no longer passes windows_expand_args to the click "
+                      "group; Windows argv expansion would corrupt secret values "
+                      "again (KSM-1186)")
+        self.assertIs(captured["windows_expand_args"], False,
+                      "main() must pass windows_expand_args=False (KSM-1186)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

[KSM-1186](https://keeper.atlassian.net/browse/KSM-1186) — on Windows, click ≥ 8.0 expands every command-line argument before parsing (`BaseCommand.main()` defaults `windows_expand_args=True` → `_expand_args()`: `os.path.expanduser`, then `os.path.expandvars`, then glob). `ntpath.expandvars` expands `%VAR%`/`$VAR` and collapses `$$` → `$`, so secret values passed as arguments were silently corrupted before storage:

| typed | stored (pre-fix) |
|---|---|
| `password=a$$b` | `a$b` |
| `login=x%OS%y` | `xWindows_NTy` |

Windows-only (posix never collapses `$$`; click gates the expansion on `os.name == "nt"`), affects **every** click argument (field values, titles, notes, `sync --map`, …) on both pip and frozen surfaces, and also pre-expands `%VAR%` inside `ksm exec` command arguments so the documented Windows exec pattern delivered raw notation instead of the resolved secret. Pre-existing — reproduced byte-identically on 1.4.0 — not a 1.5.0 regression.

## Fix

- `__main__.py` `main()`: pass `windows_expand_args=False` (the click 8.0.1+ opt-out) in the group invocation — secret values are not shell globs.
- `setup.py`: bump `click>=8.0` → `click>=8.0.1` (the version that introduced the opt-out parameter).
- `tests/windows_expand_args_test.py` (new): asserts `main()` passes the opt-out. `click.testing.CliRunner` bypasses `BaseCommand.main()` entirely — exactly how this bug evaded the unit suite — so the wiring is the honest unit-testable surface; byte fidelity end-to-end is covered by the release regression suite driving the packaged CLI in a real subprocess.

`ksm shell` inner commands dispatch through click-repl's `make_context`/`invoke`, never `BaseCommand.main()`, so the KSM-1162/1165 shell tokenizer paths are untouched.

## Verification (Windows 11, live QA US vault, editable install of this branch)

- `a$$b`, `x%OS%y`, glob `*`, `~admin`, and undefined-var controls all stored byte-for-byte on `secret add field` and `secret update` (each corrupted pre-fix except the controls).
- `ksm exec -- cmd /c "echo RESOLVED=%MYPW%"` now delivers the resolved secret to the child (pre-fix: raw notation).
- New test fails on unpatched `main()` (verified via stash), passes patched.
- Full CLI unit suite: **181 passed / 13 skipped / 1 failed** — the failure is the pre-existing privilege-gated `test_symlink_rejection`; no regressions.
- macOS/Linux behavior unchanged (expansion was Windows-gated; the kwarg is accepted everywhere).

Full QA test plan (13 test cases) and acceptance criteria are on [KSM-1186](https://keeper.atlassian.net/browse/KSM-1186) (comment of 2026-08-12). Note for release planning: the current 1.5.0 publish artifacts (run 31418361581) do **not** contain this fix; the frozen surface needs re-verification on whichever rebuilt installer ships it.

[KSM-1186]: https://keeper.atlassian.net/browse/KSM-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSM-1186]: https://keeper.atlassian.net/browse/KSM-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ