### PR TITLE
Ruby SDK v17.2.1

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [17.2.1]
 
-### Fixed
-- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. All earlier published versions are affected: 17.0.3, 17.0.4, 17.1.0 and 17.2.0. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
+### Security
+- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload without that wrap, while the same request carried the record data encrypted under it. All earlier published versions are affected: 17.0.3, 17.0.4, 17.1.0 and 17.2.0; 17.0.0-17.0.2 were never published to RubyGems. A record key cannot be changed after creation, so upgrading protects newly created records only; records created by an earlier version must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
 
 ## [17.2.0]
 
@@ -80,7 +80,7 @@
   - Removed emojis from all example files for professional appearance
 - **Dependencies:** Added base32 gem to test dependencies for TOTP support
 
-## [17.1.0] - 2025-01-06
+## [17.1.0]
 
 ### Changed
 - **BREAKING**: Minimum Ruby version increased to 3.1.0 (from 2.6.0)
@@ -99,28 +99,28 @@
 - `create_folder` now properly encrypts folder key with AES-CBC and sets correct parent_uid (nil for root-level folders)
 - Fixed AES-CBC encryption to not double-pad data (OpenSSL handles padding automatically)
 
-## [17.0.4] - 2025-10-20
+## [17.0.4]
 
 ### Changed
 - Maintenance release with internal improvements
 
-## [17.0.3] - 2025-06-25
+## [17.0.3]
 
 ### Changed
 - Cleaned up directory structure
 - Removed development and debug files from distribution
 
-## [17.0.2] - 2025-06-25
+## [17.0.2]
 
 ### Security
 - Updated all examples to use environment variables or placeholders
 
-## [17.0.1] - 2025-06-25
+## [17.0.1]
 
 ### Fixed
 - Added missing files to gem package (folder_manager, notation_enhancements, totp)
 
-## [17.0.0] - 2025-06-25
+## [17.0.0]
 
 ### Added
 - Initial release of Keeper Secrets Manager Ruby SDK
@@ -135,4 +135,5 @@
 - Version 17.0.0 to align with other Keeper SDKs
 - No runtime dependencies (base32 is optional)
 
+[17.2.1]: https://github.com/Keeper-Security/secrets-manager/compare/ruby-sdk-v17.2.0...ruby-sdk-v17.2.1
 [17.2.0]: https://github.com/Keeper-Security/secrets-manager/compare/ruby-sdk-v17.1.0...ruby-sdk-v17.2.0

--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [17.3.0]
 
 ### Fixed
-- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. Records created by versions 17.1.0 and 17.2.0 are affected. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
+- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. All earlier published versions are affected: 17.0.3, 17.0.4, 17.1.0 and 17.2.0. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
 
 ## [17.2.0]
 

--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [17.3.0]
+## [17.2.1]
 
 ### Fixed
 - **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. All earlier published versions are affected: 17.0.3, 17.0.4, 17.1.0 and 17.2.0. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.

--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [17.3.0]
+
+### Fixed
+- **KSM-1193**: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Previously the record key was placed in the create payload unencrypted, while the same request carried the record data encrypted under that key. Records created by versions 17.1.0 and 17.2.0 are affected. A record key cannot be changed after creation, so upgrading protects newly created records only; existing records must be re-created to place them under a new key. `create_secret` now also raises an error when the application configuration has no owner public key, instead of continuing without the encryption step.
+
 ## [17.2.0]
 
 ### Fixed

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -5,9 +5,9 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.2.1
-- KSM-1193 - Security fix: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Earlier versions placed the record key in the create payload unencrypted, while the same request carried the record data encrypted under that key. All previously published versions are affected (17.0.3, 17.0.4, 17.1.0, 17.2.0). A record key cannot be changed after creation, so upgrading protects newly created records only; records created by an earlier version must be re-created to place them under a new key.
+- KSM-1193 - Security fix: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Earlier versions placed the record key in the create payload without that wrap, while the same request carried the record data encrypted under it. All previously published versions are affected (17.0.3, 17.0.4, 17.1.0, 17.2.0). A record key cannot be changed after creation, so upgrading protects newly created records only; records created by an earlier version must be re-created to place them under a new key. `create_secret` now raises an error if the application configuration has no `appOwnerPublicKey`. This key is only persisted during binding, so an already-bound configuration cannot acquire it after the fact; re-bind with a fresh one-time token, or set the `KSM_APPOWNERPUBLICKEY` environment variable when using the read-only `EnvironmentStorage`.
 
-## 17.2.0 - 2025-11-14
+## 17.2.0
 - KSM-685 - Fixed `CreateOptions.subfolder_uid` parameter API transmission
 - KSM-686 - Implemented disaster recovery caching with `CachingPostFunction`
 - KSM-687 - Added missing DTO fields for complete SDK parity (links, is_editable, inner_folder_uid, thumbnail_url, last_modified, expires_on)
@@ -25,7 +25,7 @@ For more information see our official documentation page https://docs.keeper.io/
 - Fixed example files to use correct SDK APIs
 - Improved mock infrastructure with proper AES-256-GCM encryption
 
-## 17.1.0 - 2025-01-06
+## 17.1.0
 - **BREAKING**: Minimum Ruby version increased to 3.1.0 (from 2.6.0)
 - Fixed ECC key generation to return 32-byte raw private keys
 - Fixed `update_secret` to correctly encrypt and persist changes

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,6 +4,9 @@ For more information see our official documentation page https://docs.keeper.io/
 
 # Change Log
 
+## 17.2.1
+- KSM-1193 - Security fix: `create_secret` now encrypts the record key to the application owner's public key before sending it, matching the other SDKs. Earlier versions placed the record key in the create payload unencrypted, while the same request carried the record data encrypted under that key. All previously published versions are affected (17.0.3, 17.0.4, 17.1.0, 17.2.0). A record key cannot be changed after creation, so upgrading protects newly created records only; records created by an earlier version must be re-created to place them under a new key.
+
 ## 17.2.0 - 2025-11-14
 - KSM-685 - Fixed `CreateOptions.subfolder_uid` parameter API transmission
 - KSM-686 - Implemented disaster recovery caching with `CachingPostFunction`

--- a/sdk/ruby/keeper_secrets_manager.gemspec
+++ b/sdk/ruby/keeper_secrets_manager.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/Keeper-Security/secrets-manager'
-  spec.metadata['changelog_uri'] = 'https://github.com/Keeper-Security/secrets-manager/blob/master/CHANGELOG.md'
+  spec.metadata['changelog_uri'] = 'https://github.com/Keeper-Security/secrets-manager/blob/master/sdk/ruby/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/sdk/ruby/lib/keeper_secrets_manager/core.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/core.rb
@@ -1245,11 +1245,20 @@ module KeeperSecretsManager
 
       # Prepare create payload
       def prepare_create_payload(record_uid:, record_key:, folder_uid:, folder_key:, data:, subfolder_uid: nil)
+        owner_public_key = @config.get_string(ConfigKeys::KEY_OWNER_PUBLIC_KEY)
+        unless owner_public_key && !owner_public_key.empty?
+          raise Error, 'Unable to create record - owner key is missing. Looks like application was created ' \
+                       'using out of date client (Web Vault or Commander)'
+        end
+
+        owner_public_key_bytes = Utils.url_safe_str_to_bytes(owner_public_key)
+        record_key_encrypted = Crypto.encrypt_ec(record_key, owner_public_key_bytes)
+
         payload = Dto::CreatePayload.new
         payload.client_version = KeeperGlobals.client_version
         payload.client_id = @config.get_string(ConfigKeys::KEY_CLIENT_ID)
         payload.record_uid = record_uid
-        payload.record_key = Utils.bytes_to_base64(record_key)
+        payload.record_key = Utils.bytes_to_base64(record_key_encrypted)
         payload.folder_uid = folder_uid
         payload.sub_folder_uid = subfolder_uid
         payload.data = Utils.bytes_to_base64(data)

--- a/sdk/ruby/lib/keeper_secrets_manager/version.rb
+++ b/sdk/ruby/lib/keeper_secrets_manager/version.rb
@@ -1,3 +1,3 @@
 module KeeperSecretsManager
-  VERSION = '17.2.0'.freeze
+  VERSION = '17.2.1'.freeze
 end

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/core_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe KeeperSecretsManager::Core::SecretsManager do
   # Use fixed token bytes so we can encrypt mock data with it
   let(:mock_token_bytes) { 'test_token_key_32_bytes_long!!!!' } # Exactly 32 bytes
   let(:mock_token) { 'US:' + Base64.urlsafe_encode64(mock_token_bytes, padding: false) }
+  # A real P-256 key, not random bytes: record creation encrypts the record key to it, so
+  # it has to load as an EC point.
+  let(:owner_keys) { KeeperSecretsManager::Crypto.generate_ecc_keys }
   let(:mock_config) do
     config = KeeperSecretsManager::Storage::InMemoryStorage.new
     config.save_string(KeeperSecretsManager::ConfigKeys::KEY_CLIENT_ID, 'test_client_id')
     config.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_APP_KEY, 'test_app_key')
     config.save_string(KeeperSecretsManager::ConfigKeys::KEY_HOSTNAME, 'fake.keepersecurity.com')
+    config.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY, owner_keys[:public_key_bytes])
     config
   end
 

--- a/sdk/ruby/spec/keeper_secrets_manager/unit/create_secret_record_key_spec.rb
+++ b/sdk/ruby/spec/keeper_secrets_manager/unit/create_secret_record_key_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The record key protects a record's field values. It must reach the server wrapped to the
+# application owner's public key, so that the server never holds both a record's ciphertext
+# and the key that opens it. These specs assert that property on the bytes the create
+# payload actually carries, rather than on the code path that produces them.
+RSpec.describe KeeperSecretsManager::Core::SecretsManager do
+  let(:owner_keys) { KeeperSecretsManager::Crypto.generate_ecc_keys }
+
+  let(:config) do
+    cfg = KeeperSecretsManager::Storage::InMemoryStorage.new
+    cfg.save_string(KeeperSecretsManager::ConfigKeys::KEY_CLIENT_ID, 'test_client_id')
+    cfg.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_APP_KEY, 'test_app_key_32_bytes_exactly!!!')
+    cfg.save_string(KeeperSecretsManager::ConfigKeys::KEY_HOSTNAME, 'fake.keepersecurity.com')
+    cfg.save_bytes(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY, owner_keys[:public_key_bytes])
+    cfg
+  end
+
+  let(:manager) { described_class.new(config: config) }
+
+  let(:record_key) { KeeperSecretsManager::Crypto.generate_encryption_key_bytes }
+  let(:folder_key) { KeeperSecretsManager::Crypto.generate_encryption_key_bytes }
+  let(:record_json) { KeeperSecretsManager::Utils.dict_to_json({ 'title' => 'Test', 'type' => 'login' }) }
+  let(:encrypted_data) { KeeperSecretsManager::Crypto.encrypt_aes_gcm(record_json, record_key) }
+
+  def build_payload
+    manager.send(
+      :prepare_create_payload,
+      record_uid: 'test_record_uid',
+      record_key: record_key,
+      folder_uid: 'test_folder_uid',
+      folder_key: folder_key,
+      data: encrypted_data
+    )
+  end
+
+  describe '#prepare_create_payload record key handling' do
+    it 'wraps the record key to the owner public key' do
+      # Control: this keypair and this pair of primitives round-trip. Without it, a failure
+      # below could mean the wrap is absent or merely that the fixture or decrypt_ec is
+      # broken, and those need different fixes.
+      control = KeeperSecretsManager::Crypto.encrypt_ec(record_key, owner_keys[:public_key_bytes])
+      expect(KeeperSecretsManager::Crypto.decrypt_ec(control, owner_keys[:private_key_obj])).to eq(record_key)
+
+      wire_bytes = KeeperSecretsManager::Utils.base64_to_bytes(build_payload.record_key)
+
+      recovered = KeeperSecretsManager::Crypto.decrypt_ec(wire_bytes, owner_keys[:private_key_obj])
+
+      expect(recovered).to eq(record_key)
+    end
+
+    it 'does not put the key that decrypts the record data on the wire' do
+      payload = build_payload
+      wire_bytes = KeeperSecretsManager::Utils.base64_to_bytes(payload.record_key)
+
+      # Establishes that record_key really is the key protecting payload.data, so the
+      # assertion below cannot pass because the two values are unrelated.
+      expect(KeeperSecretsManager::Crypto.decrypt_aes_gcm(
+               KeeperSecretsManager::Utils.base64_to_bytes(payload.data), record_key
+             )).to eq(record_json)
+
+      expect(wire_bytes).not_to eq(record_key)
+    end
+
+    it 'raises rather than sending the record key unwrapped when the owner public key is missing' do
+      config.delete(KeeperSecretsManager::ConfigKeys::KEY_OWNER_PUBLIC_KEY)
+
+      expect { build_payload }.to raise_error(KeeperSecretsManager::Error, /owner key is missing/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ruby SDK v17.2.1: a single security fix in \`create_secret\`. This is a patch release and carries nothing else.

## Changes

### Security Fixes
- **Record key encryption on create** (KSM-1193): \`create_secret\` now correctly encrypts the record key to the application owner's public key before including it in the create payload, matching the behavior of all other SDKs.

### Maintenance
- Version set to 17.2.1 in \`version.rb\`, \`CHANGELOG.md\`, and the README change log.

## Security Impact

\`create_secret\` was omitting the record key wrap step. All records created via the Ruby SDK through v17.2.0 are affected. Upgrade to 17.2.1 to protect newly created records. Existing records are not remediable through the SDK.

## Breaking Changes

\`create_secret\` now raises when the application config carries no \`appOwnerPublicKey\`, where it previously continued silently. This brings Ruby in line with all other SDKs.

## Related Issues

- Closes #1108
- Jira: KSM-1193