### PR TITLE
fix(ruby): encrypt the record key to the owner public key on create

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [17.3.0]
+
+### Fixed
+- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. Records created by versions 17.1.0 and 17.2.0 are affected. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
+
 ## [17.2.0]
 
 ### Fixed

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -1245,11 +1245,20 @@ module KeeperSecretsManager
 
       # Prepare create payload
       def prepare_create_payload(record_uid:, record_key:, folder_uid:, folder_key:, data:, subfolder_uid: nil)
+        owner_public_key = @config.get_string(ConfigKeys::KEY_OWNER_PUBLIC_KEY)
+        unless owner_public_key && !owner_public_key.empty?
+          raise Error, 'Unable to create record - owner key is missing. Looks like application was created ' \
+                       'using out of date client (Web Vault or Commander)'
+        end
+
+        owner_public_key_bytes = Utils.url_safe_str_to_bytes(owner_public_key)
+        record_key_encrypted = Crypto.encrypt_ec(record_key, owner_public_key_bytes)
+
         payload = Dto::CreatePayload.new
         payload.client_version = KeeperGlobals.client_version
         payload.client_id = @config.get_string(ConfigKeys::KEY_CLIENT_ID)
         payload.record_uid = record_uid
-        payload.record_key = Utils.bytes_to_base64(record_key)
+        payload.record_key = Utils.bytes_to_base64(record_key_encrypted)
         payload.folder_uid = folder_uid
         payload.sub_folder_uid = subfolder_uid
         payload.data = Utils.bytes_to_base64(data)

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe KeeperSecretsManager::Core::SecretsManager do
   # Use fixed token bytes so we can encrypt mock data with it
   let(:mock_token_bytes) { 'test_token_key_32_bytes_long!!!!' } # Exactly 32 bytes
   let(:mock_token) { 'US:' + Base64.urlsafe_encode64(mock_token_bytes, padding: false) }
+  # A real P-256 key, not random bytes: record creation encrypts the record key to it, so
+  # it has to load as an EC point.
+  let(:owner_keys) { KeeperSecretsManager::Crypto.generate_ecc_keys }
   let(:mock_config) do
     config = KeeperSecretsManager::Storage::InMemoryStorage.new
     config.save_string(KeeperSecretsManager::ConfigKeys::KEY_CLIENT_ID, 'test_client_id')
     config.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_APP_KEY, 'test_app_key')
     config.save_string(KeeperSecretsManager::ConfigKeys::KEY_HOSTNAME, 'fake.keepersecurity.com')
+    config.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY, owner_keys[:public_key_bytes])
     config
   end
 

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/create_secret_record_key_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/create_secret_record_key_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The record key protects a record's field values. It must reach the server wrapped to the
+# application owner's public key, so that the server never holds both a record's ciphertext
+# and the key that opens it. These specs assert that property on the bytes the create
+# payload actually carries, rather than on the code path that produces them.
+RSpec.describe KeeperSecretsManager::Core::SecretsManager do
+  let(:owner_keys) { KeeperSecretsManager::Crypto.generate_ecc_keys }
+
+  let(:config) do
+    cfg = KeeperSecretsManager::Storage::InMemoryStorage.new
+    cfg.save_string(KeeperSecretsManager::ConfigKeys::KEY_CLIENT_ID, 'test_client_id')
+    cfg.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_APP_KEY, 'test_app_key_32_bytes_exactly!!!')
+    cfg.save_string(KeeperSecretsManager::ConfigKeys::KEY_HOSTNAME, 'fake.keepersecurity.com')
+    cfg.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY, owner_keys[:public_key_bytes])
+    cfg
+  end
+
+  let(:manager) { described_class.new(config: config) }
+
+  let(:record_key) { KeeperSecretsManager::Crypto.generate_encryption_key_bytes }
+  let(:folder_key) { KeeperSecretsManager::Crypto.generate_encryption_key_bytes }
+  let(:record_json) { KeeperSecretsManager::Utils.dict_to_json({ 'title' => 'Test', 'type' => 'login' }) }
+  let(:encrypted_data) { KeeperSecretsManager::Crypto.encrypt_aes_gcm(record_json, record_key) }
+
+  def build_payload
+    manager.send(
+      :prepare_create_payload,
+      record_uid: 'test_record_uid',
+      record_key: record_key,
+      folder_uid: 'test_folder_uid',
+      folder_key: folder_key,
+      data: encrypted_data
+    )
+  end
+
+  describe '#prepare_create_payload record key handling' do
+    it 'wraps the record key to the owner public key' do
+      # Control: this keypair and this pair of primitives round-trip. Without it, a failure
+      # below could mean the wrap is absent or merely that the fixture or decrypt_ec is
+      # broken, and those need different fixes.
+      control = KeeperSecretsManager::Crypto.encrypt_ec(record_key, owner_keys[:public_key_bytes])
+      expect(KeeperSecretsManager::Crypto.decrypt_ec(control, owner_keys[:private_key_obj])).to eq(record_key)
+
+      wire_bytes = KeeperSecretsManager::Utils.base64_to_bytes(build_payload.record_key)
+
+      recovered = KeeperSecretsManager::Crypto.decrypt_ec(wire_bytes, owner_keys[:private_key_obj])
+
+      expect(recovered).to eq(record_key)
+    end
+
+    it 'does not put the key that decrypts the record data on the wire' do
+      payload = build_payload
+      wire_bytes = KeeperSecretsManager::Utils.base64_to_bytes(payload.record_key)
+
+      # Establishes that record_key really is the key protecting payload.data, so the
+      # assertion below cannot pass because the two values are unrelated.
+      expect(KeeperSecretsManager::Crypto.decrypt_aes_gcm(
+               KeeperSecretsManager::Utils.base64_to_bytes(payload.data), record_key
+             )).to eq(record_json)
+
+      expect(wire_bytes).not_to eq(record_key)
+    end
+
+    it 'raises rather than sending the record key unwrapped when the owner public key is missing' do
+      config.delete(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY)
+
+      expect { build_payload }.to raise_error(KeeperSecretsManager::Error, /owner key is missing/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ruby SDK: `create_secret` sent the record key to the server unencrypted. `prepare_create_payload` assigned the raw AES-256 record key to `payload.record_key`, while the same request carried the record data encrypted under that key. The server therefore received both a record's ciphertext and the key that opens it. This fix encrypts the record key to the application owner's public key first, matching the other SDKs.

## Changes

### Fixed
- `prepare_create_payload` reads `appOwnerPublicKey` from storage and wraps the record key with `Crypto.encrypt_ec` before it goes on the wire (KSM-1193)
- `prepare_create_payload` raises when the application configuration has no owner public key, instead of continuing without the encryption step (KSM-1193)

The wrap mirrors Python `prepare_create_payload`. Ruby's `upload_file` path already encrypted its file record key correctly, so only the create-record payload was affected.

The hard failure on a missing owner key is deliberate. A fallback to sending the key unwrapped would keep the defect for exactly the older applications most likely to lack that key.

## Testing

```bash
cd sdk/ruby && bundle exec rspec
```

783 examples, 0 failures.

Three new examples in `spec/keeper_secrets_manager/unit/create_secret_record_key_spec.rb` assert the property on the payload bytes rather than on the code path:

1. The value in `payload.record_key` decrypts back to the record key under the owner private key. A control assertion first proves the keypair and the two primitives round-trip, so a failure can only mean the wrap is absent.
2. The record key genuinely decrypts `payload.data`, and the value on the wire is not those bytes. The first half stops the second from passing when the fixture is unrelated.
3. Deleting `appOwnerPublicKey` makes the call raise rather than send the key unwrapped.

All three fail on the unfixed code. The second reports expected and actual as byte-identical 32-byte strings.

Five existing `create_secret` examples shared a config fixture that had no owner public key, which is why this shipped twice with a green suite. The fixture now holds a real P-256 key. No assertion in those examples changed.

Live check against QA created a record, confirmed `payload.recordKey` is 125 bytes beginning with `0x04` rather than the 32-byte plaintext key, read the record back with its title and field values intact, then deleted the record.

## Breaking Changes

None for callers whose application has an owner public key, which is every application bound by a current Web Vault or Commander. An application whose configuration lacks `appOwnerPublicKey` now receives an error from `create_secret` instead of creating a record. That path previously produced records with an unwrapped key, so it was never safe to use.

## Related Issues

- Jira: KSM-1193
