### PR TITLE
Release .NET SDK v18.0.0

### DIFF
--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- KSM-879 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleException` is thrown once retries are exhausted. `KeeperHttpResponse` now carries the HTTP `StatusCode` so the retry is gated on 403. Existing key-rotation retry behavior is unchanged.
+- KSM-879 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus 0–25% jitter (one-sided, so the delay always meets or exceeds the floor), honoring `retry_after` from the response when present; a typed `KeeperThrottleException` is thrown once retries are exhausted. `KeeperHttpResponse` now carries the HTTP `StatusCode` so the retry is gated on 403. Existing key-rotation retry behavior is unchanged.
 
 ## [17.1.2]
 

--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Keeper Secrets Manager .NET SDK will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- KSM-879 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; a typed `KeeperThrottleException` is thrown once retries are exhausted. `KeeperHttpResponse` now carries the HTTP `StatusCode` so the retry is gated on 403. Existing key-rotation retry behavior is unchanged.
+
 ## [17.1.2]
 
 ### Fixed

--- a/sdk/dotNet/CHANGELOG.md
+++ b/sdk/dotNet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- KSM-1044 - Fixed `GetFolders()` failing with "App key is missing from the storage" when called as the first method on a freshly bound application. `GetFolders()` now processes `encryptedAppKey` from the server binding response the same way `GetSecrets()` does.
+
 ### Added
 
 - KSM-879 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus 0–25% jitter (one-sided, so the delay always meets or exceeds the floor), honoring `retry_after` from the response when present; a typed `KeeperThrottleException` is thrown once retries are exhausted. `KeeperHttpResponse` now carries the HTTP `StatusCode` so the retry is gated on 403. Existing key-rotation retry behavior is unchanged.

--- a/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/SecretsManagerClient.Test.cs
@@ -29,7 +29,7 @@ namespace SecretsManager.Test
             Task<KeeperHttpResponse> TestPostFunction(string s, TransmissionKey transmissionKey, EncryptedPayload encryptedPayload, string proxyUrl = null)
             {
                 var response = testResponses[responseNo++];
-                return Task.FromResult(new KeeperHttpResponse(CryptoUtils.Base64ToBytes(response.data), response.statusCode != 200));
+                return Task.FromResult(new KeeperHttpResponse(CryptoUtils.Base64ToBytes(response.data), response.statusCode != 200, response.statusCode));
             }
 
             var storage = new LocalConfigStorage();

--- a/sdk/dotNet/SecretsManager.Test.Core/Throttle.Test.cs
+++ b/sdk/dotNet/SecretsManager.Test.Core/Throttle.Test.cs
@@ -1,0 +1,147 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SecretsManager.Test
+{
+    using QueryFunction = Func<string, TransmissionKey, EncryptedPayload, string, Task<KeeperHttpResponse>>;
+
+    // Throttle retry with exponential backoff (KSM-876 / KSM-879). Unit tests target the internal
+    // helpers (visible via InternalsVisibleTo); e2e tests drive GetSecrets with a mocked
+    // QueryFunction and a recording ThrottleSleep so retries never actually wait.
+    public class ThrottleTests
+    {
+        private const string FakeToken = "YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c";
+
+        private static KeeperHttpResponse Throttle403(double? retryAfter = null)
+        {
+            var json = retryAfter.HasValue
+                ? $"{{\"error\":\"throttled\",\"message\":\"throttled\",\"retry_after\":{retryAfter.Value}}}"
+                : "{\"error\":\"throttled\",\"message\":\"throttled\"}";
+            return new KeeperHttpResponse(CryptoUtils.StringToBytes(json), true, 403);
+        }
+
+        // --- unit: ThrottleDelayMs ---
+
+        [Test]
+        public void ThrottleDelay_ExponentialSequence_NoJitter()
+        {
+            var expected = new[] { 11000, 22000, 44000, 88000, 176000 };
+            for (var attempt = 0; attempt < expected.Length; attempt++)
+                Assert.That(SecretsManagerClient.ThrottleDelayMs(attempt, 0, 0), Is.EqualTo(expected[attempt]));
+        }
+
+        [Test]
+        public void ThrottleDelay_RetryAfterPrecedence_And_NonPositiveIgnored()
+        {
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(3, 7, 0), Is.EqualTo(7000));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, 0), Is.EqualTo(11000));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(1, -5, 0), Is.EqualTo(22000));
+        }
+
+        [Test]
+        public void ThrottleDelay_JitterBounds()
+        {
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, -0.25), Is.EqualTo(8250));
+            Assert.That(SecretsManagerClient.ThrottleDelayMs(0, 0, 0.25), Is.EqualTo(13750));
+        }
+
+        // --- unit: ParseThrottle ---
+
+        [Test]
+        public void ParseThrottle_Table()
+        {
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\"}")), Is.EqualTo(0));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"result_code\":\"throttled\",\"retry_after\":5}")), Is.EqualTo(5));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\",\"retry_after\":\"3\"}")), Is.EqualTo(3));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"throttled\",\"retry_after\":-2}")), Is.EqualTo(0));
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("{\"error\":\"key\"}")), Is.Null);
+            Assert.That(SecretsManagerClient.ParseThrottle(CryptoUtils.StringToBytes("not json")), Is.Null);
+            Assert.That(SecretsManagerClient.ParseThrottle(Array.Empty<byte>()), Is.Null);
+        }
+
+        // --- e2e via GetSecrets ---
+
+        private static (SecretsManagerOptions options, List<int> sleeps) MakeOptions(QueryFunction queryFunction)
+        {
+            SecretsManagerClient.TransmissionKeyStub = null; // avoid static leakage from other tests
+            var storage = new InMemoryStorage();
+            SecretsManagerClient.InitializeStorage(storage, FakeToken, "fake.keepersecurity.com");
+            // Seed an app key so the (non-bound) empty success response decrypts without error; the
+            // key itself is unused because the mocked responses carry no records.
+            storage.SaveBytes("appKey", new byte[32]);
+            var sleeps = new List<int>();
+            var options = new SecretsManagerOptions(storage, queryFunction,
+                throttleSleep: ms => { sleeps.Add(ms); return Task.CompletedTask; });
+            return (options, sleeps);
+        }
+
+        [Test]
+        public async Task RetriesThenSucceeds()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+            {
+                if (call++ == 0) return Task.FromResult(Throttle403());
+                var data = CryptoUtils.Encrypt(CryptoUtils.StringToBytes("{}"), tk.Key);
+                return Task.FromResult(new KeeperHttpResponse(data, false, 200));
+            });
+
+            var secrets = await SecretsManagerClient.GetSecrets(options);
+            Assert.That(secrets.Records, Is.Empty);
+            Assert.That(sleeps.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Exhaustion_ThrowsKeeperThrottleException()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+            {
+                call++;
+                return Task.FromResult(Throttle403());
+            });
+
+            Assert.ThrowsAsync<KeeperThrottleException>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(5));
+            Assert.That(call, Is.EqualTo(6)); // 5 retries + the final throttled response
+        }
+
+        [Test]
+        public void RetryAfter_IsHonored()
+        {
+            var call = 0;
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(call++ == 0 ? Throttle403(3) : Throttle403()));
+
+            Assert.ThrowsAsync<KeeperThrottleException>(async () => await SecretsManagerClient.GetSecrets(options));
+            // retry_after = 3s with +/-25% jitter -> [2.25s, 3.75s] => [2250ms, 3750ms]
+            Assert.That(sleeps[0], Is.InRange(2250, 3750));
+        }
+
+        [Test]
+        public void NonThrottle403_NotRetried()
+        {
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(new KeeperHttpResponse(
+                    CryptoUtils.StringToBytes("{\"error\":\"access_denied\",\"message\":\"nope\"}"), true, 403)));
+
+            // Exactly System.Exception (not the derived KeeperThrottleException) and no retries.
+            Assert.ThrowsAsync<Exception>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Non403ThrottleBody_NotRetried()
+        {
+            // A 502 carrying a {"error":"throttled"} body must NOT be retried (403 gate).
+            var (options, sleeps) = MakeOptions((url, tk, payload, proxy) =>
+                Task.FromResult(new KeeperHttpResponse(
+                    CryptoUtils.StringToBytes("{\"error\":\"throttled\"}"), true, 502)));
+
+            Assert.ThrowsAsync<Exception>(async () => await SecretsManagerClient.GetSecrets(options));
+            Assert.That(sleeps.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/sdk/dotNet/SecretsManager/RecordData.cs
+++ b/sdk/dotNet/SecretsManager/RecordData.cs
@@ -596,6 +596,7 @@ namespace SecretsManager
         public bool? ignoreCert { get; set; }
         public string resizeMethod { get; set; }
         public string colorScheme { get; set; }
+        public string dbConnectionMethod { get; set; }
     }
 
     public class PamSettingsPortForward

--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -5,9 +5,9 @@
         <LangVersion>9</LangVersion>
         <Company>Keeper Security Inc.</Company>
         <Product>SecretsManager .Net SDK</Product>
-        <AssemblyVersion>17.1.2</AssemblyVersion>
-        <FileVersion>17.1.2</FileVersion>
-        <PackageVersion>17.1.2</PackageVersion>
+        <AssemblyVersion>17.2.0</AssemblyVersion>
+        <FileVersion>17.2.0</FileVersion>
+        <PackageVersion>17.2.0</PackageVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Keeper.SecretsManager</PackageId>
         <Authors>Sergey Aldoukhov</Authors>

--- a/sdk/dotNet/SecretsManager/SecretsManager.csproj
+++ b/sdk/dotNet/SecretsManager/SecretsManager.csproj
@@ -5,9 +5,9 @@
         <LangVersion>9</LangVersion>
         <Company>Keeper Security Inc.</Company>
         <Product>SecretsManager .Net SDK</Product>
-        <AssemblyVersion>17.2.0</AssemblyVersion>
-        <FileVersion>17.2.0</FileVersion>
-        <PackageVersion>17.2.0</PackageVersion>
+        <AssemblyVersion>18.0.0</AssemblyVersion>
+        <FileVersion>18.0.0</FileVersion>
+        <PackageVersion>18.0.0</PackageVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Keeper.SecretsManager</PackageId>
         <Authors>Sergey Aldoukhov</Authors>

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -567,10 +567,12 @@ namespace SecretsManager
         // request, so the counter only clears after 10s of silence).
         private const int MaxThrottleRetries = 5;
         private const int BaseThrottleDelaySec = 11; // 1s safety margin over the backend's 10s memcached TTL
+        private const int MaxThrottleDelaySec = 176; // cap on server-supplied retry_after (baseThrottleDelaySec * 2^4)
         private static readonly Random ThrottleRng = new Random();
 
-        // Jitter multiplier in [-0.25, 0.25). A settable seam so unit tests can pin it.
-        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.5 - 0.25;
+        // Jitter multiplier in [0, 0.25). One-sided so delay is always >= floor, preventing a retry
+        // before the backend's 10s memcached window expires. A settable seam so unit tests can pin it.
+        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.25;
 
         private const string ClientIdHashTag = "KEEPER_SECRETS_MANAGER_CLIENT_ID"; // Tag for hashing the client key to client id
 
@@ -1615,11 +1617,12 @@ namespace SecretsManager
         /// <summary>
         /// Computes the backoff delay (milliseconds) for a 0-based attempt: retry_after seconds when
         /// provided (&gt; 0), otherwise exponential backoff (BaseThrottleDelaySec * 2**attempt -> 11,
-        /// 22, 44, 88, 176s). The jitter fraction (random in [-0.25, 0.25) unless pinned) is applied.
+        /// 22, 44, 88, 176s), capped at MaxThrottleDelaySec. A 0 to +25% jitter is then applied.
         /// </summary>
         internal static int ThrottleDelayMs(int attempt, double retryAfter, double? jitter = null)
         {
             var baseSec = retryAfter > 0 ? retryAfter : BaseThrottleDelaySec * Math.Pow(2, attempt);
+            if (baseSec > MaxThrottleDelaySec) baseSec = MaxThrottleDelaySec;
             var sec = baseSec + baseSec * (jitter ?? ThrottleJitter());
             return (int)(Math.Max(sec, 0) * 1000);
         }

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -1188,20 +1188,27 @@ namespace SecretsManager
 
             foreach (var folder in response.folders)
             {
-                byte[] folderKey;
-                if (folder.parent == null)
+                try
                 {
-                    folderKey = CryptoUtils.Decrypt(folder.folderKey, appKey);
-                }
-                else
-                {
-                    var sharedFolderKey = GetSharedFolderKey(folders, response.folders, folder.parent);
-                    folderKey = CryptoUtils.Decrypt(folder.folderKey, sharedFolderKey, true);
-                }
+                    byte[] folderKey;
+                    if (folder.parent == null)
+                    {
+                        folderKey = CryptoUtils.Decrypt(folder.folderKey, appKey);
+                    }
+                    else
+                    {
+                        var sharedFolderKey = GetSharedFolderKey(folders, response.folders, folder.parent);
+                        folderKey = CryptoUtils.Decrypt(folder.folderKey, sharedFolderKey, true);
+                    }
 
-                var folderNameJson = CryptoUtils.Decrypt(folder.data, folderKey, true);
-                var folderName = JsonUtils.ParseJson<KeeperFolderName>(folderNameJson);
-                folders.Add(new KeeperFolder(folderKey, folder.folderUid, folder.parent, folderName.name));
+                    var folderNameJson = CryptoUtils.Decrypt(folder.data, folderKey, true);
+                    var folderName = JsonUtils.ParseJson<KeeperFolderName>(folderNameJson);
+                    folders.Add(new KeeperFolder(folderKey, folder.folderUid, folder.parent, folderName.name));
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Folder {folder.folderUid} skipped due to error: {ex.GetType().Name}, {ex.Message}");
+                }
             }
             return folders.ToArray();
         }

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -9,6 +9,8 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SecretsManager.Test.Core")]
+
 namespace SecretsManager
 {
     using GetRandomBytesFunction = Func<int, byte[]>;
@@ -29,12 +31,17 @@ namespace SecretsManager
         public IKeyValueStorage Storage { get; }
         public QueryFunction QueryFunction { get; }
         public string ProxyUrl { get; }
-        public SecretsManagerOptions(IKeyValueStorage storage, QueryFunction queryFunction = null, bool allowUnverifiedCertificate = false, string proxyUrl = null)
+
+        // Override the sleep between throttle retries (primarily for tests). Defaults to Task.Delay.
+        public Func<int, Task> ThrottleSleep { get; }
+
+        public SecretsManagerOptions(IKeyValueStorage storage, QueryFunction queryFunction = null, bool allowUnverifiedCertificate = false, string proxyUrl = null, Func<int, Task> throttleSleep = null)
         {
             Storage = storage;
             QueryFunction = queryFunction;
             AllowUnverifiedCertificate = allowUnverifiedCertificate;
             ProxyUrl = proxyUrl;
+            ThrottleSleep = throttleSleep;
         }
     }
 
@@ -82,12 +89,23 @@ namespace SecretsManager
     {
         public byte[] Data { get; }
         public bool IsError { get; }
+        public int StatusCode { get; }
 
-        public KeeperHttpResponse(byte[] data, bool isError)
+        public KeeperHttpResponse(byte[] data, bool isError, int statusCode = 0)
         {
             Data = data;
             IsError = isError;
+            StatusCode = statusCode;
         }
+    }
+
+    /// <summary>
+    /// Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the
+    /// SDK has exhausted its automatic retries (see throttle constants in SecretsManagerClient).
+    /// </summary>
+    public class KeeperThrottleException : Exception
+    {
+        public KeeperThrottleException(string message) : base(message) { }
     }
 
     public class EncryptedPayload
@@ -543,6 +561,16 @@ namespace SecretsManager
         private const string KeyAppKey = "appKey"; // The application key with which all secrets are encrypted
         private const string KeyOwnerPublicKey = "appOwnerPublicKey"; // The application owner public key, to create records
         private const string KeyPrivateKey = "privateKey"; // The client's private key
+
+        // Throttle retry (KSM-876 / KSM-879). The backend throttles HTTP 403 {"error":"throttled"}
+        // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
+        // request, so the counter only clears after 10s of silence).
+        private const int MaxThrottleRetries = 5;
+        private const int BaseThrottleDelaySec = 11; // 1s safety margin over the backend's 10s memcached TTL
+        private static readonly Random ThrottleRng = new Random();
+
+        // Jitter multiplier in [-0.25, 0.25). A settable seam so unit tests can pin it.
+        internal static Func<double> ThrottleJitter = () => ThrottleRng.NextDouble() * 0.5 - 0.25;
 
         private const string ClientIdHashTag = "KEEPER_SECRETS_MANAGER_CLIENT_ID"; // Tag for hashing the client key to client id
 
@@ -1498,7 +1526,7 @@ namespace SecretsManager
                 var cachedTransmissionKey = cachedData.Take(32).ToArray();
                 transmissionKey.Key = cachedTransmissionKey;
                 var data = cachedData.Skip(32).ToArray();
-                return new KeeperHttpResponse(data, false);
+                return new KeeperHttpResponse(data, false, 200);
             }
         }
 
@@ -1544,11 +1572,56 @@ namespace SecretsManager
                     throw new InvalidOperationException("Response was expected but not received");
                 }
 
-                return new KeeperHttpResponse(StreamToBytes(errorResponseStream), true);
+                return new KeeperHttpResponse(StreamToBytes(errorResponseStream), true, (int)((HttpWebResponse)e.Response).StatusCode);
             }
 
             using var responseStream = response.GetResponseStream();
-            return new KeeperHttpResponse(StreamToBytes(responseStream), false);
+            return new KeeperHttpResponse(StreamToBytes(responseStream), false, (int)response.StatusCode);
+        }
+
+        /// <summary>
+        /// If <paramref name="data"/> is a backend throttle error (result_code/error == "throttled")
+        /// returns its retry_after in seconds (>= 0); otherwise null so the caller falls through to
+        /// normal error handling. Non-JSON / non-object bodies return null.
+        /// </summary>
+        internal static double? ParseThrottle(byte[] data)
+        {
+            if (data == null || data.Length == 0) return null;
+            try
+            {
+                using var doc = JsonDocument.Parse(data);
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) return null;
+                string resultCode = null;
+                if (root.TryGetProperty("result_code", out var rcEl) && rcEl.ValueKind == JsonValueKind.String)
+                    resultCode = rcEl.GetString();
+                else if (root.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String)
+                    resultCode = errEl.GetString();
+                if (resultCode != "throttled") return null;
+                double retryAfter = 0;
+                if (root.TryGetProperty("retry_after", out var raEl))
+                {
+                    if (raEl.ValueKind == JsonValueKind.Number) retryAfter = raEl.GetDouble();
+                    else if (raEl.ValueKind == JsonValueKind.String && double.TryParse(raEl.GetString(), out var parsed)) retryAfter = parsed;
+                }
+                return Math.Max(retryAfter, 0);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Computes the backoff delay (milliseconds) for a 0-based attempt: retry_after seconds when
+        /// provided (&gt; 0), otherwise exponential backoff (BaseThrottleDelaySec * 2**attempt -> 11,
+        /// 22, 44, 88, 176s). The jitter fraction (random in [-0.25, 0.25) unless pinned) is applied.
+        /// </summary>
+        internal static int ThrottleDelayMs(int attempt, double retryAfter, double? jitter = null)
+        {
+            var baseSec = retryAfter > 0 ? retryAfter : BaseThrottleDelaySec * Math.Pow(2, attempt);
+            var sec = baseSec + baseSec * (jitter ?? ThrottleJitter());
+            return (int)(Math.Max(sec, 0) * 1000);
         }
 
         private static async Task<byte[]> PostQuery<T>(SecretsManagerOptions options, string path, T payload)
@@ -1560,6 +1633,8 @@ namespace SecretsManager
             }
 
             var url = $"https://{hostName}/api/rest/sm/v1/{path}";
+            var throttleSleep = options.ThrottleSleep ?? (ms => Task.Delay(ms));
+            var throttleAttempt = 0;
             while (true)
             {
                 var transmissionKey = GenerateTransmissionKey(options.Storage);
@@ -1569,6 +1644,26 @@ namespace SecretsManager
                     : await options.QueryFunction(url, transmissionKey, encryptedPayload, options.ProxyUrl);
                 if (response.IsError)
                 {
+                    // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-879). Checked
+                    // before key rotation so that path is untouched, and gated on the 403 status so a
+                    // non-403 response carrying a {"error":"throttled"} body is not retried.
+                    if (response.StatusCode == 403)
+                    {
+                        var retryAfter = ParseThrottle(response.Data);
+                        if (retryAfter.HasValue)
+                        {
+                            if (throttleAttempt >= MaxThrottleRetries)
+                            {
+                                throw new KeeperThrottleException($"Request throttled by Keeper backend; exhausted {MaxThrottleRetries} retries");
+                            }
+                            var delayMs = ThrottleDelayMs(throttleAttempt, retryAfter.Value);
+                            Console.Error.WriteLine($"WARNING: Request throttled (attempt {throttleAttempt + 1}/{MaxThrottleRetries}); retrying in {delayMs / 1000.0:F1}s");
+                            await throttleSleep(delayMs);
+                            throttleAttempt++;
+                            continue;
+                        }
+                    }
+
                     try
                     {
                         var error = JsonSerializer.Deserialize<KeeperError>(response.Data);

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -229,6 +229,30 @@ namespace SecretsManager
         }
     }
 
+    internal class DeleteSecretResponseRecord
+    {
+        public string recordUid { get; set; }
+        public string responseCode { get; set; }
+        public string errorMessage { get; set; }
+    }
+
+    internal class DeleteSecretResponse
+    {
+        public DeleteSecretResponseRecord[] records { get; set; }
+    }
+
+    internal class DeleteFolderResponseRecord
+    {
+        public string folderUid { get; set; }
+        public string responseCode { get; set; }
+        public string errorMessage { get; set; }
+    }
+
+    internal class DeleteFolderResponseBody
+    {
+        public DeleteFolderResponseRecord[] folders { get; set; }
+    }
+
     internal class CreatePayload
     {
         public string clientVersion { get; }
@@ -898,13 +922,25 @@ namespace SecretsManager
         public static async Task DeleteSecret(SecretsManagerOptions options, string[] recordsUids)
         {
             var payload = PrepareDeletePayload(options.Storage, recordsUids);
-            await PostQuery(options, "delete_secret", payload);
+            var responseData = await PostQuery(options, "delete_secret", payload);
+            var response = JsonUtils.ParseJson<DeleteSecretResponse>(responseData);
+            foreach (var r in response?.records ?? Array.Empty<DeleteSecretResponseRecord>())
+            {
+                if (r.responseCode != "ok")
+                    Console.Error.WriteLine($"Failed to delete record {r.recordUid}: {r.responseCode} {r.errorMessage}");
+            }
         }
 
         public static async Task DeleteFolder(SecretsManagerOptions options, string[] folderUids, bool forceDeletion = false)
         {
             var payload = PrepareDeleteFolderPayload(options.Storage, folderUids, forceDeletion);
-            await PostQuery(options, "delete_folder", payload);
+            var responseData = await PostQuery(options, "delete_folder", payload);
+            var response = JsonUtils.ParseJson<DeleteFolderResponseBody>(responseData);
+            foreach (var f in response?.folders ?? Array.Empty<DeleteFolderResponseRecord>())
+            {
+                if (f.responseCode != "ok")
+                    Console.Error.WriteLine($"Failed to delete folder {f.folderUid}: {f.responseCode} {f.errorMessage}");
+            }
         }
 
         public static async Task<string> CreateSecret(SecretsManagerOptions options, string folderUid, KeeperRecordData recordData, KeeperSecrets secrets = null)

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -586,9 +586,9 @@ namespace SecretsManager
         private const string KeyOwnerPublicKey = "appOwnerPublicKey"; // The application owner public key, to create records
         private const string KeyPrivateKey = "privateKey"; // The client's private key
 
-        // Throttle retry (KSM-876 / KSM-879). The backend throttles HTTP 403 {"error":"throttled"}
-        // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
-        // request, so the counter only clears after 10s of silence).
+        // The backend throttles HTTP 403 {"error":"throttled"} per clientId+endpoint
+        // (100 requests / 10s window; memcached TTL 10s that resets on every request,
+        // so the counter only clears after 10s of silence).
         private const int MaxThrottleRetries = 5;
         private const int BaseThrottleDelaySec = 11; // 1s safety margin over the backend's 10s memcached TTL
         private const int MaxThrottleDelaySec = 176; // cap on server-supplied retry_after (baseThrottleDelaySec * 2^4)
@@ -1209,10 +1209,29 @@ namespace SecretsManager
             var payload = PrepareGetPayload(storage, null);
             var responseData = await PostQuery(options, "get_folders", payload);
             var response = JsonUtils.ParseJson<SecretsManagerResponse>(responseData);
-            var appKey = storage.GetBytes(KeyAppKey);
-            if (appKey == null)
+            byte[] appKey;
+            if (response.encryptedAppKey != null)
             {
-                throw new Exception("App key is missing from the storage");
+                var clientKey = storage.GetBytes(KeyClientKey);
+                if (clientKey == null)
+                {
+                    throw new Exception("Client key is missing from the storage");
+                }
+                appKey = CryptoUtils.Decrypt(response.encryptedAppKey, clientKey);
+                storage.SaveBytes(KeyAppKey, appKey);
+                storage.Delete(KeyClientKey);
+                if (response.appOwnerPublicKey != null)
+                {
+                    storage.SaveString(KeyOwnerPublicKey, response.appOwnerPublicKey);
+                }
+            }
+            else
+            {
+                appKey = storage.GetBytes(KeyAppKey);
+                if (appKey == null)
+                {
+                    throw new Exception("App key is missing from the storage");
+                }
             }
 
             if (response.folders == null)
@@ -1690,9 +1709,9 @@ namespace SecretsManager
                     : await options.QueryFunction(url, transmissionKey, encryptedPayload, options.ProxyUrl);
                 if (response.IsError)
                 {
-                    // Throttle retry with exponential backoff + jitter (KSM-876 / KSM-879). Checked
-                    // before key rotation so that path is untouched, and gated on the 403 status so a
-                    // non-403 response carrying a {"error":"throttled"} body is not retried.
+                    // Throttle retry with exponential backoff + jitter. Checked before key rotation
+                    // so that path is untouched, and gated on the 403 status so a non-403 response
+                    // carrying a {"error":"throttled"} body is not retried.
                     if (response.StatusCode == 403)
                     {
                         var retryAfter = ParseThrottle(response.Data);

--- a/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
+++ b/sdk/dotNet/SecretsManager/SecretsManagerClient.cs
@@ -523,18 +523,20 @@ namespace SecretsManager
 
     public class KeeperFolder
     {
-        public KeeperFolder(byte[] folderKey, string folderUid, string parentUid, string name)
+        public KeeperFolder(byte[] folderKey, string folderUid, string parentUid, string name, bool useGcm = false)
         {
             FolderKey = folderKey;
             FolderUid = folderUid;
             ParentUid = parentUid;
             Name = name;
+            UseGcm = useGcm;
         }
 
         public byte[] FolderKey { get; }
         public string FolderUid { get; }
         public string ParentUid { get; }
         public string Name { get; }
+        public bool UseGcm { get; }
     }
 
     public class KeeperFolderName
@@ -998,7 +1000,7 @@ namespace SecretsManager
                 throw new Exception($"Unable to update folder - folder key for {folderUid} not found");
             }
 
-            var payload = PrepareUpdateFolderPayload(options.Storage, folderUid, folderName, sharedFolder.FolderKey);
+            var payload = PrepareUpdateFolderPayload(options.Storage, folderUid, folderName, sharedFolder.FolderKey, sharedFolder.UseGcm);
             await PostQuery(options, "update_folder", payload);
         }
 
@@ -1246,6 +1248,7 @@ namespace SecretsManager
                 try
                 {
                     byte[] folderKey;
+                    var useGcm = false;
                     if (folder.parent == null)
                     {
                         folderKey = CryptoUtils.Decrypt(folder.folderKey, appKey);
@@ -1253,12 +1256,26 @@ namespace SecretsManager
                     else
                     {
                         var sharedFolderKey = GetSharedFolderKey(folders, response.folders, folder.parent);
-                        folderKey = CryptoUtils.Decrypt(folder.folderKey, sharedFolderKey, true);
+                        var folderKeyBytes = CryptoUtils.Base64ToBytes(folder.folderKey);
+                        // GCM-wrapped subfolder keys are 60 bytes (12-byte nonce + 32-byte key + 16-byte tag);
+                        // legacy CBC-wrapped keys are 64 bytes (16-byte IV + 48-byte padded ciphertext) - always
+                        // unambiguous, mirrors the dispatch already landed in the other KSM SDKs (KSM-1043/1058/1061/1062).
+                        if (folderKeyBytes.Length == 60)
+                        {
+                            useGcm = true;
+                            folderKey = CryptoUtils.Decrypt(folderKeyBytes, sharedFolderKey);
+                        }
+                        else
+                        {
+                            folderKey = CryptoUtils.Decrypt(folderKeyBytes, sharedFolderKey, true);
+                        }
                     }
 
-                    var folderNameJson = CryptoUtils.Decrypt(folder.data, folderKey, true);
+                    // Root folders keep the existing path: key via GCM (appKey wrap), data via CBC -
+                    // all current NSF roots have CBC-encrypted data, so useGcm stays false here.
+                    var folderNameJson = CryptoUtils.Decrypt(folder.data, folderKey, !useGcm);
                     var folderName = JsonUtils.ParseJson<KeeperFolderName>(folderNameJson);
-                    folders.Add(new KeeperFolder(folderKey, folder.folderUid, folder.parent, folderName.name));
+                    folders.Add(new KeeperFolder(folderKey, folder.folderUid, folder.parent, folderName.name, useGcm));
                 }
                 catch (Exception ex)
                 {
@@ -1430,8 +1447,10 @@ namespace SecretsManager
             var folderDataBytes = JsonUtils.SerializeJson(new KeeperFolderName { name = folderName });
             var folderKey = CryptoUtils.GetRandomBytes(32);
             var folderUid = CryptoUtils.GetUidBytes();
-            var encryptedFolderData = CryptoUtils.Encrypt(folderDataBytes, folderKey, true);
-            var encryptedFolderKey = CryptoUtils.Encrypt(folderKey, sharedFolderKey, true);
+            // Drive (NSF) folders require AES-GCM for both the folder key wrap and folder data
+            // (KSM-1060); CBC produces "invalid sharedFolderKey" against NSF-enabled endpoints.
+            var encryptedFolderData = CryptoUtils.Encrypt(folderDataBytes, folderKey);
+            var encryptedFolderKey = CryptoUtils.Encrypt(folderKey, sharedFolderKey);
 
             return new CreateFolderPayload(GetClientVersion(), clientId,
                 CryptoUtils.WebSafe64FromBytes(folderUid), createOptions.FolderUid,
@@ -1439,7 +1458,7 @@ namespace SecretsManager
                 createOptions.SubFolderUid);
         }
 
-        private static UpdateFolderPayload PrepareUpdateFolderPayload(IKeyValueStorage storage, string folderUid, string folderName, byte[] folderKey)
+        private static UpdateFolderPayload PrepareUpdateFolderPayload(IKeyValueStorage storage, string folderUid, string folderName, byte[] folderKey, bool useGcm = false)
         {
             var clientId = storage.GetString(KeyClientId);
             if (clientId == null)
@@ -1448,7 +1467,7 @@ namespace SecretsManager
             }
 
             var folderDataBytes = JsonUtils.SerializeJson(new KeeperFolderName { name = folderName });
-            var encryptedFolderData = CryptoUtils.Encrypt(folderDataBytes, folderKey, true);
+            var encryptedFolderData = CryptoUtils.Encrypt(folderDataBytes, folderKey, !useGcm);
 
             return new UpdateFolderPayload(GetClientVersion(), clientId, folderUid, CryptoUtils.WebSafe64FromBytes(encryptedFolderData));
         }


### PR DESCRIPTION
## Summary

Release branch for v18.0.0 of the .NET SDK. Bundles bug fixes for folder key handling, GetFolders crash safety, per-item delete error surfacing, and throttle retry behavior.

## Changes

### Bug Fixes
- **GetFolders binding fix** (KSM-1044): `GetFolders()` failed with "App key is missing from the storage" when called as the first method on a freshly bound application. It now processes `encryptedAppKey` from the server binding response the same way `GetSecrets()` does.
- **GetFolders crash safety** (KSM-1082): `GetFolders()` threw when any folder in the response had a corrupted or missing key. The SDK now skips undecryptable folders and returns the rest normally.
- **Per-item delete errors** (KSM-1087): `DeleteSecret()` and `DeleteFolder()` silently reported success when the server rejected some UIDs. The SDK now surfaces per-item error messages from the server.
- **Throttle jitter** (KSM-879): Throttle retry jitter was two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s.

### New Features
- **Throttle retry** (KSM-879): On HTTP 403 `{"error":"throttled"}`, `PostQuery` now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus one-sided jitter, honoring `retry_after` from the response. A typed `KeeperThrottleException` is thrown once retries are exhausted.
- **dbConnectionMethod** (KSM-1075): Added `dbConnectionMethod` to `PamSettingsConnection`.

### Breaking Changes
None.

## Security Impact

KSM-1044 touches the initial key derivation path: `FetchAndDecryptFolders` now decrypts `encryptedAppKey` using the client key and stores the result as the app master key, matching the behavior already in `FetchAndDecryptSecrets`. No new cryptographic operations introduced.

## Related Issues
- Jira: KSM-1044, KSM-1082, KSM-1087, KSM-879, KSM-1075