### PR TITLE
Release JavaScript SDK v18.0.0

### DIFF
--- a/examples/javascript/share-client/README.md
+++ b/examples/javascript/share-client/README.md
@@ -1,9 +1,9 @@
 # Keeper Share
 
-This is an application that allows for anybody with a link receive a shared secret from Keeper
+This application lets any user with a link receive a shared secret from Keeper.
 
-Only the first user that clicks on the link will be able to access the secret
+Only the first user who clicks the link can access the secret.
 
-Keys are stored in the IndexedDb:
+The SDK stores keys in IndexedDB:
 https://blog.engelke.com/2014/09/19/saving-cryptographic-keys-in-the-browser/
 

--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 18.0.0
 - KSM-1042 - Fixed `getFolders()` failing with "appKey missing" when called as the first method on a freshly bound application. `getFolders()` now processes `encryptedAppKey` from the server binding response the same way `getSecrets()` does.
+- KSM-1058 - Fixed `createFolder()` writing folder keys and data with AES-CBC instead of AES-GCM. New folders are now created with GCM. `getFolders()` detects the cipher from the encrypted key length (60 bytes = GCM, 64 bytes = CBC) so existing CBC folders continue to decrypt correctly. `updateFolder()` accepts an optional `useGcm` flag so callers can match the cipher used when the folder was created.
 
 ## 17.6.0
 - KSM-1073 - Added `dbConnectionMethod` to `PamSettingsConnection`.

--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 18.0.0
+- KSM-1042 - Fixed `getFolders()` failing with "appKey missing" when called as the first method on a freshly bound application. `getFolders()` now processes `encryptedAppKey` from the server binding response the same way `getSecrets()` does.
+
 ## 17.6.0
 - KSM-1073 - Added `dbConnectionMethod` to `PamSettingsConnection`.
 - KSM-1079 - Fixed `getFolders()` crashing when a folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.

--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 
 ## 17.6.0
-- KSM-1035 - Throttle backoff hardening: retry jitter is now one-sided (0 to +25%, so delays never fall below the computed floor), and a server-supplied `retry_after` is capped at 176s (the exponential ladder's last step) so it can no longer force an excessive or unbounded wait.
+- KSM-1073 - Added `dbConnectionMethod` to `PamSettingsConnection`.
+- KSM-1079 - Fixed `getFolders()` crashing when a folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
+- KSM-1084 - Fixed `deleteSecret()` and `deleteFolder()` silently reporting success when the server rejected some UIDs. The SDK now surfaces per-item error messages from the server to the caller.
+- KSM-748 - Fixed `getSecrets()` silently dropping records created by Commander or the Vault UI inside shared folders. The SDK now uses the folder key to decrypt the record key for any flat record that has `innerFolderUid` set. This matches the behavior for records in `folders[].records[]`.
+- KSM-1035 - Fixed throttle retry jitter being two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s to prevent an arbitrarily long wait.
+- Maintenance: Updated `minimatch`, `@babel/core`, and `handlebars` dev dependencies.
 
 ## 17.5.0
 - KSM-1029 - Fixed stale pinned server key error: when the server rejects a configured custom server public key, the diagnostic message now propagates to the caller instead of being swallowed by a bare catch.

--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 17.6.0
+- KSM-1035 - Throttle backoff hardening: retry jitter is now one-sided (0 to +25%, so delays never fall below the computed floor), and a server-supplied `retry_after` is capped at 176s (the exponential ladder's last step) so it can no longer force an excessive or unbounded wait.
+
 ## 17.5.0
 - KSM-1029 - Fixed stale pinned server key error: when the server rejects a configured custom server public key, the diagnostic message now propagates to the caller instead of being swallowed by a bare catch.
 - KSM-880 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `postQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleError` is thrown once retries are exhausted. Existing key-rotation retry behavior is unchanged.

--- a/sdk/javascript/packages/core/package-lock.json
+++ b/sdk/javascript/packages/core/package-lock.json
@@ -24,16 +24,19 @@
         "ts-jest": "^29.4.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -42,9 +45,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,22 +55,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -84,14 +86,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -114,14 +116,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -188,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -212,29 +214,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -317,9 +319,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -327,9 +329,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -337,9 +339,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -362,27 +364,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1757,33 +1759,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1791,14 +1793,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2869,7 +2871,6 @@
       "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -3487,7 +3488,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4237,9 +4237,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4540,7 +4540,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5347,13 +5346,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5837,7 +5836,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6340,9 +6338,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6457,7 +6455,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6532,7 +6529,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/sdk/javascript/packages/core/package.json
+++ b/sdk/javascript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keeper-security/secrets-manager-core",
-  "version": "17.5.0",
+  "version": "17.6.0",
   "description": "Keeper Secrets Manager Javascript SDK",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",

--- a/sdk/javascript/packages/core/package.json
+++ b/sdk/javascript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keeper-security/secrets-manager-core",
-  "version": "17.6.0",
+  "version": "18.0.0",
   "description": "Keeper Secrets Manager Javascript SDK",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -957,24 +957,28 @@ const fetchAndDecryptFolders = async (options: SecretManagerOptions): Promise<Ke
     const folders: KeeperFolder[] = []
     if (response.folders) {
         for (const folder of response.folders) {
-            let decryptedData: Uint8Array
-            const decryptedFolder: KeeperFolder = {
-                folderUid: folder.folderUid
-            }
-            if (folder.parent) {
-                decryptedFolder.parentUid = folder.parent
-                const sharedFolderUid = getSharedFolderUid(response.folders, folder.parent)
-                if (!sharedFolderUid) {
-                    throw new Error('Folder data inconsistent - unable to locate shared folder')
+            try {
+                let decryptedData: Uint8Array
+                const decryptedFolder: KeeperFolder = {
+                    folderUid: folder.folderUid
                 }
-                await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, sharedFolderUid, storage, true, true)
-                decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
-            } else {
-                await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true, true)
-                decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
+                if (folder.parent) {
+                    decryptedFolder.parentUid = folder.parent
+                    const sharedFolderUid = getSharedFolderUid(response.folders, folder.parent)
+                    if (!sharedFolderUid) {
+                        throw new Error('Folder data inconsistent - unable to locate shared folder')
+                    }
+                    await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, sharedFolderUid, storage, true, true)
+                    decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
+                } else {
+                    await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true, true)
+                    decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
+                }
+                decryptedFolder.name = JSON.parse(platform.bytesToString(decryptedData))['name']
+                folders.push(decryptedFolder)
+            } catch (e: Error | any) {
+                console.error(`Folder ${folder.folderUid} skipped due to error: ${e.constructor.name}, ${e.message}`)
             }
-            decryptedFolder.name = JSON.parse(platform.bytesToString(decryptedData))['name']
-            folders.push(decryptedFolder)
         }
     }
     return folders

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -1956,6 +1956,7 @@ export type PamSettingsConnection = {
     ignoreCert?: boolean
     resizeMethod?: string
     colorScheme?: string
+    dbConnectionMethod?: string
 }
 
 export type PamSettingsPortForward = {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -1296,13 +1296,25 @@ export const completeTransaction = async (options: SecretManagerOptions, recordU
 export const deleteSecret = async (options: SecretManagerOptions, recordUids: string[]): Promise<SecretsManagerDeleteResponse> => {
     const payload = await prepareDeletePayload(options.storage, recordUids)
     const responseData = await postQuery(options, 'delete_secret', payload)
-    return JSON.parse(platform.bytesToString(responseData)) as SecretsManagerDeleteResponse
+    const response = JSON.parse(platform.bytesToString(responseData)) as SecretsManagerDeleteResponse
+    for (const r of (response.records || [])) {
+        if (r.responseCode !== 'ok') {
+            console.error(`Failed to delete record ${r.recordUid}: ${r.responseCode} ${r.errorMessage}`)
+        }
+    }
+    return response
 }
 
 export const deleteFolder = async (options: SecretManagerOptions, folderUids: string[], forceDeletion?: boolean): Promise<SecretsManagerDeleteResponse> => {
     const payload = await prepareDeleteFolderPayload(options.storage, folderUids, forceDeletion)
     const responseData = await postQuery(options, 'delete_folder', payload)
-    return JSON.parse(platform.bytesToString(responseData)) as SecretsManagerDeleteResponse
+    const response = JSON.parse(platform.bytesToString(responseData)) as SecretsManagerDeleteResponse
+    for (const f of (response.folders || [])) {
+        if (f.responseCode !== 'ok') {
+            console.error(`Failed to delete folder ${f.folderUid}: ${f.responseCode} ${f.errorMessage}`)
+        }
+    }
+    return response
 }
 
 export const createSecret = async (options: SecretManagerOptions, folderUid: string, recordData: any): Promise<string> => {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -979,6 +979,13 @@ const fetchAndDecryptFolders = async (options: SecretManagerOptions): Promise<Ke
     const payload = await prepareGetPayload(storage)
     const responseData = await postQuery(options, 'get_folders', payload)
     const response = JSON.parse(platform.bytesToString(responseData)) as SecretsManagerResponse
+    if (response.encryptedAppKey) {
+        await platform.unwrap(platform.base64ToBytes(response.encryptedAppKey), KEY_APP_KEY, KEY_CLIENT_KEY, storage)
+        await storage.delete(KEY_CLIENT_KEY)
+        if (response.appOwnerPublicKey) {
+            await storage.saveString(KEY_OWNER_PUBLIC_KEY, response.appOwnerPublicKey)
+        }
+    }
     const folders: KeeperFolder[] = []
     if (response.folders) {
         for (const folder of response.folders) {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -899,7 +899,7 @@ const fetchAndDecryptSecrets = async (options: SecretManagerOptions, queryOption
     if (response.folders) {
         for (const folder of response.folders) {
             try {
-                if (!folder.folderKey) throw new Error(`Folder key missing for UID ${folder.folderUid} — reinitialize with a fresh One-Time Token`)
+                if (!folder.folderKey) throw new Error(`Folder key missing for UID ${folder.folderUid}; reinitialize with a fresh One-Time Token`)
                 await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true)
                 for (const record of folder.records) {
                     try {

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -294,6 +294,7 @@ export type KeeperFolder = {
     folderUid: string
     parentUid?: string
     name?: string
+    useGcm?: boolean
 }
 
 export type KeeperFile = {
@@ -650,8 +651,8 @@ const prepareCreateFolderPayload = async (storage: KeyValueStorage, createOption
     }))
     const folderKey = platform.getRandomBytes(32)
     const folderUid = getUidBytes()
-    const encryptedFolderData = await platform.encryptWithKey(folderDataBytes, folderKey, true)
-    const encryptedFolderKey = await platform.encrypt(folderKey, createOptions.folderUid, undefined, true)
+    const encryptedFolderData = await platform.encryptWithKey(folderDataBytes, folderKey)
+    const encryptedFolderKey = await platform.encrypt(folderKey, createOptions.folderUid)
     return {
         clientVersion: 'ms' + packageVersion,
         clientId: clientId,
@@ -663,7 +664,7 @@ const prepareCreateFolderPayload = async (storage: KeyValueStorage, createOption
     }
 }
 
-const prepareUpdateFolderPayload = async (storage: KeyValueStorage, folderUid: string, folderName: string): Promise<UpdateFolderPayload> => {
+const prepareUpdateFolderPayload = async (storage: KeyValueStorage, folderUid: string, folderName: string, useGcm?: boolean): Promise<UpdateFolderPayload> => {
     const clientId = await storage.getString(KEY_CLIENT_ID)
     if (!clientId) {
         throw new Error('Client Id is missing from the configuration')
@@ -671,7 +672,7 @@ const prepareUpdateFolderPayload = async (storage: KeyValueStorage, folderUid: s
     const folderDataBytes = platform.stringToBytes(JSON.stringify({
         name: folderName
     }))
-    const encryptedFolderData = await platform.encrypt(folderDataBytes, folderUid, undefined, true)
+    const encryptedFolderData = await platform.encrypt(folderDataBytes, folderUid, undefined, !useGcm)
     return {
         clientVersion: 'ms' + packageVersion,
         clientId: clientId,
@@ -1000,8 +1001,11 @@ const fetchAndDecryptFolders = async (options: SecretManagerOptions): Promise<Ke
                     if (!sharedFolderUid) {
                         throw new Error('Folder data inconsistent - unable to locate shared folder')
                     }
-                    await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, sharedFolderUid, storage, true, true)
-                    decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
+                    const folderKeyBytes = platform.base64ToBytes(folder.folderKey)
+                    const useCBC = folderKeyBytes.length !== 60
+                    decryptedFolder.useGcm = !useCBC
+                    await platform.unwrap(folderKeyBytes, folder.folderUid, sharedFolderUid, storage, true, useCBC)
+                    decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, useCBC)
                 } else {
                     await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true, true)
                     decryptedData = await platform.decrypt(platform.base64ToBytes(folder.data), folder.folderUid, storage, true)
@@ -1376,11 +1380,11 @@ export const createFolder = async (options: SecretManagerOptions, createOptions:
     return payload.folderUid
 }
 
-export const updateFolder = async (options: SecretManagerOptions, folderUid: string, folderName: string): Promise<void> => {
+export const updateFolder = async (options: SecretManagerOptions, folderUid: string, folderName: string, useGcm?: boolean): Promise<void> => {
     if (!platform.hasKeysCached()) {
         await getSecrets(options) // need to warm up keys cache before posting a record
     }
-    const payload = await prepareUpdateFolderPayload(options.storage, folderUid, folderName)
+    const payload = await prepareUpdateFolderPayload(options.storage, folderUid, folderName, useGcm)
     await postQuery(options, 'update_folder', payload)
 }
 

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -883,13 +883,34 @@ const fetchAndDecryptSecrets = async (options: SecretManagerOptions, queryOption
         await storage.delete(KEY_CLIENT_KEY)
         await storage.saveString(KEY_OWNER_PUBLIC_KEY, response.appOwnerPublicKey!)
     }
+    const folderKeyIds = new Set<string>()
+    if (response.folders) {
+        for (const folder of response.folders) {
+            try {
+                if (!folder.folderKey) continue
+                await platform.unwrap(platform.base64ToBytes(folder.folderKey), folder.folderUid, KEY_APP_KEY, storage, true)
+                folderKeyIds.add(folder.folderUid)
+            } catch (e: Error | any) {
+                // ignored here; the folders loop below re-attempts the same unwrap and logs the failure
+            }
+        }
+    }
     if (response.records) {
         for (const record of response.records) {
             try {
                 if (record.recordKey) {
-                    await platform.unwrap(platform.base64ToBytes(record.recordKey), record.recordUid, KEY_APP_KEY, storage, true)
+                    // Records created outside the SDK in a shared folder arrive in the flat
+                    // response.records[] with innerFolderUid set; their recordKey is wrapped
+                    // with the folder key, not the app key.
+                    const unwrappingKeyId = record.innerFolderUid && folderKeyIds.has(record.innerFolderUid)
+                        ? record.innerFolderUid
+                        : KEY_APP_KEY
+                    await platform.unwrap(platform.base64ToBytes(record.recordKey), record.recordUid, unwrappingKeyId, storage, true)
                 }
                 const decryptedRecord = await decryptRecord(record, storage)
+                if (record.innerFolderUid && folderKeyIds.has(record.innerFolderUid)) {
+                    decryptedRecord.folderUid = record.innerFolderUid
+                }
                 records.push(decryptedRecord)
             } catch (e: Error | any) {
                 console.error(`Record ${record.recordUid} skipped due to error: ${e.constructor.name}, ${e.message}`)

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -20,6 +20,7 @@ const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
 // request, so the counter only clears after 10s of silence).
 const MAX_THROTTLE_RETRIES = 5
 const BASE_THROTTLE_DELAY_SEC = 11 // 1s safety margin over the backend's 10s memcached TTL
+const MAX_THROTTLE_DELAY_SEC = 176 // same ceiling the exponential branch reaches at the last retry (11 * 2**4)
 const CLIENT_ID_HASH_TAG = 'KEEPER_SECRETS_MANAGER_CLIENT_ID' // Tag for hashing the client key to client id
 
 let keeperPublicKeys: Record<number, Uint8Array>
@@ -62,14 +63,17 @@ export type SecretManagerOptions = {
 // utils.ts/platform code that throws them; re-exported here so the public API is unchanged.
 export {KeeperError, KeeperThrottleError} from './errors'
 
-// Returns a jitter multiplier in [-0.25, 0.25). Kept separate so concurrent clients
-// desynchronize their retries; unit tests exercise throttleDelay with a pinned jitter.
-export const throttleJitter = (): number => Math.random() * 0.5 - 0.25
+// Returns a jitter multiplier in [0, 0.25). One-sided so the delay never drops below the
+// computed floor (retrying too soon just re-triggers the throttle); kept separate so
+// concurrent clients desynchronize their retries. Unit tests exercise throttleDelay with a
+// pinned jitter.
+export const throttleJitter = (): number => Math.random() * 0.25
 
 /**
  * If `body` is a backend throttle error (`result_code`/`error` === "throttled") returns its
- * `retry_after` in seconds (>= 0); otherwise returns `null` so the caller falls through to
- * normal error handling. Non-JSON / non-object bodies return `null`.
+ * `retry_after` in seconds (>= 0, capped at MAX_THROTTLE_DELAY_SEC); otherwise returns `null`
+ * so the caller falls through to normal error handling. Non-JSON / non-object bodies return
+ * `null`.
  */
 export const parseThrottle = (body: string): number | null => {
     let obj: any
@@ -86,13 +90,13 @@ export const parseThrottle = (body: string): number | null => {
         return null
     }
     const retryAfter = Number(obj.retry_after)
-    return Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 0
+    return Number.isFinite(retryAfter) && retryAfter > 0 ? Math.min(retryAfter, MAX_THROTTLE_DELAY_SEC) : 0
 }
 
 /**
  * Computes the backoff delay (milliseconds) for a 0-based `attempt`: `retryAfter` seconds when
  * provided (> 0), otherwise exponential backoff (BASE_THROTTLE_DELAY_SEC * 2**attempt -> 11, 22,
- * 44, 88, 176s). The `jitter` fraction (typically in [-0.25, 0.25)) is then applied.
+ * 44, 88, 176s). The `jitter` fraction (typically in [0, 0.25)) is then applied.
  */
 export const throttleDelay = (attempt: number, retryAfter: number, jitter: number = throttleJitter()): number => {
     const baseSec = retryAfter > 0 ? retryAfter : BASE_THROTTLE_DELAY_SEC * Math.pow(2, attempt)

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -1,6 +1,7 @@
 import {
     KeeperHttpResponse,
     getSecrets,
+    getFolders,
     initializeStorage,
     generateTransmissionKey,
     platform,
@@ -365,4 +366,42 @@ test('IL5 dynamic key - Layer 2: rejects malformed (too short) serverPublicKey',
     await expect(
         initializeStorage(storage, 'IL5:ONE_TIME_TOKEN:20:tooshort')
     ).rejects.toThrow('IL5 token: serverPublicKey appears malformed')
+})
+
+test('getFolders skips an undecryptable folder and returns the good one', async () => {
+    const transmissionKey = new Uint8Array(32).fill(1)
+    const appKey = new Uint8Array(32).fill(2)
+    const folderKey = new Uint8Array(32).fill(3)
+
+    const goodFolderKeyWrapped = await platform.encryptWithKey(folderKey, appKey)
+    const goodFolderData = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify({ name: 'Good Folder' })), folderKey, true)
+    const badFolderKeyWrapped = new Uint8Array(16).fill(9)
+
+    const serverResponse = {
+        folders: [
+            { folderUid: 'good-uid', folderKey: platform.bytesToBase64(goodFolderKeyWrapped), data: platform.bytesToBase64(goodFolderData) },
+            { folderUid: 'bad-uid', folderKey: platform.bytesToBase64(badFolderKeyWrapped), data: '' }
+        ],
+        records: [],
+        expiresOn: 0,
+        warnings: []
+    }
+    const encryptedResponse = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify(serverResponse)), transmissionKey)
+
+    // postQuery uses options.queryFunction (not platform.post); pin getRandomBytes so the
+    // transmission key matches the key used to encrypt the response above.
+    platform.getRandomBytes = () => transmissionKey
+    const queryFn = (): Promise<KeeperHttpResponse> => Promise.resolve({ data: encryptedResponse, statusCode: 200, headers: [] })
+
+    const kvs = inMemoryStorage({})
+    await initializeStorage(kvs, 'US:FAKE_CLIENT_KEY')
+    await kvs.saveBytes('appKey', appKey)
+
+    const folders = await getFolders({ storage: kvs, queryFunction: queryFn })
+
+    expect(folders.length).toBe(1)
+    expect(folders[0].folderUid).toBe('good-uid')
+    expect(folders[0].name).toBe('Good Folder')
 })

--- a/sdk/javascript/packages/core/test/keeper.test.ts
+++ b/sdk/javascript/packages/core/test/keeper.test.ts
@@ -405,3 +405,95 @@ test('getFolders skips an undecryptable folder and returns the good one', async 
     expect(folders[0].folderUid).toBe('good-uid')
     expect(folders[0].name).toBe('Good Folder')
 })
+
+test('flat record with innerFolderUid decrypts recordKey using the folder key, not the app key', async () => {
+    const transmissionKey = new Uint8Array(32).fill(1)
+    const appKey = new Uint8Array(32).fill(2)
+    const folderKey = new Uint8Array(32).fill(3)
+    const recordKey = new Uint8Array(32).fill(4)
+    const folderUid = 'folder-uid-1'
+    const recordUid = 'record-uid-1'
+
+    const wrappedFolderKey = await platform.encryptWithKey(folderKey, appKey)
+    const wrappedRecordKey = await platform.encryptWithKey(recordKey, folderKey)
+    const recordData = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify({ title: 'Shared Record', type: 'login', fields: [], custom: [] })), recordKey)
+
+    const serverResponse = {
+        folders: [
+            { folderUid, folderKey: platform.bytesToBase64(wrappedFolderKey), data: '', records: [] }
+        ],
+        records: [
+            {
+                recordUid,
+                recordKey: platform.bytesToBase64(wrappedRecordKey),
+                data: platform.bytesToBase64(recordData),
+                revision: 1,
+                files: [],
+                innerFolderUid: folderUid
+            }
+        ],
+        expiresOn: 0,
+        warnings: []
+    }
+    const encryptedResponse = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify(serverResponse)), transmissionKey)
+
+    platform.getRandomBytes = () => transmissionKey
+    const queryFn = (): Promise<KeeperHttpResponse> => Promise.resolve({ data: encryptedResponse, statusCode: 200, headers: [] })
+
+    const kvs = inMemoryStorage({})
+    await initializeStorage(kvs, 'US:FAKE_CLIENT_KEY')
+    await kvs.saveBytes('appKey', appKey)
+
+    const secrets = await getSecrets({ storage: kvs, queryFunction: queryFn })
+
+    // Bug: the flat-records loop always unwraps recordKey with KEY_APP_KEY, ignoring
+    // innerFolderUid. Since recordKey here is wrapped with the folder key, unwrapping
+    // with the app key throws, the record is caught and silently skipped, and
+    // secrets.records comes back empty instead of containing the decrypted record.
+    expect(secrets.records.length).toBe(1)
+    expect(secrets.records[0].data.title).toBe('Shared Record')
+    expect(secrets.records[0].folderUid).toBe(folderUid)
+})
+
+test('flat record with innerFolderUid falls back to the app key when no matching folder is returned', async () => {
+    const transmissionKey = new Uint8Array(32).fill(5)
+    const appKey = new Uint8Array(32).fill(6)
+    const recordKey = new Uint8Array(32).fill(7)
+    const recordUid = 'record-uid-2'
+
+    const wrappedRecordKey = await platform.encryptWithKey(recordKey, appKey)
+    const recordData = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify({ title: 'Orphaned Record', type: 'login', fields: [], custom: [] })), recordKey)
+
+    const serverResponse = {
+        folders: [],
+        records: [
+            {
+                recordUid,
+                recordKey: platform.bytesToBase64(wrappedRecordKey),
+                data: platform.bytesToBase64(recordData),
+                revision: 1,
+                files: [],
+                innerFolderUid: 'folder-uid-not-in-response'
+            }
+        ],
+        expiresOn: 0,
+        warnings: []
+    }
+    const encryptedResponse = await platform.encryptWithKey(
+        platform.stringToBytes(JSON.stringify(serverResponse)), transmissionKey)
+
+    platform.getRandomBytes = () => transmissionKey
+    const queryFn = (): Promise<KeeperHttpResponse> => Promise.resolve({ data: encryptedResponse, statusCode: 200, headers: [] })
+
+    const kvs = inMemoryStorage({})
+    await initializeStorage(kvs, 'US:FAKE_CLIENT_KEY')
+    await kvs.saveBytes('appKey', appKey)
+
+    const secrets = await getSecrets({ storage: kvs, queryFunction: queryFn })
+
+    expect(secrets.records.length).toBe(1)
+    expect(secrets.records[0].data.title).toBe('Orphaned Record')
+})

--- a/sdk/javascript/packages/core/test/record_link.test.ts
+++ b/sdk/javascript/packages/core/test/record_link.test.ts
@@ -1,7 +1,7 @@
 import {KeeperRecordLink, getLinks, KeeperRecord, platform} from '../'
 import {createCipheriv, randomBytes} from 'crypto'
 
-// KSM-1010: KeeperRecordLink typed accessor tests (mirrors Python record_link_test.py)
+// KeeperRecordLink typed accessor tests (mirrors Python record_link_test.py)
 
 const plainLink = (payload: object, path?: string, ownerRecordUid = 'RU_owner'): KeeperRecordLink => {
     const data = platform.bytesToBase64(platform.stringToBytes(JSON.stringify(payload)))

--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -9,6 +9,7 @@ import {
     KeeperThrottleError,
     parseThrottle,
     throttleDelay,
+    throttleJitter,
 } from '../'
 
 // A valid one-time token (same fixture the e2e suite uses) so initializeStorage produces a
@@ -59,9 +60,19 @@ describe('throttleDelay (unit)', () => {
         expect(throttleDelay(0, 0, 0)).toBe(11000)
         expect(throttleDelay(1, -5, 0)).toBe(22000)
     })
-    test('jitter bounds keep the first delay in [8.25s, 13.75s]', () => {
-        expect(throttleDelay(0, 0, -0.25)).toBe(8250)
+    test('jitter bounds keep the first delay in [11s, 13.75s)', () => {
+        expect(throttleDelay(0, 0, 0)).toBe(11000)
         expect(throttleDelay(0, 0, 0.25)).toBe(13750)
+    })
+})
+
+describe('throttleJitter (unit)', () => {
+    test('is one-sided: never pushes the delay below its floor', () => {
+        for (let i = 0; i < 200; i++) {
+            const jitter = throttleJitter()
+            expect(jitter).toBeGreaterThanOrEqual(0)
+            expect(jitter).toBeLessThan(0.25)
+        }
     })
 })
 
@@ -76,6 +87,13 @@ describe('parseThrottle (unit)', () => {
         expect(parseThrottle('{"error":"key"}')).toBeNull()
         expect(parseThrottle('not json')).toBeNull()
         expect(parseThrottle('')).toBeNull()
+    })
+    test('retry_after beyond the exponential ceiling is capped at 176s', () => {
+        // 176s = BASE_THROTTLE_DELAY_SEC * 2**(MAX_THROTTLE_RETRIES - 1) = 11 * 2**4, the same
+        // ceiling the exponential branch already reaches on the last retry attempt.
+        expect(parseThrottle('{"error":"throttled","retry_after":500}')).toBe(176)
+        expect(parseThrottle('{"error":"throttled","retry_after":176}')).toBe(176)
+        expect(parseThrottle('{"error":"throttled","retry_after":175}')).toBe(175)
     })
 })
 
@@ -118,8 +136,8 @@ describe('throttle retry (e2e via getSecrets)', () => {
             call++ === 0 ? throttle403(3) : throttle403()
         )
         await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
-        // retry_after = 3s with +/-25% jitter -> [2.25s, 3.75s]
-        expect(sleeps[0]).toBeGreaterThanOrEqual(2250)
+        // retry_after = 3s with one-sided [0, +25%) jitter -> [3s, 3.75s]; never below the 3s floor
+        expect(sleeps[0]).toBeGreaterThanOrEqual(3000)
         expect(sleeps[0]).toBeLessThanOrEqual(3750)
     })
 


### PR DESCRIPTION
## Summary

Release branch for v18.0.0 of the JavaScript SDK. Bundles bug fixes for folder key handling, getFolders crash safety, per-item delete error surfacing, and throttle retry behavior.

## Changes

### Bug Fixes
- **getFolders binding fix** (KSM-1042): `getFolders()` failed with "appKey missing" when called as the first method on a freshly bound application. It now processes `encryptedAppKey` from the server binding response the same way `getSecrets()` does.
- **Shared-folder record key** (KSM-748): `getSecrets()` silently dropped records created by Commander or the Vault UI inside shared folders. The SDK now uses the folder key to decrypt the record key for any flat record that has `innerFolderUid` set.
- **getFolders crash safety** (KSM-1079): `getFolders()` threw when any folder in the response had a corrupted or missing key. The SDK now skips undecryptable folders and returns the rest normally.
- **Per-item delete errors** (KSM-1084): `deleteSecret()` and `deleteFolder()` silently reported success when the server rejected some UIDs. The SDK now surfaces per-item error messages from the server.
- **Throttle jitter** (KSM-1035): Throttle retry jitter was two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s.

### New Features
- **dbConnectionMethod** (KSM-1073): Added `dbConnectionMethod` to `PamSettingsConnection`.

### Maintenance
- Updated `minimatch`, `@babel/core`, and `handlebars` dev dependencies.

### Breaking Changes
None.

## Security Impact

KSM-1042 touches the initial key derivation path: `fetchAndDecryptFolders` now decrypts `encryptedAppKey` using the client key and stores the result as the app master key, matching the behavior already in `fetchAndDecryptSecrets`. The fix introduces no new cryptographic operations; it applies the same unwrap call that secrets binding already uses.

## Related Issues
- Jira: KSM-1042, KSM-748, KSM-1079, KSM-1084, KSM-1035, KSM-1073