### PR TITLE
CI: run the JavaScript test matrix on release-branch PRs (KSM-1334)

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -1,8 +1,13 @@
 name: Test-JS
 
 on:
+  # Runs on the merge result (head merged into base), so it gates a change before it lands on
+  # a JS core release branch as well as on master. Deliberately not also on push to release/**,
+  # which would only re-test a commit this pull_request run already tested.
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/sdk/javascript/core/**'
     paths:
       - 'sdk/javascript/packages/core/**'
       - '.github/workflows/test.js.yml'


### PR DESCRIPTION
## Summary
`test.js.yml` triggered only on `pull_request` into `master`, so JS core fixes that target a release branch merged with no test signal at all.

## Changes

### Fixed
- Added `release/sdk/javascript/core/**` to `test.js.yml`'s `pull_request` branch filter, so the Node 20/22/24 matrix runs on PRs into a JS core release branch as well as into `master`. (KSM-1334)

Deliberately not adding a `push` trigger on `release/**`. That is the duplicate-run pattern KSM-1302 tracks in `test.ruby.yml` and the four JavaScript KMS workflows, where the `pull_request` run has already tested the same commit.

This follows PR #1119, which made the same change to `test.java.yml` for KSM-1269 and landed on the Java release branch for the same reason: workflow triggers are evaluated against the merge commit, so the fix has to be on the branch that PRs actually target.

## Testing
`actionlint .github/workflows/test.js.yml` is clean. The workflow already lists itself under `paths`, so this PR gates itself: Test-JS appears on this PR's own checks. That is the same self-validation PR #1119 demonstrated, where its four Test-Java jobs ran and passed.

Result on this PR:

```
KSM test with Node.js 20 | SUCCESS
KSM test with Node.js 22 | SUCCESS
KSM test with Node.js 24 | SUCCESS
```

That is the first Test-JS run ever produced on a PR into a release branch.

## Impact
Open PRs into `release/sdk/javascript/core/v17.6.0` (#1131, #1135) and the branches stacked on them (#1136, #1139) pick up a real test run on their next rebase, instead of the two Socket Security checks they carry today.

## Security Impact
None. CI trigger configuration only. No change to permissions, which stay `contents: read`, and no change to what the workflow runs.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1334
- Epic: KSM-1284 (SDK core test workflows on release-branch PRs). Remaining legs: KSM-1335, KSM-1336 (Python), KSM-1337, KSM-1338 (.NET and PowerShell), KSM-1339 (Rust)
- Precedent: #1119 (KSM-1269, Java)
- Related: KSM-1302 (double-run on release-branch globs), KSM-1285, KSM-1286