### PR TITLE
Fix generatePassword using non-cryptographic shuffle (KSM-1203)

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,7 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.4.0
+- KSM-1203 - Fixed `generatePassword` using a non-cryptographic PRNG (Kotlin `Random.Default`) for the final character shuffle. The shuffle now uses `SecureRandom`, so the entire password generation path is cryptographically secure.
 - KSM-1081 - Fixed `getFolders()` crashing when any folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
 - KSM-1086 - Fixed `deleteFolder()` to return `SecretsManagerDeleteFolderResponse` (typed per-folder status), matching `deleteSecret()`. The SDK now logs per-item server failures to stderr and includes them in the return value so callers can detect partial failures.
 - KSM-1248 - Server-supplied key IDs are validated against the embedded public key table before being stored. An unrecognized key ID throws `SecretsManagerException` and leaves storage unchanged. Key rotation retries are now capped at `MAX_KEY_ROTATION_RETRIES` (3); exhausted retries throw a typed error naming the last suggested key ID.

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/CryptoUtils.kt
@@ -416,7 +416,7 @@ fun generatePassword(
         if (it.first > 0)
             passwordCharacters += randomSample(it.first, it.second)
     }
-    val pCharArray = passwordCharacters.toCharArray()
-    pCharArray.shuffle()
-    return String(pCharArray)
+    val pCharList = passwordCharacters.toMutableList()
+    Collections.shuffle(pCharList, SecureRandom.getInstanceStrong())
+    return String(pCharList.toCharArray())
 }


### PR DESCRIPTION
## What changed

`generatePassword` in `CryptoUtils.kt` selected characters using `SecureRandom` but then shuffled the assembled array with `pCharArray.shuffle()`, which uses Kotlin's `Random.Default` — a non-cryptographic PRNG. The final character arrangement was therefore predictable from PRNG state.

Replaced with `Collections.shuffle(pCharList, SecureRandom.getInstanceStrong())` so the entire password generation path uses a CSPRNG. No new imports are needed; both `java.util.Collections` and `java.security.SecureRandom` are already imported in the file.

OWASP audit finding F-02, CWE-338. Part of epic KSM-1197.

## Test plan

- [ ] Existing `testGeneratePassword` passes — length and character-class constraints are preserved
- [ ] `./gradlew test` green