### PR TITLE
Expose isEditable on KeeperRecord (KSM-1176)

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -6,6 +6,7 @@ For more information see our official documentation page https://docs.keeper.io/
 
 ## 17.4.0
 - KSM-1203 - Fixed `generatePassword` using a non-cryptographic PRNG (Kotlin `Random.Default`) for the final character shuffle. The shuffle now uses `SecureRandom`, so the entire password generation path is cryptographically secure.
+- KSM-1176 - `KeeperRecord` now exposes `isEditable: Boolean`, forwarded from the server response envelope. Callers can inspect this field before calling `updateSecret` to determine whether the app has write permission for the record.
 - KSM-1081 - Fixed `getFolders()` crashing when any folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
 - KSM-1086 - Fixed `deleteFolder()` to return `SecretsManagerDeleteFolderResponse` (typed per-folder status), matching `deleteSecret()`. The SDK now logs per-item server failures to stderr and includes them in the return value so callers can detect partial failures.
 - KSM-1248 - Server-supplied key IDs are validated against the embedded public key table before being stored. An unrecognized key ID throws `SecretsManagerException` and leaves storage unchanged. Key rotation retries are now capped at `MAX_KEY_ROTATION_RETRIES` (3); exhausted retries throw a typed error naming the last suggested key ID.

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -723,6 +723,7 @@ data class KeeperRecord(
     var innerFolderUid: String? = null,
     val data: KeeperRecordData,
     val revision: Long,
+    val isEditable: Boolean = false,
     val files: List<KeeperFile>? = null,
     val links: List<KeeperRecordLink>? = null
 ) {
@@ -1423,6 +1424,7 @@ private fun decryptRecord(record: SecretsManagerResponseRecord, recordKey: ByteA
         record.innerFolderUid,
         recordData,
         record.revision,
+        record.isEditable,
         files,
         record.links
     ) else null

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -364,6 +364,34 @@ internal class SecretsManagerTest {
     }
 
     @Test
+    fun testIsEditableForwardedToKeeperRecord() {
+        val transmissionKey = ByteArray(32) { it.toByte() }
+        TestStubs.transmissionKeyStub = { transmissionKey }
+
+        val appKey = getRandomBytes(32)
+        val recordKey = getRandomBytes(32)
+        val encRecordKey = bytesToBase64(encrypt(recordKey, appKey))
+        val encData = bytesToBase64(encrypt(stringToBytes(
+            """{"title":"Test","type":"login","fields":[],"custom":[]}"""), recordKey))
+
+        fun response(isEditable: Boolean) = encrypt(stringToBytes(
+            """{"encryptedAppKey":null,"folders":null,"records":[{"recordUid":"uid1","recordKey":"$encRecordKey","data":"$encData","revision":1,"isEditable":$isEditable,"files":null,"innerFolderUid":null}]}"""
+        ), transmissionKey)
+
+        val storage = InMemoryStorage()
+        initializeStorage(storage, "US:FAKE_CLIENT_KEY")
+        storage.saveBytes(KEY_APP_KEY, appKey)
+
+        var options = SecretsManagerOptions(storage, queryFunction = { _, _, _ -> KeeperHttpResponse(200, response(true)) })
+        assertEquals(true, getSecrets(options).records[0].isEditable,
+            "isEditable:true from server must reach KeeperRecord")
+
+        options = SecretsManagerOptions(storage, queryFunction = { _, _, _ -> KeeperHttpResponse(200, response(false)) })
+        assertEquals(false, getSecrets(options).records[0].isEditable,
+            "isEditable:false from server must reach KeeperRecord")
+    }
+
+    @Test
     fun testGetFoldersSkipsUndecryptableFolder() {
         // A single folder whose key cannot be decrypted must not abort getFolders(). The bad
         // folder is skipped and the remaining good folder is still returned.


### PR DESCRIPTION
## What changed

The server returns `isEditable` in the record envelope. `SecretsManagerResponseRecord` already parsed it correctly, but `KeeperRecord` had no corresponding field, so callers could not check read permission before calling `updateSecret`.

Added `val isEditable: Boolean = false` to `KeeperRecord` (default `false` is backward-compatible with any caller constructing the class directly) and forwarded `record.isEditable` in `decryptRecord()`.

**Constructor note**: `isEditable` is inserted between `revision` and `files` in the positional constructor. Kotlin callers using named parameters (the common pattern) are unaffected. Java callers constructing `KeeperRecord` positionally with explicit `files`/`links` arguments would see a compile error. In practice `KeeperRecord` is obtained from `getSecrets()`, not constructed by callers, so the impact is expected to be zero -- but noting it for completeness.

Part of KSM-1173.

## Test plan

- [ ] `testIsEditableForwardedToKeeperRecord` -- verifies both `true` and `false` values propagate end-to-end from the server JSON to `KeeperRecord.isEditable`
- [ ] All existing tests pass
- [ ] `./gradlew test` green