### PR TITLE
fix(ci): KSM-1301 stop test.java.yml double-running on release branches

### DIFF
--- a/.github/workflows/test.java.yml
+++ b/.github/workflows/test.java.yml
@@ -1,6 +1,8 @@
 name: Test-Java
 
 on:
+  # The gate. Runs on the merge result (head merged into base), so it can block
+  # a bad change before it lands, on release branches as well as master.
   pull_request:
     branches:
       - master
@@ -8,21 +10,34 @@ on:
     paths:
       - 'sdk/java/core/**'
       - '.github/workflows/test.java.yml'
+  # master only. Two purposes: catch a direct push that bypassed a PR, and seed
+  # the writable Gradle cache that every release-branch PR run then restores.
+  # Deliberately NOT on release/**, where it would only re-test a commit the
+  # pull_request run already tested.
   push:
-    branches:
-      - master
-      - 'release/sdk/java/core/**'
+    branches: [ master ]
     paths:
       - 'sdk/java/core/**'
       - '.github/workflows/test.java.yml'
+  # Manual re-run after a transient infrastructure failure, no empty commit needed.
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+# One in-flight run per ref. A new push supersedes the previous run rather than
+# racing it, which also keeps simultaneous Maven Central requests down. Never
+# cancel a master run, since that is what populates the cache.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-java:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky JDK must not hide the results of the other three.
+      fail-fast: false
       matrix:
         java-version: [ '8', '11', '17', '21' ]
     name: KSM test with Java ${{ matrix.java-version }}
@@ -43,6 +58,26 @@ jobs:
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
         gradle-version: '8.14'
+        # Writable on master only, so one seeded cache serves every branch.
+        # Without this the cache is never written and every job resolves the
+        # full dependency graph over the network.
+        cache-read-only: ${{ github.event_name != 'push' }}
 
     - name: Build and Test
-      run: gradle build test
+      shell: bash
+      run: |
+        log="${RUNNER_TEMP}/gradle-output.log"
+        for attempt in 1 2 3; do
+          if gradle build test 2>&1 | tee "${log}"; then
+            exit 0
+          fi
+          if ! grep -qE 'Too Many Requests|Could not (resolve|GET|download)' "${log}"; then
+            echo "::error::Build or tests failed; not a dependency-resolution error, so not retrying"
+            exit 1
+          fi
+          delay=$((attempt * 30))
+          echo "::warning::Dependency resolution failed on attempt ${attempt}; retrying in ${delay}s"
+          sleep "${delay}"
+        done
+        echo "::error::Dependency resolution still failing after 3 attempts"
+        exit 1


### PR DESCRIPTION
Fixes the CI failure on this release PR ([run 32381530096](https://github.com/Keeper-Security/secrets-manager/actions/runs/32381530096)), which was not a code failure. KSM-1301.

## What failed

```
Could not resolve com.google.code.gson:gson:2.10.1
  Required by: ... org.gradle.toolchains.foojay-resolver:0.9.0
    > Could not GET 'https://repo.maven.apache.org/maven2/.../gson-2.10.1.pom'.
      Received status code 429 from server: Too Many Requests
```

Maven Central rate-limited the runner. `gson` is a transitive dependency of the `foojay-resolver` plugin declared in `sdk/java/core/settings.gradle.kts`, so it resolves on the settings classpath of every build, before any project code compiles.

## Three defects in this file turned that rate limit into a red PR

**1. Every push to the release branch fired two identical runs.** The file listed `release/sdk/java/core/**` under both `push` and `pull_request`. Because this branch is the head of the open release PR #1110, each push fired the `push` trigger and `pull_request: synchronize` on #1110, on the same SHA:

| Run | Event | Result |
| --- | --- | --- |
| 32381525647 | `push` | success |
| 32381530096 | `pull_request` | 429 failure |

Two seconds apart. Seven such pairs occurred on this branch in roughly 20 hours: 28 redundant jobs, about 54 minutes of runner time. The duplication was also part of the cause, since two runs of a four-job matrix means eight simultaneous cold Gradle builds resolving from Maven Central at once.

**2. The Gradle cache was never written.** From the failing job's log:

```
cache-read-only: true
Gradle User Home cache not found. Will initialize empty.
Cache is read-only: will not save state for use in subsequent builds.
```

`gradle/actions/setup-gradle` only writes the cache from the default branch, and this workflow had no `push` trigger on master, so a writable run never happened. Every job in this workflow's history has started cold, which is why a rate limit could reach us at all.

**3. `fail-fast` was left at its default.** The single 429 on Java 21 cancelled Java 8, 11 and 17, so the PR went red with no signal on the other three JDKs.

## Changes

- `push` restricted to `branches: [ master ]`. Removes the duplicate run, and gives the cache a writable seeding run, one per release. No coverage is lost: the `pull_request` run already tested the same merge result before the commit landed, and a `push` run that reports after the merge cannot block anything.
- `cache-read-only: ${{ github.event_name != 'push' }}` on `setup-gradle`, set explicitly rather than relying on the action's default.
- `fail-fast: false` on the matrix.
- `concurrency` group per ref, cancelling in progress on `pull_request` events only. This does not dedupe the push/PR pair (the two runs land in different groups); it stops stale runs from stacking up on a series of pushes.
- Bounded retry on Build and Test, gated on the output matching `Too Many Requests|Could not (resolve|GET|download)`, so a genuine test failure still fails on the first attempt. Three attempts, 30s then 60s backoff.
- `workflow_dispatch`, so a transient infrastructure failure can be re-run without an empty commit.

## Verification

- `actionlint` clean, YAML parses.
- Retry logic exercised locally on all three paths: transient 429 then success exits 0; genuine test failure exits 1 immediately with no retry; persistent 429 exhausts three attempts then fails.
- Action SHA pins unchanged.
- Because `pull_request` uses the merge-ref workflow definition, this PR runs under the new file and self-tests the trigger, `fail-fast` and `concurrency` changes.

## Expectations

The cache benefit does not appear until #1110 reaches master and a `push` run seeds it; release-branch runs stay cold until then. And since the current release-branch file still has the old triggers, merging this PR produces one final duplicate pair before the dedupe takes effect.

## Follow-ups filed

- KSM-1302: `test.ruby.yml` and the four JavaScript KMS workflows duplicate the same way. The JS four also have no `master` trigger at all, so their release PRs currently run no tests.
- KSM-1303: 13 of 20 `test.*` workflows have no dependency cache, and only `test.dotnet.powershell.yml` sets `fail-fast` anywhere in the repo.
- KSM-1304: whether `foojay-resolver` can be dropped in favour of a JDK 8 installed by `setup-java`, which would remove this failure class outright. Also notes the `gradle-version: '8.14'` versus wrapper `8.14.3` mismatch.

Not in scope here: branch protection on `release/**` to require PRs (an org setting, noted on KSM-1301; commit 3f0f0edc landed on this branch without a PR). The Python storage gate gap is already tracked in KSM-1285.