### PR TITLE
docs(java): document the 17.4.0 breaking changes, and three review follow-ups

### DIFF
--- a/sdk/java/core/README.md
+++ b/sdk/java/core/README.md
@@ -5,6 +5,10 @@ For more information see our official documentation page https://docs.keeper.io/
 # Change Log
 
 ## 17.4.0
+**Breaking Changes**
+- `deleteFolder()` returns `SecretsManagerDeleteFolderResponse` instead of `SecretsManagerDeleteResponse`. The new type exposes a `folders` list, where each entry has `folderUid`, `responseCode`, and an optional `errorMessage`; callers that read `.records` on the old return type must switch to `.folders`.
+- `KeeperRecord` and `SecretsManagerOptions` each gained a constructor parameter. Recompiling is enough: Kotlin source needs no edit, and Java call sites keep every constructor form published in 17.3.0 because both types carry `@JvmOverloads`. What does change is bytecode-level. The generated `copy()` methods and the synthetic constructor Kotlin emits for omitted default arguments both changed arity, so Kotlin code compiled against 17.3.0 throws `NoSuchMethodError` if the 17.4.0 jar is swapped in without recompiling. Rebuild dependents against 17.4.0 rather than replacing the jar in place.
+
 - KSM-1203 - Fixed `generatePassword` using a non-cryptographic PRNG (Kotlin `Random.Default`) for the final character shuffle. The shuffle now uses `SecureRandom`, so the entire password generation path is cryptographically secure.
 - KSM-1176 - `KeeperRecord` now exposes `isEditable: Boolean`, forwarded from the server response envelope. Callers can inspect this field before calling `updateSecret` to determine whether the app has write permission for the record.
 - KSM-1207 - Fixed all `HttpsURLConnection` calls defaulting to an infinite timeout. Added `connectTimeoutMillis` (default 5 000 ms) and `readTimeoutMillis` (default 30 000 ms) to `SecretsManagerOptions`. A stalled or unresponsive server now causes a `SocketTimeoutException` rather than an indefinite hang.

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/LocalConfigStorage.kt
@@ -18,8 +18,12 @@ fun saveCachedValue(data: ByteArray) {
     val tmpPath = try {
         Files.createTempFile(targetPath.parent, "ksm_", ".tmp")
     } catch (e: IOException) {
+        // Report what actually failed: createTempFile also fails on a full or read-only volume,
+        // a missing parent, or an fd limit, none of which are a permission problem.
         throw SecretsManagerException(
-            "Cannot write cache $targetPath: directory ${targetPath.parent} is not writable."
+            "Cannot write cache $targetPath: could not create a temporary file in ${targetPath.parent} " +
+            "(${e.javaClass.simpleName}: ${e.message}). The directory must exist and be writable.",
+            e
         )
     }
     try {
@@ -144,9 +148,13 @@ class LocalConfigStorage(configName: String? = null) : KeyValueStorage {
         val tmpPath = try {
             Files.createTempFile(targetPath.parent, "ksm_", ".tmp")
         } catch (e: IOException) {
+            // Report what actually failed: createTempFile also fails on a full or read-only volume,
+            // a missing parent, or an fd limit, none of which are a permission problem.
             throw SecretsManagerException(
-                "Cannot write config $targetPath: directory ${targetPath.parent} is not writable. " +
-                "Move the config to a writable directory or use InMemoryStorage with an injected config string."
+                "Cannot write config $targetPath: could not create a temporary file in ${targetPath.parent} " +
+                "(${e.javaClass.simpleName}: ${e.message}). The directory must exist and be writable; " +
+                "move the config to a writable directory or use InMemoryStorage with an injected config string.",
+                e
             )
         }
         try {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -729,6 +729,14 @@ data class KeeperRecord @JvmOverloads constructor(
     val links: List<KeeperRecordLink>? = null,
     // Appended rather than inserted: Java sees no default arguments, so an interior
     // parameter would shift the constructor Java callers already compile against.
+    /**
+     * Write permission for this record, set by the backend from how the application's share was
+     * configured: `true` when the application may call [updateSecret] on it, `false` when the
+     * share is read-only. Informational only; the SDK does not enforce it before an update.
+     *
+     * The default applies only to direct construction. Records returned by [getSecrets] always
+     * carry the server's value, because the field is required in the response envelope.
+     */
     val isEditable: Boolean = false
 ) {
     fun getPassword(): String? {

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerExceptions.kt
@@ -2,7 +2,16 @@
 
 package com.keepersecurity.secretsManager.core
 
-open class SecretsManagerException(message: String): Exception(message)
+/**
+ * Base type for errors raised by this SDK.
+ *
+ * [cause] is optional so a wrapped failure can keep the underlying exception and its stack trace.
+ * `@JvmOverloads` keeps the single-argument form Java callers and subclasses already compile against.
+ */
+open class SecretsManagerException @JvmOverloads constructor(
+    message: String,
+    cause: Throwable? = null
+): Exception(message, cause)
 
 internal class SecureRandomException(message: String): SecretsManagerException(message)
 internal class SecureRandomSlowGenerationException(message: String): SecretsManagerException(message)

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/SecretsManagerTest.kt
@@ -365,6 +365,8 @@ internal class SecretsManagerTest {
 
     @Test
     fun testIsEditableForwardedToKeeperRecord() {
+        // The server's per-record write-permission flag must survive decryptRecord() unchanged in
+        // both directions. Asserting only the true case would pass against a hardcoded value.
         val transmissionKey = ByteArray(32) { it.toByte() }
         TestStubs.transmissionKeyStub = { transmissionKey }
 
@@ -382,13 +384,18 @@ internal class SecretsManagerTest {
         initializeStorage(storage, "US:FAKE_CLIENT_KEY")
         storage.saveBytes(KEY_APP_KEY, appKey)
 
-        var options = SecretsManagerOptions(storage, queryFunction = { _, _, _ -> KeeperHttpResponse(200, response(true)) })
-        assertEquals(true, getSecrets(options).records[0].isEditable,
-            "isEditable:true from server must reach KeeperRecord")
-
-        options = SecretsManagerOptions(storage, queryFunction = { _, _, _ -> KeeperHttpResponse(200, response(false)) })
-        assertEquals(false, getSecrets(options).records[0].isEditable,
-            "isEditable:false from server must reach KeeperRecord")
+        // fetchAndDecryptSecrets swallows per-record failures to stderr, so assert the record
+        // survived before indexing: a decrypt regression must not surface as IndexOutOfBounds.
+        for (expected in listOf(true, false)) {
+            val options = SecretsManagerOptions(
+                storage,
+                queryFunction = { _, _, _ -> KeeperHttpResponse(200, response(expected)) }
+            )
+            val records = getSecrets(options).records
+            assertEquals(1, records.size, "record must decrypt for the isEditable:$expected case")
+            assertEquals(expected, records[0].isEditable,
+                "isEditable:$expected from server must reach KeeperRecord")
+        }
     }
 
     @Test


### PR DESCRIPTION
Follow-ups from the review pass over the v17.4.0 release branch, picking up what #1117 did not cover. Four fixes, one commit each; every commit builds and tests green on its own (70 tests, 0 failures).

Nothing here changes runtime behaviour except the exception message in item 2.

## 1. The changelog never documented the 17.4.0 breaking changes

The 17.4.0 section listed only features and fixes. #1110's description calls out the `deleteFolder()` return type change under a Breaking Changes heading, but that never reached `README.md`, which is what users actually read on upgrade. The 17.3.0 section right below it already uses a Breaking Changes block, so the convention exists.

To make the list defensible rather than a judgment call, I enumerated every class in the compiled jar and diffed `javap` output against master. Exactly three public members change, plus two synthetic constructors:

| Member | Change |
|---|---|
| `deleteFolder()` | return type `SecretsManagerDeleteResponse` to `SecretsManagerDeleteFolderResponse` |
| `KeeperRecord.copy()` | arity 9 to 10 |
| `SecretsManagerOptions.copy()` | arity 7 to 9 |

Nothing else is removed anywhere in the SDK.

The second entry is easy to state too narrowly, and my first draft did. Adding a constructor parameter changes `copy()`, but it also changes the synthetic `$default` constructor, which is the real call target whenever Kotlin source omits a defaulted argument. So Kotlin code that merely builds a `KeeperRecord` breaks on a jar swap too, not just `copy()` callers. Verified by compiling a caller against 17.3.0 and running it against 17.4.0:

```
run against 17.3.0 : OK uid=uid rev=1
run against 17.4.0 : java.lang.NoSuchMethodError: 'void KeeperRecord.<init>(
                       byte[], String, String, byte[], String, KeeperRecordData,
                       long, List, List, int, DefaultConstructorMarker)'
```

Recompiling resolves it, and Java call sites are unaffected either way thanks to the `@JvmOverloads` added in #1117. The changelog entry now says exactly that.

## 2. A failed config write threw away the underlying IOException (KSM-1262)

Both temp-file write paths in `LocalConfigStorage` caught `IOException` and threw a `SecretsManagerException` constructed from a message alone, so the stack trace and the errno were gone. The message also asserted a cause it could not know:

```
Cannot write config <path>: directory <parent> is not writable.
```

`Files.createTempFile` also fails on a full or read-only volume, a missing parent directory, and an fd limit. In each of those cases the operator was told, confidently, that it was a permission problem.

`SecretsManagerException` gains an optional `cause`. `@JvmOverloads` keeps the single-argument constructor, so Java callers and the two existing subclasses that call `super(message)` are untouched; `javap` confirms no member was removed from the class.

## 3. `KeeperRecord.isEditable` had no KDoc

The field carries a backend permission decision and its only description lived in the changelog. The doc records the three things a caller needs: what each value means, that the SDK does not enforce it before an update (per KSM-1173), and that the `false` default is reachable only through direct construction, because the response envelope requires the field.

Worth knowing for the last point: `SecretsManagerResponseRecord.isEditable` has no default, so a server that omitted the field would fail the whole `getSecrets()` call rather than yielding `false`:

```
field absent -> MissingFieldException: Field 'isEditable' is required ...
field null   -> JsonDecodingException: Expected valid boolean literal ...
```

That is pre-existing and not changed here, but it is why the default is documented as construction-only.

## 4. The isEditable test could fail as IndexOutOfBounds

`testIsEditableForwardedToKeeperRecord` indexed `records[0]` directly. `fetchAndDecryptSecrets` swallows per-record failures to stderr, so a decrypt regression would have surfaced as `IndexOutOfBoundsException` instead of a readable assertion. Both neighbouring tests already guard on the record count first.

Also folds the two cases into a loop. The assertion still discriminates: hardcoding `isEditable = true` in `decryptRecord` fails the test, reverting passes.

## Verification

- 70 tests, 0 failures. Each of the four commits builds and tests green on its own.
- `javap` sweep over every class in the jar: the three members above are the only public removals between master and this branch.
- `javap` on `SecretsManagerException`: two additions, nothing removed.
- Jar-swap probe reproduces and then confirms the `NoSuchMethodError` described in item 1.

## Not addressed here

Found during the same pass, left out as pre-existing and outside the release-blocker scope. Happy to open tickets:

- The atomic write has no `fsync` before the rename, so a power cut can leave a truncated config. Outside the permissions threat model KSM-1262 states, but "atomic write" invites the expectation.
- `keyId` at `SecretsManager.kt:1738` is a public mutable top-level `var`, mutated as a side effect of the `keeperPublicKeys` initializer and exported as `getKeyId()`/`setKeyId()`.
- `testConfigFileAtomicWriteIsOwnerOnly` asserts permissions but not atomicity despite the name, and does not cover `saveCachedValue`, the other half of KSM-1262.
- `LocalConfigStorage` switched from `FileReader` to `readText(Charsets.UTF_8)` in #1109, which pairs correctly with the UTF-8 write side and fixes a latent platform-charset mismatch. Harmless for ASCII configs, but it went unremarked in the changelog.
