### PR TITLE
chore(java): drop inert JvmOverloads and isolate proxy test global state

### DIFF
--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/ProxySupport.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/ProxySupport.kt
@@ -264,6 +264,11 @@ internal object ProxyAuthenticator : Authenticator() {
         return PasswordAuthentication(credential.username, credential.password.clone())
     }
 
+    // Drops every registered credential. Exists for test isolation: this object is a process-wide
+    // singleton, so without it a test that registers a proxy credential leaves it answerable for
+    // the rest of the JVM's life. Not part of the SDK's supported surface.
+    fun reset() = credentials.clear()
+
     private fun key(host: String, port: Int) = "${host.lowercase(Locale.ROOT)}:$port"
 }
 

--- a/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
+++ b/sdk/java/core/src/main/kotlin/com/keepersecurity/secretsManager/core/SecretsManager.kt
@@ -1759,7 +1759,9 @@ fun cachingPostFunction(url: String, transmissionKey: TransmissionKey, payload: 
     }
 }
 
-@JvmOverloads
+// Kept as an explicit overload rather than a default argument on the function below: this is the
+// arity Java callers and cachingPostFunction already compile against. No @JvmOverloads, because
+// there are no default arguments here for it to generate overloads from.
 fun postFunction(
     url: String,
     transmissionKey: TransmissionKey,

--- a/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ProxyTest.kt
+++ b/sdk/java/core/src/test/kotlin/com/keepersecurity/secretsManager/core/ProxyTest.kt
@@ -4,6 +4,7 @@ import java.net.Authenticator
 import java.net.Proxy
 import kotlin.test.Test
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -23,9 +24,25 @@ internal class ProxyTest {
 
     private val target = "https://vault.keepersecurity.com/api/rest/sm/v1/get_secret"
 
+    private val tunnelingSchemesProperty = "jdk.http.auth.tunneling.disabledSchemes"
+    private var tunnelingSchemesBefore: String? = null
+
+    @BeforeTest
+    fun captureTunnelingSchemes() {
+        tunnelingSchemesBefore = System.getProperty(tunnelingSchemesProperty)
+    }
+
+    // Registering a proxy credential mutates three pieces of process-wide state: the default
+    // Authenticator, the ProxyAuthenticator credential store, and the JDK's tunneling-schemes
+    // property. Gradle runs the whole suite in one JVM, so all three have to be put back or they
+    // stay visible to every test that follows, including the weakened tunneling default.
     @AfterTest
-    fun clearGlobalAuthenticator() {
+    fun restoreGlobalProxyState() {
         Authenticator.setDefault(null)
+        ProxyAuthenticator.reset()
+        val before = tunnelingSchemesBefore
+        if (before == null) System.clearProperty(tunnelingSchemesProperty)
+        else System.setProperty(tunnelingSchemesProperty, before)
     }
 
     @Test
@@ -261,6 +278,19 @@ internal class ProxyTest {
             "other.local", null, 8080, "http", "", "basic", null, Authenticator.RequestorType.PROXY
         )
         assertNull(otherProxy)
+    }
+
+    @Test
+    fun proxyAuthenticatorResetDropsRegisteredCredentials() {
+        // Guards the teardown above: if reset() ever stops emptying the store, a registered
+        // credential outlives its test and the leak this test exists to prevent comes back.
+        ProxyAuthenticator.register("proxy.local", 8080, "u", "p")
+        ProxyAuthenticator.reset()
+
+        val afterReset = Authenticator.requestPasswordAuthentication(
+            "proxy.local", null, 8080, "http", "", "basic", null, Authenticator.RequestorType.PROXY
+        )
+        assertNull(afterReset)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Two cleanups from the code review of #1110. Neither changes shipped behavior. Raised now rather than after 17.4.0 because QA tests the release branch from source, so any commit landing mid-cycle invalidates that run.

## 1. Inert `@JvmOverloads` on `postFunction` (B10)

The 4-argument `postFunction` carried `@JvmOverloads` despite having no default arguments, so the annotation generated nothing and the compiler warned on every build of the release:

```
w: SecretsManager.kt:1762:1 '@JvmOverloads' annotation has no effect for methods without default arguments.
```

Removed, with a comment in its place explaining why the overload is spelled out by hand rather than expressed as a default argument: 4 arguments is the arity Java callers and `cachingPostFunction` already compile against.

**Verified ABI-neutral.** `javap` over the `SecretsManager` facade before and after reports the same 76 public members with byte-for-byte identical signatures, including all three `postFunction` entry points:

```
postFunction(String, TransmissionKey, EncryptedPayload, boolean)
postFunction(String, TransmissionKey, EncryptedPayload, boolean, String, int, int)
postFunction$default(String, TransmissionKey, EncryptedPayload, boolean, String, int, int, int, Object)
```

The build is now warning-clean.

## 2. `ProxyTest` left process-wide state behind (B7)

`ProxyAuthenticator.register()` mutates three pieces of global state: the default `Authenticator`, the credential store, and `jdk.http.auth.tunneling.disabledSchemes`. The teardown reset only the first.

Gradle runs the whole suite in one JVM, so after `proxyAuthenticatorAnswersOnlyForRegisteredProxy` ran, `proxy.local:8080` stayed answerable and Basic auth over CONNECT stayed enabled for every test that followed. Harmless with the current suite, but it quietly weakens any later test that exercises a proxied connection, and a test asserting the JDK default is intact would pass or fail depending on ordering.

The teardown now restores all three. The tunneling property is captured per-test in `@BeforeTest` and returned to whatever the JVM actually had, rather than assumed unset, so the test does not impose its own idea of the default on the process.

Clearing the credential store needs a hook, so `ProxyAuthenticator` gains `reset()`. It is declared the same way as the neighbouring `register()`: the enclosing object is already `internal`, so an explicit `internal` modifier would only add name mangling (`reset$core()`) without changing what a consumer can reach. Nothing is added to the SDK's supported surface.

## Tests
- New `proxyAuthenticatorResetDropsRegisteredCredentials`, so the teardown is guarded rather than trusted. Registers a credential, resets, and asserts the `Authenticator` no longer answers for it.
- Full suite: 103 tests, 0 failures, verified locally on a real JDK 8 (Zulu 8.0.492). No compiler warnings.
