### PR TITLE
Test tooling: harden subprocess and path handling in Ruby SDK and Azure DevOps scripts (KSM-1244)

### DIFF
--- a/integration/keeper_secrets_manager_azure_pipeline_extension/ksm-azure-devops-secrets-task/tests/run-tests.sh
+++ b/integration/keeper_secrets_manager_azure_pipeline_extension/ksm-azure-devops-secrets-task/tests/run-tests.sh
@@ -53,7 +53,7 @@ else
 
     # Run the tests in the Docker container
     echo "Running tests in Docker container..."
-    DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v $(pwd)/.env:/app/.env keeper-secrets-test
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v "$(pwd)/.env:/app/.env" keeper-secrets-test
 
     # Capture the exit code of the Docker run command
     EXIT_CODE=$?

--- a/sdk/ruby/test/integration/docker_multi_version_test.rb
+++ b/sdk/ruby/test/integration/docker_multi_version_test.rb
@@ -351,11 +351,10 @@ RUBY_VERSIONS.each do |version|
 
   # Build Docker image
   image_name = "ksm-ruby-test:#{version}"
-  build_cmd = "docker build -f #{dockerfile_path} -t #{image_name} #{test_dir} 2>&1"
 
-  if system(build_cmd, out: File::NULL)
+  if system('docker', 'build', '-f', dockerfile_path, '-t', image_name, test_dir, out: File::NULL, err: File::NULL)
     # Run the test
-    output = `docker run --rm #{image_name} 2>&1`
+    output = IO.popen(['docker', 'run', '--rm', image_name], err: [:child, :out], &:read)
 
     begin
       result = JSON.parse(output.lines.last)
@@ -417,7 +416,7 @@ puts "\nDetailed results saved to: #{results_file}"
 # Cleanup Docker images
 puts "\nCleaning up Docker images..."
 RUBY_VERSIONS.each do |version|
-  system("docker rmi ksm-ruby-test:#{version} 2>&1", out: File::NULL)
+  system('docker', 'rmi', "ksm-ruby-test:#{version}", out: File::NULL, err: File::NULL)
 end
 
 # Exit with appropriate code

--- a/sdk/ruby/test/integration/docker_test_suite.rb
+++ b/sdk/ruby/test/integration/docker_test_suite.rb
@@ -159,10 +159,9 @@ options[:versions].each do |version|
   image_name = "ksm-ruby-test:#{version}"
   print 'Building Docker image... '
 
-  build_cmd = "docker build -f #{dockerfile_path} -t #{image_name} #{docker_dir}"
-  build_cmd += ' > /dev/null 2>&1' unless options[:verbose]
+  quiet_opts = options[:verbose] ? {} : { out: File::NULL, err: File::NULL }
 
-  if system(build_cmd)
+  if system('docker', 'build', '-f', dockerfile_path, '-t', image_name, docker_dir, **quiet_opts)
     puts '✅'
   else
     puts '❌'
@@ -175,11 +174,9 @@ options[:versions].each do |version|
     print "  #{test_file.ljust(30)} ... "
 
     # Run test in container
-    run_cmd = "docker run --rm #{image_name} ruby /app/run_test.rb /app/test/integration/#{test_file}"
-    run_cmd += ' > /dev/null 2>&1' unless options[:verbose]
-
     test_start = Time.now
-    if system(run_cmd)
+    if system('docker', 'run', '--rm', image_name, 'ruby', '/app/run_test.rb',
+              "/app/test/integration/#{test_file}", **quiet_opts)
       test_time = Time.now - test_start
       puts "✅ (#{test_time.round(2)}s)"
       results[version][test_file] = :passed
@@ -190,7 +187,7 @@ options[:versions].each do |version|
   end
 
   # Clean up image unless keeping
-  system("docker rmi #{image_name} > /dev/null 2>&1") unless options[:keep_containers]
+  system('docker', 'rmi', image_name, out: File::NULL, err: File::NULL) unless options[:keep_containers]
 end
 
 # Print summary

--- a/sdk/ruby/test/integration/run_all_tests.rb
+++ b/sdk/ruby/test/integration/run_all_tests.rb
@@ -125,9 +125,9 @@ options[:tests].each do |test_key|
 
     # Run test in subprocess to isolate failures
     if options[:verbose]
-      system("ruby -I ../../lib #{test_file}")
+      system('ruby', '-I', '../../lib', test_file)
     else
-      output = `ruby -I ../../lib #{test_file} 2>&1`
+      output = IO.popen(['ruby', '-I', '../../lib', test_file], err: [:child, :out], &:read)
 
       # Show summary
       if $?.success?


### PR DESCRIPTION
## Summary
Ruby SDK: hardens how the Docker/integration test-runner scripts invoke subprocesses. Azure DevOps extension: hardens a path substitution in its test runner. Both are dev/CI tooling only, not shipped in a published artifact, so no version bump is needed for either component.

## Changes

### Maintenance
- `sdk/ruby/test/integration/docker_test_suite.rb`, `docker_multi_version_test.rb`, and `run_all_tests.rb`: switched subprocess invocations from interpolated shell strings to array-form `system()`/`IO.popen()`, which pass each argument directly to the binary with no shell involved (KSM-1244)
- `integration/keeper_secrets_manager_azure_pipeline_extension/ksm-azure-devops-secrets-task/tests/run-tests.sh`: quoted a command substitution in a `docker run` mount argument so it isn't word-split or glob-expanded (KSM-1244)

## Testing
```bash
cd sdk/ruby
ruby -c test/integration/docker_test_suite.rb
ruby -c test/integration/docker_multi_version_test.rb
ruby -c test/integration/run_all_tests.rb
ruby test/integration/docker_test_suite.rb -h
ruby test/integration/run_all_tests.rb -h

cd ../../integration/keeper_secrets_manager_azure_pipeline_extension/ksm-azure-devops-secrets-task/tests
bash -n run-tests.sh
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1244