### PR TITLE
KSM-1269 Run Java test matrix on release-branch PRs

### DIFF
--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -2,7 +2,16 @@ name: Test-Java
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/sdk/java/core/**'
+    paths:
+      - 'sdk/java/core/**'
+      - '.github/workflows/test.java.yml'
+  push:
+    branches:
+      - master
+      - 'release/sdk/java/core/**'
     paths:
       - 'sdk/java/core/**'
       - '.github/workflows/test.java.yml'

--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -11,6 +11,8 @@ For more information see our official documentation page https://docs.keeper.io/
 - KSM-1081 - Fixed `getFolders()` crashing when any folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
 - KSM-1086 - Fixed `deleteFolder()` to return `SecretsManagerDeleteFolderResponse` (typed per-folder status), matching `deleteSecret()`. The SDK now logs per-item server failures to stderr and includes them in the return value so callers can detect partial failures.
 - KSM-1248 - Server-supplied key IDs are validated against the embedded public key table before being stored. An unrecognized key ID throws `SecretsManagerException` and leaves storage unchanged. Key rotation retries are now capped at `MAX_KEY_ROTATION_RETRIES` (3); exhausted retries throw a typed error naming the last suggested key ID.
+- KSM-1269 - Fixed the Java CI workflow not running on pull requests targeting release branches.
+The test matrix now triggers on both `master` and `release/sdk/java/core/**` targets.
 - KSM-1262 - On POSIX systems, config and cache files are now written via a temp-file swap with 0600 permissions set before data is written, closing the window where other local users could read the file during a write. Two behavior changes from the new approach: (1) a symlinked config path is replaced by a regular file on the first write; (2) a config file in a directory without write permission (for example, a read-only container volume mount) will fail at temp-file creation — move the config to a writable directory or use `InMemoryStorage` with an injected config string instead.
 
 ## 17.3.0


### PR DESCRIPTION
## Summary

- Adds `release/sdk/java/core/**` to the `pull_request` and `push` triggers in `test.java.yml`. Previously, the Java CI matrix only fired on PRs targeting `master`; fix PRs developed against a release branch received no CI signal.
- Adding `push:` as well covers direct commits to the release branch.

## Test plan

- [ ] This PR itself triggers the Java 8/11/17/21 matrix (visible in the PR's checks tab — the fix proves itself)