### PR TITLE
fix(java): restore Java API compatibility and unblock the 17.4.0 release

### DIFF
--- a/sdk/java/core/build.gradle.kts
+++ b/sdk/java/core/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 group = "com.keepersecurity.secrets-manager"
 
 // During publishing, If version ends with '-SNAPSHOT' then it will be published to Maven snapshot repository
-version = "17.3.0"
+version = "17.4.0"
 
 plugins {
     `java-library`

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -28,7 +28,7 @@ import java.util.concurrent.*
 import kotlin.random.Random
 import javax.net.ssl.*
 
-const val KEEPER_CLIENT_VERSION = "mj17.3.0"
+const val KEEPER_CLIENT_VERSION = "mj17.4.0"
 
 // Throttle retry. The backend throttles HTTP 403 {"error":"throttled"}
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -717,7 +717,7 @@ data class KeeperSecrets(val appData: AppData, val records: List<KeeperRecord>, 
 @Serializable
 data class AppData(val title: String, val type: String)
 
-data class KeeperRecord(
+data class KeeperRecord @JvmOverloads constructor(
     val recordKey: ByteArray,
     val recordUid: String,
     var folderUid: String? = null,
@@ -725,9 +725,11 @@ data class KeeperRecord(
     var innerFolderUid: String? = null,
     val data: KeeperRecordData,
     val revision: Long,
-    val isEditable: Boolean = false,
     val files: List<KeeperFile>? = null,
-    val links: List<KeeperRecordLink>? = null
+    val links: List<KeeperRecordLink>? = null,
+    // Appended rather than inserted: Java sees no default arguments, so an interior
+    // parameter would shift the constructor Java callers already compile against.
+    val isEditable: Boolean = false
 ) {
     fun getPassword(): String? {
         val passwordField = data.getField<Password>() ?: return null
@@ -1426,16 +1428,16 @@ private fun decryptRecord(record: SecretsManagerResponseRecord, recordKey: ByteA
     }
 
     return if (recordData != null) KeeperRecord(
-        recordKey,
-        record.recordUid,
-        null,
-        null,
-        record.innerFolderUid,
-        recordData,
-        record.revision,
-        record.isEditable,
-        files,
-        record.links
+        recordKey = recordKey,
+        recordUid = record.recordUid,
+        folderUid = null,
+        folderKey = null,
+        innerFolderUid = record.innerFolderUid,
+        data = recordData,
+        revision = record.revision,
+        files = files,
+        links = record.links,
+        isEditable = record.isEditable
     ) else null
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1692,6 +1692,7 @@ fun cachingPostFunction(url: String, transmissionKey: TransmissionKey, payload: 
     }
 }
 
+@JvmOverloads
 fun postFunction(
     url: String,
     transmissionKey: TransmissionKey,

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1169,7 +1169,13 @@ fun uploadFile(options: SecretsManagerOptions, ownerRecord: KeeperRecord, file: 
     val payloadAndFile = prepareFileUploadPayload(options.storage, ownerRecord, file)
     val responseData = postQuery(options, "add_file", payloadAndFile.payload)
     val response = nonStrictJson.decodeFromString<SecretsManagerAddFileResponse>(bytesToString(responseData))
-    val uploadResult = uploadFile(response.url, response.parameters, payloadAndFile.encryptedFile)
+    val uploadResult = uploadFile(
+        response.url,
+        response.parameters,
+        payloadAndFile.encryptedFile,
+        options.connectTimeoutMillis,
+        options.readTimeoutMillis
+    )
     if (uploadResult.statusCode != response.successStatusCode) {
         throw SecretsManagerException("Upload failed (${bytesToString(uploadResult.data)}), code ${uploadResult.statusCode}")
     }
@@ -1211,7 +1217,13 @@ private fun downloadFile(file: KeeperFile, url: String): ByteArray {
     }
 }
 
-private fun uploadFile(url: String, parameters: String, fileData: ByteArray): KeeperHttpResponse {
+private fun uploadFile(
+    url: String,
+    parameters: String,
+    fileData: ByteArray,
+    connectTimeoutMillis: Int,
+    readTimeoutMillis: Int
+): KeeperHttpResponse {
     var statusCode: Int
     var data: ByteArray
     val boundary = String.format("----------%x", Instant.now().epochSecond)
@@ -1219,8 +1231,8 @@ private fun uploadFile(url: String, parameters: String, fileData: ByteArray): Ke
     val paramJson = Json.parseToJsonElement(parameters) as JsonObject
     val connection = URI.create(url).toURL().openConnection() as HttpsURLConnection
     try {
-        connection.connectTimeout = DEFAULT_CONNECT_TIMEOUT_MS
-        connection.readTimeout = DEFAULT_READ_TIMEOUT_MS
+        connection.connectTimeout = connectTimeoutMillis
+        connection.readTimeout = readTimeoutMillis
         connection.requestMethod = "POST"
         connection.useCaches = false
         connection.doInput = true

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -420,15 +420,6 @@ internal class SecretsManagerTest {
         assertEquals("Good Folder", folders[0].name)
     }
 
-    @Test
-    fun testSecretsManagerOptionsAcceptsCustomTimeouts() {
-        val storage = InMemoryStorage()
-        initializeStorage(storage, "US:FAKE_CLIENT_KEY")
-        val options = SecretsManagerOptions(storage, connectTimeoutMillis = 2_000, readTimeoutMillis = 10_000)
-        assertEquals(2_000, options.connectTimeoutMillis)
-        assertEquals(10_000, options.readTimeoutMillis)
-    }
-
 //    @Test // uncomment to debug the integration test
     fun integrationTest() {
         val trustAllPostFunction: (

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/TimeoutTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/TimeoutTest.kt
@@ -1,0 +1,89 @@
+package com.keepersecurity.secretsManager.core
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.test.*
+
+// Connect/read timeouts on the built-in HTTP transport. The behavioural test points
+// postFunction at a socket that accepts the TCP connection and then goes silent, so the client
+// blocks reading the ServerHello, which is exactly the stall readTimeout has to bound. The call
+// runs under a watchdog on a daemon thread: without the timeout the read never returns, and a
+// plain assertion would hang the Gradle test JVM instead of failing it.
+@ExperimentalSerializationApi
+internal class TimeoutTest {
+
+    private val stubTransmissionKey = TransmissionKey(7, ByteArray(32), ByteArray(32))
+    private val stubPayload = EncryptedPayload(ByteArray(8), ByteArray(8))
+
+    // Generous relative to the 1s timeout under test: this is the "it hung" tripwire, not a
+    // latency assertion, so a loaded CI runner must not trip it.
+    private val watchdogSeconds = 20L
+    private val probeReadTimeoutMillis = 1_000
+
+    @Test
+    fun timeoutDefaults_matchDocumentedValues() {
+        val options = SecretsManagerOptions(InMemoryStorage())
+        assertEquals(5_000, options.connectTimeoutMillis, "documented default connect timeout")
+        assertEquals(30_000, options.readTimeoutMillis, "documented default read timeout")
+    }
+
+    @Test
+    fun timeoutOptions_acceptCustomValues() {
+        val options = SecretsManagerOptions(
+            InMemoryStorage(),
+            connectTimeoutMillis = 2_000,
+            readTimeoutMillis = 10_000
+        )
+        assertEquals(2_000, options.connectTimeoutMillis)
+        assertEquals(10_000, options.readTimeoutMillis)
+    }
+
+    @Test
+    fun readTimeout_boundsAStalledServer() {
+        ServerSocket(0).use { server ->
+            val accepted = Thread { runCatching { server.accept() } }
+            accepted.isDaemon = true
+            accepted.start()
+
+            val url = "https://127.0.0.1:${server.localPort}/"
+            val elapsedMillis = withWatchdog {
+                val start = System.nanoTime()
+                assertFailsWith<SocketTimeoutException> {
+                    postFunction(
+                        url,
+                        stubTransmissionKey,
+                        stubPayload,
+                        true,
+                        readTimeoutMillis = probeReadTimeoutMillis
+                    )
+                }
+                (System.nanoTime() - start) / 1_000_000
+            }
+            assertTrue(
+                elapsedMillis >= probeReadTimeoutMillis / 2,
+                "returned in ${elapsedMillis}ms, too fast to have been the read timeout"
+            )
+        }
+    }
+
+    // Runs [block] on a daemon thread, failing (rather than blocking) if it never returns.
+    private fun <T> withWatchdog(block: () -> T): T {
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "timeout-test").apply { isDaemon = true }
+        }
+        try {
+            return executor.submit(block).get(watchdogSeconds, TimeUnit.SECONDS)
+        } catch (_: TimeoutException) {
+            fail("call did not return within ${watchdogSeconds}s; the timeout was never applied")
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+}

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/TimeoutTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/TimeoutTest.kt
@@ -2,11 +2,13 @@ package com.keepersecurity.secretsManager.core
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import java.net.ServerSocket
+import java.net.Socket
 import java.net.SocketTimeoutException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.*
 
 // Connect/read timeouts on the built-in HTTP transport. The behavioural test points
@@ -46,28 +48,39 @@ internal class TimeoutTest {
     @Test
     fun readTimeout_boundsAStalledServer() {
         ServerSocket(0).use { server ->
-            val accepted = Thread { runCatching { server.accept() } }
-            accepted.isDaemon = true
-            accepted.start()
+            // The accepted socket is held for the whole timeout window on purpose. Dropped, it
+            // turns unreachable the moment the acceptor thread exits, and a GC cycle closes it
+            // underneath the handshake: the client then fails in tens of milliseconds with a
+            // handshake or reset error rather than timing out, and this test fails on the wrong
+            // exception. Reproduced on JDK 8 and 21 under forced GC.
+            val accepted = AtomicReference<Socket?>(null)
+            val acceptor = Thread { runCatching { accepted.set(server.accept()) } }
+            acceptor.isDaemon = true
+            acceptor.start()
 
-            val url = "https://127.0.0.1:${server.localPort}/"
-            val elapsedMillis = withWatchdog {
-                val start = System.nanoTime()
-                assertFailsWith<SocketTimeoutException> {
-                    postFunction(
-                        url,
-                        stubTransmissionKey,
-                        stubPayload,
-                        true,
-                        readTimeoutMillis = probeReadTimeoutMillis
-                    )
+            try {
+                val url = "https://127.0.0.1:${server.localPort}/"
+                val elapsedMillis = withWatchdog {
+                    val start = System.nanoTime()
+                    assertFailsWith<SocketTimeoutException> {
+                        postFunction(
+                            url,
+                            stubTransmissionKey,
+                            stubPayload,
+                            true,
+                            readTimeoutMillis = probeReadTimeoutMillis
+                        )
+                    }
+                    (System.nanoTime() - start) / 1_000_000
                 }
-                (System.nanoTime() - start) / 1_000_000
+                assertTrue(
+                    elapsedMillis >= probeReadTimeoutMillis / 2,
+                    "returned in ${elapsedMillis}ms, too fast to have been the read timeout"
+                )
+            } finally {
+                acceptor.join(1_000)
+                accepted.get()?.close()
             }
-            assertTrue(
-                elapsedMillis >= probeReadTimeoutMillis / 2,
-                "returned in ${elapsedMillis}ms, too fast to have been the read timeout"
-            )
         }
     }
 


### PR DESCRIPTION
Review findings from a pass over the v17.4.0 release branch (#1110), covering #1116 (KSM-1207) and #1115 (KSM-1176). Five fixes, one commit each; every commit builds and tests green on its own.

Two of these are silent public API breaks that CI cannot see: `test.java.yml` runs `gradle build test` with `working-directory: ./sdk/java/core`, so it compiles core against itself and never compiles the Java consumers in `integration/` or `examples/`. Kotlin callers are unaffected either way, which is why the four green JDK matrix jobs on #1110 pass.

## 1. `postFunction` lost its four-argument Java overload (KSM-1207)

Kotlin default arguments do not exist in bytecode, so adding two defaulted parameters replaced the published static method rather than extending it.

| | `SecretsManager.postFunction` |
|---|---|
| 17.3.0 | `(String, TransmissionKey, EncryptedPayload, boolean)` |
| 17.4.0 before this PR | `(String, TransmissionKey, EncryptedPayload, boolean, int, int)` only |

Compiling the existing call site against 17.4.0:

```
error: method postFunction in class SecretsManager cannot be applied to given types;
  required: String,TransmissionKey,EncryptedPayload,boolean,int,int
  found:    String,TransmissionKey,EncryptedPayload,boolean
```

The runtime half is worse. Bytecode compiled against 17.3.0, run against 17.4.0 as a drop-in jar upgrade:

```
java.lang.NoSuchMethodError: 'KeeperHttpResponse SecretsManager.postFunction(
    String, TransmissionKey, EncryptedPayload, boolean)'
```

That compiles clean and fails at the first vault call.

Callers of the four-argument form:
- `integration/servicenow-external-credential-resolver/src/main/java/com/keepersecurity/secretsManager/CredentialResolver.java:333` (pinned `core:17.3.0`)
- `examples/java/hello-secret-custom-caching/app/src/main/java/org/example/App.java:24` (pinned `core:17.1.2`)

The pins defer this rather than prevent it. External customers following the documented custom-caching pattern have no pin.

Fix: `@JvmOverloads`, which restores the four- and five-argument forms alongside the new one.

## 2. `KeeperRecord`'s constructor went from nine parameters to ten (KSM-1176)

`isEditable` was inserted between `revision` and `files`. `KeeperRecord` carries no `@JvmOverloads`, so Java sees only the full-arity constructor. Verbatim from this repo's own `integration/servicenow-external-credential-resolver/src/test/java/com/keepersecurity/secretsManager/KeeperCredentialMapperTest.java:39`:

```java
new KeeperRecord(new byte[32], uid, null, null, null, data, 0L, null, null);
```

compiles against 17.3.0 and fails against 17.4.0 with `constructor KeeperRecord cannot be applied to given types`.

`@JvmOverloads` alone does not fix this one: with `isEditable` mid-list the generated nine-argument overload drops `links` and ends in `boolean`, so the call still fails. The field has to move to the end **and** get `@JvmOverloads`. `javap` then shows the original nine-argument constructor restored exactly.

`KeeperRecord` is not `@Serializable`, so reordering does not affect JSON decoding. The internal construction site now uses named arguments so a future field cannot silently shift positions again.

## 3. `uploadFile` ignored the timeouts the caller configured (KSM-1207)

`uploadFile(options, ownerRecord, file)` already holds the options and passes them to `postQuery` for the `add_file` request, but the private helper doing the actual upload hardcoded the module defaults. Setting `readTimeoutMillis = 120_000` was honoured for the metadata request and silently ignored for the upload in the same call.

`downloadFile` keeps the module constants, since its public entry points take a `KeeperFile` and no options.

## 4. The timeout test did not test the timeout (KSM-1207)

`testSecretsManagerOptionsAcceptsCustomTimeouts` asserted that `SecretsManagerOptions` echoes its own constructor arguments. That holds for any Kotlin data class, and it passes unchanged if both `connection.readTimeout` assignments are deleted.

`TimeoutTest` points `postFunction` at a `ServerSocket` that accepts the connection and then goes silent, so the client blocks reading the ServerHello. Measured:

| | `readTimeout_boundsAStalledServer` |
|---|---|
| with the fix | passes in 1.1s (`SocketTimeoutException: Read timed out`) |
| with `connection.readTimeout` removed | fails at 20.0s, `call did not return within 20s; the timeout was never applied` |

The call runs under a watchdog on a daemon thread, so a regression fails the build rather than hanging the Gradle test JVM. The documented 5000/30000 defaults are asserted separately.

No behavioural test for connect timeout: it needs a blackholed address, which is not reproducible across CI environments.

## 5. The version was never bumped

`build.gradle.kts` and `KEEPER_CLIENT_VERSION` still said 17.3.0 while the branch and changelog say 17.4.0. `publish.maven.java.core.yml` takes no version input and reads the coordinate straight from `build.gradle.kts`, so publishing would have attempted to republish 17.3.0 to Maven Central and reported `mj17.3.0` in the client version header.

## Verification

- 70 tests, 0 failures. Each of the five commits builds and tests green on its own.
- `javap` confirms the four-argument `postFunction` and the nine-argument `KeeperRecord` constructor are both back.
- Both real Java call sites compile against the fixed build.
- 17.3.0-compiled bytecode links against the fixed 17.4.0 classes (no `NoSuchMethodError`).

## Not addressed here

Left out to keep this reviewable; happy to open tickets:

- A custom `queryFunction` still bypasses both new timeout options, including core's own `cachingPostFunction`. Worth a KDoc note at minimum.
- `SecretsManagerOptions` does not validate the timeouts. `0` is accepted and means infinite in `URLConnection`, so a caller can silently reopen the hang KSM-1207 closed; negatives throw `IllegalArgumentException` from inside the first request instead of at construction.
- `SocketTimeoutException` escapes raw, where every other failure in `postQuery` is a `SecretsManagerException` or `KeeperThrottleException`.
- `SecretsManagerOptions` still uses `5_000` / `30_000` literals while `DEFAULT_CONNECT_TIMEOUT_MS` / `DEFAULT_READ_TIMEOUT_MS` hold the same values.
- Two unbounded `HttpURLConnection` sites remain outside core, in `sdk/java/storage/.../gcp/KMSUtils.java:341` and `:413`.
- Worth considering for CI: a job that compiles `integration/` and `examples/java/**` against the local core, and/or the `binary-compatibility-validator` plugin. Either would have caught items 1 and 2 on the PRs that introduced them.
