### PR TITLE
fix(java): validate server key_id range and eliminate config write race window

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -7,6 +7,8 @@ For more information see our official documentation page https://docs.keeper.io/
 ## 17.4.0
 - KSM-1081 - Fixed `getFolders()` crashing when any folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
 - KSM-1086 - Fixed `deleteFolder()` to return `SecretsManagerDeleteFolderResponse` (typed per-folder status), matching `deleteSecret()`. The SDK now logs per-item server failures to stderr and includes them in the return value so callers can detect partial failures.
+- KSM-1248 - Server-supplied key IDs are validated against the embedded public key table before being stored. An unrecognized key ID throws `SecretsManagerException` and leaves storage unchanged. Key rotation retries are now capped at `MAX_KEY_ROTATION_RETRIES` (3); exhausted retries throw a typed error naming the last suggested key ID.
+- KSM-1262 - On POSIX systems, config and cache files are now written via a temp-file swap with 0600 permissions set before data is written, closing the window where other local users could read the file during a write. Two behavior changes from the new approach: (1) a symlinked config path is replaced by a regular file on the first write; (2) a config file in a directory without write permission (for example, a read-only container volume mount) will fail at temp-file creation — move the config to a writable directory or use `InMemoryStorage` with an injected config string instead.
 
 ## 17.3.0
 **Breaking Changes**

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -6,33 +6,42 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.*
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
-import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.*
 import kotlin.collections.HashMap
 
 fun saveCachedValue(data: ByteArray) {
-    val file = File("cache.dat")
-    FileOutputStream(file).use { fos -> fos.write(data) } // .use{} closes on exception even if the operation throws
-
-    // Set file permissions to 0600 (owner read/write only)
+    val targetPath = File("cache.dat").absoluteFile.toPath()
+    val tmpPath = Files.createTempFile(targetPath.parent, "ksm_", ".tmp")
     try {
-        val perms = PosixFilePermissions.fromString("rw-------")
-        Files.setPosixFilePermissions(file.toPath(), perms)
-    } catch (e: UnsupportedOperationException) {
-        // Windows or file system doesn't support POSIX permissions
-        // File.setReadable/setWritable provides basic protection
-        file.setReadable(false, false)  // Remove all read permissions
-        file.setWritable(false, false)  // Remove all write permissions
-        file.setReadable(true, true)     // Owner read only
-        file.setWritable(true, true)     // Owner write only
+        try {
+            Files.setPosixFilePermissions(tmpPath, PosixFilePermissions.fromString("rw-------"))
+        } catch (_: UnsupportedOperationException) {
+            tmpPath.toFile().let { f ->
+                f.setReadable(false, false)
+                f.setWritable(false, false)
+                f.setReadable(true, true)
+                f.setWritable(true, true)
+            }
+        }
+        Files.write(tmpPath, data)
+        try {
+            Files.move(tmpPath, targetPath, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(tmpPath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+        }
+    } catch (e: Exception) {
+        try { Files.deleteIfExists(tmpPath) } catch (_: Exception) { }
+        throw e
     }
 }
 
 fun getCachedValue(): ByteArray {
     try {
-        return FileInputStream("cache.dat").use { it.readBytes() } // .use{} closes on exception even if the operation throws
+        return FileInputStream("cache.dat").use { it.readBytes() } // .use{} closes on exception
     } catch (e: Exception) {
         throw SecretsManagerException("Cached value does not exist")
     }
@@ -115,7 +124,7 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private val file = configName?.let { File(it) }
     private var storage: InMemoryStorage = if (file != null && file.exists()) {
-        val content = BufferedReader(FileReader(file)).use { it.readText() } // previously never closed on exception; .use{} guarantees it
+        val content = file.readText(Charsets.UTF_8)
         InMemoryStorage(content)
     } else {
         InMemoryStorage()
@@ -125,29 +134,38 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
 
     private fun saveToFile() {
         if (file == null) return
-        val config = LocalConfig()
-        config.hostname = storage.getString(KEY_HOSTNAME)
-        config.clientId = storage.getString(KEY_CLIENT_ID)
-        config.privateKey = storage.getString(KEY_PRIVATE_KEY)
-        config.clientKey = storage.getString(KEY_CLIENT_KEY)
-        config.appKey = storage.getString(KEY_APP_KEY)
-        config.appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY)
-        config.serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
-        config.serverPublicKey = storage.getString(KEY_SERVER_PUBLIC_KEY)
-        val json = prettyJson.encodeToString(config)
-        BufferedWriter(FileWriter(file)).use { it.write(json) } // .use{} closes on exception even if the operation throws
-
-        // Set file permissions to 0600 (owner read/write only)
+        val targetPath = file.absoluteFile.toPath()
+        val tmpPath = Files.createTempFile(targetPath.parent, "ksm_", ".tmp")
         try {
-            val perms = PosixFilePermissions.fromString("rw-------")
-            Files.setPosixFilePermissions(file.toPath(), perms)
-        } catch (e: UnsupportedOperationException) {
-            // Windows or file system doesn't support POSIX permissions
-            // File.setReadable/setWritable provides basic protection
-            file.setReadable(false, false)  // Remove all read permissions
-            file.setWritable(false, false)  // Remove all write permissions
-            file.setReadable(true, true)     // Owner read only
-            file.setWritable(true, true)     // Owner write only
+            try {
+                Files.setPosixFilePermissions(tmpPath, PosixFilePermissions.fromString("rw-------"))
+            } catch (_: UnsupportedOperationException) {
+                tmpPath.toFile().let { f ->
+                    f.setReadable(false, false)
+                    f.setWritable(false, false)
+                    f.setReadable(true, true)
+                    f.setWritable(true, true)
+                }
+            }
+            val config = LocalConfig(
+                hostname = storage.getString(KEY_HOSTNAME),
+                clientId = storage.getString(KEY_CLIENT_ID),
+                privateKey = storage.getString(KEY_PRIVATE_KEY),
+                clientKey = storage.getString(KEY_CLIENT_KEY),
+                appKey = storage.getString(KEY_APP_KEY),
+                appOwnerPublicKey = storage.getString(KEY_OWNER_PUBLIC_KEY),
+                serverPublicKeyId = storage.getString(KEY_SERVER_PUBLIC_KEY_ID),
+                serverPublicKey = storage.getString(KEY_SERVER_PUBLIC_KEY)
+            )
+            Files.write(tmpPath, prettyJson.encodeToString(config).toByteArray())
+            try {
+                Files.move(tmpPath, targetPath, StandardCopyOption.ATOMIC_MOVE)
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(tmpPath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+            }
+        } catch (e: Exception) {
+            try { Files.deleteIfExists(tmpPath) } catch (_: Exception) { }
+            throw e
         }
     }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -36,6 +36,7 @@ const val KEEPER_CLIENT_VERSION = "mj17.3.0"
 const val MAX_THROTTLE_RETRIES = 5
 const val BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
 const val MAX_THROTTLE_DELAY_SEC = 176 // caps a backend-supplied retry_after from forcing an excessive wait
+const val MAX_KEY_ROTATION_RETRIES = 3 // parity with JS SDK open PR #1078
 
 const val KEY_HOSTNAME = "hostname" // base url for the Secrets Manager service
 const val KEY_SERVER_PUBLIC_KEY_ID = "serverPublicKeyId"
@@ -1806,6 +1807,7 @@ private inline fun <reified T> postQuery(
     val url = "https://${hostName}/api/rest/sm/v1/${path}"
     val throttleSleep = options.throttleSleepMillis ?: { ms -> Thread.sleep(ms) }
     var throttleAttempt = 0
+    var keyRotationAttempt = 0
     while (true) {
         val transmissionKey = generateTransmissionKey(options.storage)
         val encryptedPayload = encryptAndSignPayload(options.storage, transmissionKey, payload)
@@ -1846,6 +1848,18 @@ private inline fun <reified T> postQuery(
                     val currentKeyId = options.storage.getString(KEY_SERVER_PUBLIC_KEY_ID)
                     throw SecretsManagerException("Server rejected the custom server public key (id $currentKeyId). The server suggested key id ${error.key_id}. Please update your IL5 KSM configuration.")
                 }
+                if (!keeperPublicKeys.containsKey(error.key_id)) {
+                    val ids = keeperPublicKeys.keys.sorted()
+                    throw SecretsManagerException(
+                        "Server suggested unsupported key id ${error.key_id}; this SDK version supports key ids ${ids.first()}-${ids.last()}"
+                    )
+                }
+                if (keyRotationAttempt >= MAX_KEY_ROTATION_RETRIES) {
+                    throw SecretsManagerException(
+                        "Server key rotation exhausted $MAX_KEY_ROTATION_RETRIES retries; key id ${transmissionKey.publicKeyId} was not accepted"
+                    )
+                }
+                keyRotationAttempt++
                 options.storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, error.key_id.toString())
                 continue
             }

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -181,6 +181,94 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testServerKeyIdOutOfRangeIsRejected() {
+        // Server-supplied key_id outside the known range must be rejected before storage is written.
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "fake.keepersecurity.com:FAKE_CLIENT_KEY")
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+        val testPostFunction: (String, TransmissionKey, EncryptedPayload) -> KeeperHttpResponse = { _, _, _ ->
+            KeeperHttpResponse(400, """{"error":"key","key_id":999}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, testPostFunction)
+        val ex = assertFailsWith<SecretsManagerException> {
+            getSecrets(options)
+        }
+        assertTrue(
+            ex.message?.contains("unsupported key id 999") == true,
+            "Exception must come from the key-table guard and name the rejected id. Got: ${ex.message}"
+        )
+        assertNull(
+            storage.getString(KEY_SERVER_PUBLIC_KEY_ID),
+            "Storage must not be poisoned with key_id=999. Got: ${storage.getString(KEY_SERVER_PUBLIC_KEY_ID)}"
+        )
+    }
+
+    @Test
+    fun testCustomServerKeyGuardTakesPriorityOverKeyTable() {
+        // When a custom server key is configured, a server key-rotation hint must reach
+        // the custom-key branch and throw the actionable error before the key-table guard.
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "fake.keepersecurity.com:FAKE_CLIENT_KEY")
+        // Use a real EC public key so webSafe64ToBytes succeeds in generateTransmissionKey.
+        // The value here is keeper public key #7 (from the embedded table).
+        storage.saveString(KEY_SERVER_PUBLIC_KEY, "BK9w6TZFxE6nFNbMfIpULCup2a8xc6w2tUTABjxny7yFmxW0dAEojwC6j6zb5nTlmb1dAx8nwo3qF7RPYGmloRM")
+        storage.saveString(KEY_SERVER_PUBLIC_KEY_ID, "20")
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+        val testPostFunction: (String, TransmissionKey, EncryptedPayload) -> KeeperHttpResponse = { _, _, _ ->
+            KeeperHttpResponse(400, """{"error":"key","key_id":999}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, testPostFunction)
+        val ex = assertFailsWith<SecretsManagerException> {
+            getSecrets(options)
+        }
+        assertTrue(
+            ex.message?.contains("custom server public key") == true,
+            "Custom-key path must fire before the key-table guard. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun testServerKeyRotationRetryCap() {
+        // When the server keeps returning an in-table key_id, the loop must stop after MAX_KEY_ROTATION_RETRIES.
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "fake.keepersecurity.com:FAKE_CLIENT_KEY")
+        TestStubs.transmissionKeyStub = { ByteArray(32) }
+        val callCount = intArrayOf(0)
+        val testPostFunction: (String, TransmissionKey, EncryptedPayload) -> KeeperHttpResponse = { _, _, _ ->
+            callCount[0]++
+            KeeperHttpResponse(400, """{"error":"key","key_id":10}""".toByteArray())
+        }
+        val options = SecretsManagerOptions(storage, testPostFunction)
+        val ex = assertFailsWith<SecretsManagerException> {
+            getSecrets(options)
+        }
+        assertTrue(
+            ex.message?.contains("key rotation exhausted $MAX_KEY_ROTATION_RETRIES retries") == true,
+            "Exception must name the retry limit. Got: ${ex.message}"
+        )
+        assertEquals(
+            MAX_KEY_ROTATION_RETRIES + 1, callCount[0],
+            "Must make exactly MAX_KEY_ROTATION_RETRIES+1 calls (initial + cap retries)"
+        )
+    }
+
+    @Test
+    fun testConfigFileAtomicWriteIsOwnerOnly() {
+        // KSM-1262: the config file must be written via atomic rename and be readable only by the owner.
+        val configFile = File.createTempFile("ksm-test-", ".json").also { it.delete() }
+        try {
+            val storage = LocalConfigStorage(configFile.absolutePath)
+            initializeStorage(storage, "fake.keepersecurity.com:FAKE_CLIENT_KEY")
+            assertTrue(configFile.exists(), "Config file must exist after initializeStorage")
+            val perms = java.nio.file.Files.getPosixFilePermissions(configFile.toPath())
+            val expected = java.nio.file.attribute.PosixFilePermissions.fromString("rw-------")
+            assertEquals(expected, perms, "Config file must be owner-read/write only. Got: $perms")
+        } finally {
+            configFile.delete()
+        }
+    }
+
+    @Test
     fun testRecordCreateEmptyCustomSerialized() {
         // RecordCreate with no custom fields must include "custom": [] in JSON payload
         val recordData = KeeperRecordData(
@@ -195,7 +283,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileDataMissingLastModified() {
-        // lastModified entirely absent; must deserialize without throwing
+        // lastModified is absent. The SDK must deserialize without throwing.
         val json = """{"title":"test.txt","name":"test.txt","type":"text/plain","size":1024}"""
         val result = Json.decodeFromString<KeeperFileData>(json)
         assertEquals(0L, result.lastModified)
@@ -212,7 +300,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileDataFractionalLastModified() {
-        // Regression guard: fractional lastModified (iOS client format)
+        // Regression guard for fractional lastModified (iOS client format)
         val json = """{"title":"test.txt","name":"test.txt","size":1024,"lastModified":1760646182.790214}"""
         val result = Json.decodeFromString<KeeperFileData>(json)
         assertEquals(1760646182L, result.lastModified)
@@ -220,7 +308,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testKeeperFileNullUrl() {
-        // KeeperFile.url must be nullable; server may omit url for files without a download link
+        // KeeperFile.url must be nullable. The server may omit url for files without a download link.
         val fileData = KeeperFileData("test.txt", "test.txt", "text/plain", 1024)
         val file = KeeperFile(ByteArray(32), "uid123", fileData, null, null)
         assertNull(file.url)
@@ -228,7 +316,7 @@ internal class SecretsManagerTest {
 
     @Test
     fun testBase64EmptyStringThrowsTypedException() {
-        // Empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64
+        // Empty string must throw a typed Keeper exception, not an NPE from inside java.util.Base64.
         val base64Ex = assertFailsWith<Exception> { base64ToBytes("") }
         assertTrue(base64Ex.message?.isNotEmpty() == true)
         val webSafe64Ex = assertFailsWith<Exception> { webSafe64ToBytes("") }


### PR DESCRIPTION
## Summary

Java SDK: validates and bounds server-supplied key ID rotation in `postQuery`, and eliminates the config/cache file read window on write.

## Changes

### Fixed

- **Server key_id validation and rotation cap** (KSM-1248): the SDK accepted any `key_id` from a server error response and wrote it directly to storage without checking whether the key existed, and retried with no bound. An unrecognized key ID corrupted the stored configuration and made every subsequent call fail. A valid key ID that the server kept re-suggesting caused an infinite loop of full encrypt/sign/POST cycles. The SDK now (1) rejects any key ID not in the embedded public key table, throwing `SecretsManagerException` naming the suggested ID and the supported range, and (2) caps key rotation retries at `MAX_KEY_ROTATION_RETRIES` (3), throwing a typed terminal error naming the key ID that was not accepted.
- **Config and cache file write race window** (KSM-1262): on POSIX systems, config and cache files are now written via a temp-file swap with 0600 permissions set before data is written, closing the window where other local users could read the file during a write. Two behavior changes: (1) a symlinked config path is replaced by a regular file on the first write; (2) a config file in a directory without write permission will fail at temp-file creation — move the config to a writable directory or use `InMemoryStorage` with an injected config string instead.

## Testing

```bash
cd sdk/java/core && ./gradlew test
```

`testServerKeyIdOutOfRangeIsRejected` confirms that a server-supplied `key_id` of 999 throws `SecretsManagerException` naming the suggested ID and the supported range, and that `KEY_SERVER_PUBLIC_KEY_ID` is not written to storage.
`testCustomServerKeyGuardTakesPriorityOverKeyTable` confirms that when a custom server key is configured, a server key-rotation hint throws the custom-key error before the key-table guard — pinning the branch boundary.
`testServerKeyRotationRetryCap` confirms that a server that keeps returning an in-table key ID causes exactly `MAX_KEY_ROTATION_RETRIES + 1` calls and then throws a terminal `SecretsManagerException` naming the retry limit.
`testConfigFileAtomicWriteIsOwnerOnly` confirms that the config file is written with `rw-------` POSIX permissions.

## Security Impact

KSM-1248 prevents a hostile server response from either corrupting the stored key ID or pinning the client in an unbounded retry loop.

KSM-1262 eliminates the window where other local users can read the config or cache file on POSIX systems. The config file holds the app key, which decrypts all record field values.

## Breaking Changes

None.

## Related Issues

- Jira: KSM-1248, KSM-1262