### PR TITLE
JavaScript SDK: fix browser IndexedDB storage hanging forever on a storage failure (KSM-1332)

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@
 - KSM-1035 - Fixed throttle retry jitter being two-sided, which could reduce a retry delay below the computed floor. Jitter is now one-sided (0 to +25%). The SDK also caps a server-supplied `retry_after` at 176s to prevent an arbitrarily long wait.
 - KSM-1128 - Bounded the server key-rotation retry in `postQuery`. When the server sends `{"error":"key"}`, the code retries at most 3 times before throwing a typed `KeeperError`, instead of retrying forever. Before storing a suggested `key_id`, the code validates its shape (positive integer) and its membership in the bundled key table (keys 7-18). An unsupported key id can no longer corrupt the configuration. The pinned custom-key path does not change.
 - KSM-1254 - Fixed the Node platform's `hash()` ignoring its `tag` parameter and always hashing with a hardcoded string; it now hashes with the caller-supplied tag, matching the browser implementation and the `Platform` contract. No behavior change for existing callers (the SDK's only caller already passed that same string).
+- KSM-1332 - Fixed the browser IndexedDB storage hanging forever on a storage failure. `localConfigStorage` and `secureStorage` wired only `onsuccess`, so a failed IndexedDB open, read, write or delete left the promise pending with no error, no rejection and no timeout. All eight wrappers now reject with a typed `KeeperError`, and the blocked-upgrade and missing-object-store paths reject too instead of hanging.
 - Maintenance: Updated `minimatch`, `@babel/core`, and `handlebars` dev dependencies.
 
 ## 17.5.0

--- a/sdk/javascript/packages/core/src/browser/localConfigStorage.ts
+++ b/sdk/javascript/packages/core/src/browser/localConfigStorage.ts
@@ -1,15 +1,56 @@
 import {EncryptedPayload, KeeperHttpResponse, KeyValueStorage, TransmissionKey, platform} from "../platform";
+import {KeeperError} from "../errors";
+
+type Reject = (reason: Error) => void
+
+// Duck-typed rather than `instanceof Error`. IndexedDB reports failures as a DOMException, and
+// whether that satisfies `instanceof Error` depends on the realm it was constructed in, so a
+// cross-realm failure (a worker, an iframe) would otherwise lose the diagnostic entirely.
+const describeCause = (cause: unknown): string => {
+    const {name, message} = (cause ?? {}) as { name?: unknown, message?: unknown }
+    if (typeof name === 'string' && typeof message === 'string') return `${name}: ${message}`
+    if (typeof message === 'string') return message
+    return 'unknown error'
+}
+
+const idbFailure = (operation: string, cause: unknown): KeeperError =>
+    new KeeperError(`IndexedDB ${operation} failed: ${describeCause(cause)}`)
+
+// A failing IDBRequest fires onerror and never onsuccess, so a promise that only handles
+// onsuccess stays pending forever. The caller then hangs with no error, no rejection and no
+// timeout, which is far worse than failing. Every request in this file is wired through here.
+const rejectOnError = (request: IDBRequest, reject: Reject, operation: string): void => {
+    request.onerror = () => reject(idbFailure(operation, request.error))
+}
+
+const rejectOnOpenFailure = (request: IDBOpenDBRequest, reject: Reject, dbName: string): void => {
+    rejectOnError(request, reject, `open of database '${dbName}'`)
+    // onblocked fires when another live connection holds the database at the old version during
+    // an upgrade. Neither onsuccess nor onerror follows it, so this is the only chance to settle.
+    request.onblocked = () => reject(new KeeperError(
+        `IndexedDB open of database '${dbName}' is blocked by another open connection to it`))
+}
 
 export const localConfigStorage = (client: string, useObjects: boolean): KeyValueStorage => {
+
+    const STORE_NAME = 'secrets'
 
     const getObjectStore = async (mode: IDBTransactionMode): Promise<IDBObjectStore> =>
         new Promise<IDBObjectStore>(((resolve, reject) => {
             const request = indexedDB.open(client, 1)
+            rejectOnOpenFailure(request, reject, client)
             request.onupgradeneeded = () => {
-                request.result.createObjectStore('secrets');
+                request.result.createObjectStore(STORE_NAME);
             }
             request.onsuccess = () => {
-                resolve(request.result.transaction('secrets', mode).objectStore('secrets'))
+                // transaction() throws synchronously when the store is missing, and a throw
+                // inside an event handler is not caught by the Promise executor, so it has to
+                // be turned into a rejection here or the promise never settles.
+                try {
+                    resolve(request.result.transaction(STORE_NAME, mode).objectStore(STORE_NAME))
+                } catch (e) {
+                    reject(idbFailure(`transaction on store '${STORE_NAME}'`, e))
+                }
             }
         }))
 
@@ -17,6 +58,7 @@ export const localConfigStorage = (client: string, useObjects: boolean): KeyValu
         const objectStore = await getObjectStore('readonly')
         return new Promise<string | undefined>(((resolve, reject) => {
             const request = objectStore.get(key)
+            rejectOnError(request, reject, `read of key '${key}'`)
             request.onsuccess = () => {
                 resolve(request.result)
             }
@@ -32,6 +74,7 @@ export const localConfigStorage = (client: string, useObjects: boolean): KeyValu
         const objectStore = await getObjectStore('readwrite')
         return new Promise<void>(((resolve, reject) => {
             const request = objectStore.put(value, key)
+            rejectOnError(request, reject, `write of key '${key}'`)
             request.onsuccess = () => {
                 resolve()
             }
@@ -42,6 +85,7 @@ export const localConfigStorage = (client: string, useObjects: boolean): KeyValu
         const objectStore = await getObjectStore('readwrite')
         return new Promise<void>(((resolve, reject) => {
             const request = objectStore.delete(key)
+            rejectOnError(request, reject, `delete of key '${key}'`)
             request.onsuccess = () => {
                 resolve()
             }
@@ -72,32 +116,42 @@ export const secureStorage = async (dbName: string): Promise<KeyValueStorage> =>
     const META_KEY = '__secureKey__'
 
     const getObjectStore = async (mode: IDBTransactionMode): Promise<IDBObjectStore> =>
-        new Promise<IDBObjectStore>((resolve) => {
+        new Promise<IDBObjectStore>((resolve, reject) => {
             const req = indexedDB.open(dbName, 1)
+            rejectOnOpenFailure(req, reject, dbName)
             req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME)
-            req.onsuccess = () => resolve(req.result.transaction(STORE_NAME, mode).objectStore(STORE_NAME))
+            req.onsuccess = () => {
+                try {
+                    resolve(req.result.transaction(STORE_NAME, mode).objectStore(STORE_NAME))
+                } catch (e) {
+                    reject(idbFailure(`transaction on store '${STORE_NAME}'`, e))
+                }
+            }
         })
 
     const getRaw = async (key: string): Promise<any> => {
         const store = await getObjectStore('readonly')
-        return new Promise<any>(resolve => {
+        return new Promise<any>((resolve, reject) => {
             const r = store.get(key)
+            rejectOnError(r, reject, `read of key '${key}'`)
             r.onsuccess = () => resolve(r.result)
         })
     }
 
     const putRaw = async (key: string, value: any): Promise<void> => {
         const store = await getObjectStore('readwrite')
-        return new Promise<void>(resolve => {
+        return new Promise<void>((resolve, reject) => {
             const r = store.put(value, key)
+            rejectOnError(r, reject, `write of key '${key}'`)
             r.onsuccess = () => resolve()
         })
     }
 
     const delRaw = async (key: string): Promise<void> => {
         const store = await getObjectStore('readwrite')
-        return new Promise<void>(resolve => {
+        return new Promise<void>((resolve, reject) => {
             const r = store.delete(key)
+            rejectOnError(r, reject, `delete of key '${key}'`)
             r.onsuccess = () => resolve()
         })
     }

--- a/sdk/javascript/packages/core/test/browserConfigStorage.test.ts
+++ b/sdk/javascript/packages/core/test/browserConfigStorage.test.ts
@@ -1,0 +1,165 @@
+import {localConfigStorage, secureStorage} from '../src/browser/localConfigStorage'
+import {KeeperError} from '../src/errors'
+
+// How the fake database behaves. Each mode drives one of the paths that, before this fix, left a
+// promise pending forever instead of rejecting.
+type FakeMode = 'ok' | 'openError' | 'openBlocked' | 'requestError' | 'missingStore'
+
+const later = (fn: () => void) => setTimeout(fn, 0)
+
+// Minimal IndexedDB double covering only the surface this module touches: indexedDB.open, the
+// open request's four handlers, db.transaction().objectStore(), and the store's get/put/delete
+// requests. Handlers fire on a later task, as the real implementation does, so a wrapper that
+// never attaches one simply never settles, which is exactly the defect under test.
+const installFakeIndexedDB = (mode: FakeMode) => {
+    const data = new Map<string, any>()
+
+    const request = (run: (req: any) => void) => {
+        const req: any = {onsuccess: null, onerror: null, result: undefined, error: null}
+        later(() => {
+            if (mode === 'requestError') {
+                req.error = new DOMException('the quota has been exceeded', 'QuotaExceededError')
+                req.onerror?.()
+                return
+            }
+            run(req)
+            req.onsuccess?.()
+        })
+        return req
+    }
+
+    const store = {
+        get: (key: string) => request(req => { req.result = data.get(key) }),
+        put: (value: any, key: string) => request(() => { data.set(key, value) }),
+        delete: (key: string) => request(() => { data.delete(key) })
+    }
+
+    const db = {
+        createObjectStore: () => store,
+        transaction: () => {
+            if (mode === 'missingStore') {
+                throw new DOMException('One of the specified object stores was not found.', 'NotFoundError')
+            }
+            return {objectStore: () => store}
+        }
+    }
+
+    ;(globalThis as any).indexedDB = {
+        open: () => {
+            const req: any = {
+                onsuccess: null, onerror: null, onupgradeneeded: null, onblocked: null,
+                result: db, error: null
+            }
+            later(() => {
+                if (mode === 'openError') {
+                    req.error = new DOMException('access to storage is denied', 'SecurityError')
+                    req.onerror?.()
+                } else if (mode === 'openBlocked') {
+                    req.onblocked?.()
+                } else {
+                    req.onupgradeneeded?.()
+                    req.onsuccess?.()
+                }
+            })
+            return req
+        }
+    }
+}
+
+// Every failure case here is a promise that used to never settle. Racing a short timer turns a
+// regression into a fast, legible failure instead of a suite that stalls until Jest's timeout.
+const rejectionFrom = async (p: Promise<unknown>): Promise<unknown> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const neverSettled = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('promise never settled: the failure path still hangs')), 500)
+    })
+    try {
+        await Promise.race([p, neverSettled])
+        return new Error('expected a rejection but the promise resolved')
+    } catch (e) {
+        return e
+    } finally {
+        clearTimeout(timer)
+    }
+}
+
+const expectKeeperError = (err: unknown, pattern: RegExp) => {
+    expect(err).toBeInstanceOf(KeeperError)
+    expect((err as Error).message).toMatch(pattern)
+}
+
+afterEach(() => {
+    delete (globalThis as any).indexedDB
+})
+
+describe('browser localConfigStorage', () => {
+    const storage = () => localConfigStorage('test-db', false)
+
+    test('rejects when opening the database fails', async () => {
+        installFakeIndexedDB('openError')
+        expectKeeperError(await rejectionFrom(storage().getString('key')),
+            /open of database 'test-db' failed: SecurityError/)
+    })
+
+    test('rejects when the open is blocked by another connection', async () => {
+        installFakeIndexedDB('openBlocked')
+        expectKeeperError(await rejectionFrom(storage().getString('key')),
+            /open of database 'test-db' is blocked/)
+    })
+
+    test('rejects when the object store is missing', async () => {
+        installFakeIndexedDB('missingStore')
+        expectKeeperError(await rejectionFrom(storage().getString('key')),
+            /transaction on store 'secrets' failed: NotFoundError/)
+    })
+
+    test('rejects when a read fails', async () => {
+        installFakeIndexedDB('requestError')
+        expectKeeperError(await rejectionFrom(storage().getString('key')),
+            /read of key 'key' failed: QuotaExceededError/)
+    })
+
+    test('rejects when a write fails', async () => {
+        installFakeIndexedDB('requestError')
+        expectKeeperError(await rejectionFrom(storage().saveString('key', 'value')),
+            /write of key 'key' failed: QuotaExceededError/)
+    })
+
+    test('rejects when a delete fails', async () => {
+        installFakeIndexedDB('requestError')
+        expectKeeperError(await rejectionFrom(storage().delete('key')),
+            /delete of key 'key' failed: QuotaExceededError/)
+    })
+
+    test('still reads back what it wrote when IndexedDB is healthy', async () => {
+        installFakeIndexedDB('ok')
+        const s = storage()
+        await s.saveString('key', 'value')
+        expect(await s.getString('key')).toBe('value')
+        await s.delete('key')
+        expect(await s.getString('key')).toBeUndefined()
+    })
+})
+
+describe('browser secureStorage', () => {
+    // secureStorage awaits a read before it returns the storage object, so an IndexedDB failure
+    // used to hang the constructor itself and never hand the caller anything to catch.
+    test('rejects when opening the database fails', async () => {
+        installFakeIndexedDB('openError')
+        expectKeeperError(await rejectionFrom(secureStorage('secure-db')),
+            /open of database 'secure-db' failed: SecurityError/)
+    })
+
+    test('rejects when a read fails', async () => {
+        installFakeIndexedDB('requestError')
+        expectKeeperError(await rejectionFrom(secureStorage('secure-db')),
+            /read of key '__secureKey__' failed: QuotaExceededError/)
+    })
+
+    test('still round-trips through encryption when IndexedDB is healthy', async () => {
+        installFakeIndexedDB('ok')
+        const s = await secureStorage('secure-db')
+        await s.saveString('key', 'value')
+        expect(await s.getString('key')).toBe('value')
+    })
+})


### PR DESCRIPTION
## Summary
JavaScript SDK: every IndexedDB call in the browser config storage wired only `onsuccess`, so any storage failure left the caller's promise pending forever with no error, no rejection and no timeout.

## Changes

### Fixed
- `src/browser/localConfigStorage.ts` wired only `onsuccess` (plus `onupgradeneeded` on the two `indexedDB.open` calls) across all eight promise wrappers in `localConfigStorage` and `secureStorage`. A failing `IDBRequest` fires `onerror` and never `onsuccess`, so a failure left the promise pending forever. Four of the eight even destructured `reject` from the Promise executor and never called it. All eight now reject with a typed `KeeperError`. (KSM-1332)

Three failure paths were unhandled, and all three are covered:

| Path | Fires | Previously |
| --- | --- | --- |
| Request failure (quota, corrupt DB, blocked site data, private browsing) | `onerror` | promise never settles |
| Blocked version change, another live connection holds the database | `onblocked` | promise never settles |
| Missing object store | `transaction()` throws synchronously inside `onsuccess` | promise never settles |

The third one is easy to miss: a throw inside an event handler is not caught by the enclosing `Promise` executor, so it leaks as an uncaught exception and the promise stays pending.

`secureStorage` was the worst case. It awaits a read of `__secureKey__` before it returns the storage object, so a failure hung the constructor itself and never handed the caller anything to catch.

The cause is duck-typed on `name` and `message` rather than tested with `instanceof Error`. A `DOMException` only satisfies `instanceof Error` in the realm it was constructed in, so a cross-realm failure (a worker, an iframe) would otherwise report `unknown error` and lose the diagnostic entirely.

## Testing
```
cd sdk/javascript/packages/core && npm test
```
9 suites, 76 tests, all passing. `tsc --noEmit` clean.

Adds `test/browserConfigStorage.test.ts`: 10 tests covering both exported storages, driven by a minimal IndexedDB double, with **no new dependency**. Each failure test races a 500ms timer, so a regression fails fast with `promise never settled` rather than stalling the suite until Jest's default timeout.

Verified against the unfixed file, which is what makes the suite meaningful here:

```
✕ rejects when opening the database fails            (506 ms)
✕ rejects when the open is blocked by another conn.  (502 ms)
✕ rejects when the object store is missing           (503 ms)
✕ rejects when a read fails                          (501 ms)
✕ rejects when a write fails                         (503 ms)
✕ rejects when a delete fails                        (503 ms)
✓ still reads back what it wrote when healthy        ( 13 ms)
✕ secureStorage: rejects when opening fails          (504 ms)
✕ secureStorage: rejects when a read fails           (503 ms)
✓ secureStorage: still round-trips through encryption ( 18 ms)
```

All eight failure tests fail on the old code, each at roughly 500ms, which is the hang being caught by the timer. Both happy-path tests pass on either side, which is the evidence that the healthy path is unchanged.

## Security Impact
No change to what is stored, encrypted, or transmitted. `secureStorage`'s AES-GCM wrapping key handling is untouched. This is availability only: a browser client that previously hung indefinitely on a storage failure now fails with an error the caller can catch, log, or retry. Same defect class as KSM-1209 (no request timeout on network I/O), on the storage path rather than the network path.

## Breaking Changes
None for a working IndexedDB. Callers that previously hung now receive a rejected promise, which is the intended fix; any caller that awaited these methods without a `catch` will surface an error where it previously waited forever.

## Merge notes
Merge-tested against the other open branches targeting this release branch:

- `src/browser/localConfigStorage.ts` **auto-merges cleanly** with #1139, which edits `createCachingFunction` further down the same file.
- The `CHANGELOG.md` conflict with #1131 and #1139, and the `test/nodePlatform.test.ts` add/add conflict with #1139, are **pre-existing**. Both already conflict with the release-branch tip at `1ffba2b5` without this commit. This PR adds no new conflict.

## Known adjacent issue, not fixed here
Each `getObjectStore` call opens a new `IDBDatabase` connection and never calls `close()`. Those leaked connections are exactly what causes `onblocked` for a later version change. Fixing the lifecycle changes resolve timing and is out of scope for this ticket; worth a follow-up.

## Related Issues
- Jira: KSM-1332
- Related: KSM-1209 (same hang class, network path), KSM-1265, KSM-1266