### PR TITLE
JavaScript SDK: fix Node platform hash() ignoring tag parameter (KSM-1254)

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -7,6 +7,7 @@
 - KSM-748 - Fixed `getSecrets()` silently dropping records created by Commander or the Vault UI inside shared folders. The SDK now uses the folder key to decrypt the record key for any flat record that has `innerFolderUid` set. This matches the behavior for records in `folders[].records[]`.
 - KSM-1035 - Fixed throttle retry jitter being two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s to prevent an arbitrarily long wait.
 - KSM-1128 - Bounded the server key-rotation retry in `postQuery`. When the server sends `{"error":"key"}`, the code retries at most 3 times before throwing a typed `KeeperError`, instead of retrying forever. Before storing a suggested `key_id`, the code validates its shape (positive integer) and its membership in the bundled key table (keys 7-18). An unsupported key id can no longer corrupt the configuration. The pinned custom-key path does not change.
+- KSM-1254 - Fixed the Node platform's `hash()` ignoring its `tag` parameter and always hashing with a hardcoded string; it now hashes with the caller-supplied tag, matching the browser implementation and the `Platform` contract. No behavior change for existing callers (the SDK's only caller already passed that same string).
 - Maintenance: Updated `minimatch`, `@babel/core`, and `handlebars` dev dependencies.
 
 ## 17.5.0

--- a/sdk/javascript/packages/core/src/node/nodePlatform.ts
+++ b/sdk/javascript/packages/core/src/node/nodePlatform.ts
@@ -166,8 +166,8 @@ const decrypt = async (data: Uint8Array, keyId: string, storage?: KeyValueStorag
     return await _decrypt(data, key, useCBC)
 }
 
-function hash(data: Uint8Array): Promise<Uint8Array> {
-    const hash = createHmac('sha512', data).update('KEEPER_SECRETS_MANAGER_CLIENT_ID').digest()
+function hash(data: Uint8Array, tag: string): Promise<Uint8Array> {
+    const hash = createHmac('sha512', data).update(tag).digest()
     return Promise.resolve(hash)
 }
 

--- a/sdk/javascript/packages/core/test/hashCompatibility.test.ts
+++ b/sdk/javascript/packages/core/test/hashCompatibility.test.ts
@@ -1,0 +1,31 @@
+import {nodePlatform} from '../src/node/nodePlatform'
+import {browserPlatform} from '../src/browser/browserPlatform'
+
+// hash() is HMAC-SHA512 keyed by `data`, over the message `tag`, and not the other way round.
+// The client id every SDK sends at binding time is that digest, so what this file pins is wire
+// format shared with the Python, Java, .NET, Go, Rust and Ruby SDKs, not a Node-local detail.
+const CLIENT_ID_HASH_TAG = 'KEEPER_SECRETS_MANAGER_CLIENT_ID'
+
+// A pinned digest rather than one recomputed with the same crypto call the implementation makes:
+// a recomputed expectation drifts along with the implementation, and this value must not drift.
+// Cross-checked against the Python SDK's
+// hmac.new(client_key_bytes, b'KEEPER_SECRETS_MANAGER_CLIENT_ID', 'sha512').
+test('hash produces the client id digest the other SDKs produce for the same client key', async () => {
+    const clientKey = Buffer.from('0123456789abcdef0123456789abcdef', 'hex')
+    const digest = await nodePlatform.hash(clientKey, CLIENT_ID_HASH_TAG)
+    expect(Buffer.from(digest).toString('hex')).toBe(
+        'e25a52879c9913c1ee272ea381e6fab73ad219a61f45fe74633dfa37496b187b' +
+        '7b1c3d1fafdf1ab8738a4e5802b80d3acbb5356c6c54884b8e2fdc46e8e79f5e')
+})
+
+// The guard against a Node hash() that ignores its tag again. Every call site inside the SDK
+// passes CLIENT_ID_HASH_TAG, so an implementation that hardcoded that string would still agree
+// with the browser everywhere the SDK itself looks; only a tag the code does not contain
+// separates the two. A caller outside the SDK is free to pass one.
+test('node and browser hash agree on a tag the SDK does not use internally', async () => {
+    const data = new TextEncoder().encode('client-key-bytes')
+    const tag = 'SOME_OTHER_TAG'
+    const nodeDigest = await nodePlatform.hash(data, tag)
+    const browserDigest = await browserPlatform.hash(data, tag)
+    expect(Buffer.from(nodeDigest).equals(Buffer.from(browserDigest))).toBe(true)
+})

--- a/sdk/javascript/packages/core/test/nodePlatform.test.ts
+++ b/sdk/javascript/packages/core/test/nodePlatform.test.ts
@@ -1,0 +1,17 @@
+import {nodePlatform} from '../src/node/nodePlatform'
+import {createHmac} from 'crypto'
+
+test('hash produces different digests for different tags with the same data', async () => {
+    const data = new TextEncoder().encode('client-key-bytes')
+    const digestA = await nodePlatform.hash(data, 'TAG_A')
+    const digestB = await nodePlatform.hash(data, 'TAG_B')
+    expect(Buffer.from(digestA).equals(Buffer.from(digestB))).toBe(false)
+})
+
+test('hash matches an independently computed HMAC-SHA512 over data and tag', async () => {
+    const data = new TextEncoder().encode('client-key-bytes')
+    const tag = 'KEEPER_SECRETS_MANAGER_CLIENT_ID'
+    const digest = await nodePlatform.hash(data, tag)
+    const expected = createHmac('sha512', data).update(tag).digest()
+    expect(Buffer.from(digest).equals(expected)).toBe(true)
+})


### PR DESCRIPTION
## Summary
JavaScript SDK: fixes the Node platform's `hash()` ignoring its `tag` parameter and always hashing with a hardcoded string.

## Changes

### Fixed
- Node platform's `hash()` hardcoded `'KEEPER_SECRETS_MANAGER_CLIENT_ID'` as the HMAC input instead of using its `tag` parameter, unlike the browser implementation and the `Platform` contract. It now hashes with the caller-supplied tag. (KSM-1254)

## Testing
cd sdk/javascript/packages/core && npm test -- test/nodePlatform.test.ts

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1254
