### PR TITLE
JavaScript SDK: strengthen throttle e2e assertions (KSM-1252)

### DIFF
--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -68,11 +68,16 @@ describe('throttleDelay (unit)', () => {
 
 describe('throttleJitter (unit)', () => {
     test('is one-sided: never pushes the delay below its floor', () => {
+        const draws: number[] = []
         for (let i = 0; i < 200; i++) {
             const jitter = throttleJitter()
             expect(jitter).toBeGreaterThanOrEqual(0)
             expect(jitter).toBeLessThan(0.25)
+            draws.push(jitter)
         }
+        // A regression collapsing jitter to a constant in-range value would still pass the two
+        // bounds checks above; require actual variation across draws.
+        expect(new Set(draws).size).toBeGreaterThan(1)
     })
 })
 
@@ -152,6 +157,18 @@ describe('throttle retry (e2e via getSecrets)', () => {
         // retry_after = 3s with one-sided [0, +25%) jitter -> [3s, 3.75s]; never below the 3s floor
         expect(sleeps[0]).toBeGreaterThanOrEqual(3000)
         expect(sleeps[0]).toBeLessThanOrEqual(3750)
+        // attempt 1 falls through to the exponential branch once retry_after stops being sent:
+        // base = 11 * 2**1 = 22s, one-sided jitter -> [22s, 27.5s)
+        expect(sleeps[1]).toBeGreaterThanOrEqual(22000)
+        expect(sleeps[1]).toBeLessThan(27500)
+    })
+
+    test('caps a server-supplied retry_after at 176s through the real retry path', async () => {
+        const { options, sleeps } = await makeOptions(async () => throttle403(500))
+        await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
+        // retry_after: 500 is capped to 176s inside parseThrottle, then one-sided jitter applies -> [176s, 220s)
+        expect(sleeps[0]).toBeGreaterThanOrEqual(176000)
+        expect(sleeps[0]).toBeLessThan(220000)
     })
 
     test('non-throttle 403 is not retried', async () => {


### PR DESCRIPTION
## Summary
Closes a coverage gap in the throttle e2e suite: it never value-asserted the exponential-branch sleeps, the retry_after cap through the real retry path, or jitter variability, only sleeps[0] and raw retry counts. A regression in attempt bookkeeping or the cap logic could ship with the whole suite green.

## Changes

### Maintenance
- `test/throttle.test.ts`: added a `sleeps[1]` bound to the existing `honors retry_after from the response body` test (exponential branch once retry_after stops being sent, `[22000, 27500)`). Added a new e2e test, `caps a server-supplied retry_after at 176s through the real retry path`, pinning the 176s cap through `getSecrets` → `postQuery` → `parseThrottle` → `throttleDelay` rather than only at the `parseThrottle` unit level. Added a non-constant check (`new Set(draws).size > 1`) on the existing 200-draw `throttleJitter` range test. (KSM-1252)

No source change; this branch only adds test assertions.

## Testing
```
cd sdk/javascript/packages/core
npm test
```
Verified each new assertion against a deliberately broken version of the code it guards, then reverted the break before committing:
- Moving `throttleAttempt++` above the delay calculation in `postQuery` pushed `sleeps[1]` to ~50.7s — caught by the new bound.
- Removing the `Math.min` cap in `parseThrottle` pushed the capped-retry sleep to ~591s — caught by the new cap-lock test.
- Hardcoding `throttleJitter` to a constant `0.1` collapsed the draw set to size 1 — caught by the new variability check.

Full suite 78/78 passing with all three assertions restored to guard the real code, run twice for stability; `tsc --noEmit` clean.

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1252