### PR TITLE
KSM-1351: JavaScript SDK: fix hasEncryptedData misreading ciphertext as JSON

### DIFF
--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -371,8 +371,17 @@ export class KeeperRecordLink {
         return typeof value === 'number' && !Number.isNaN(value) ? Math.trunc(value) : null
     }
 
+    // The leading-character check alone is not enough: encrypted data has roughly a 1-in-128
+    // chance of coincidentally decoding to a leading '{' or '[' byte, which would otherwise get
+    // misread as plaintext JSON. Requiring an actual successful parse closes that gap.
     private static _isReadableJson(text: string): boolean {
-        return text.startsWith('{') || text.startsWith('[')
+        if (!(text.startsWith('{') || text.startsWith('['))) return false
+        try {
+            JSON.parse(text)
+            return true
+        } catch {
+            return false
+        }
     }
 
     private static _isPrintableText(text: string): boolean {

--- a/sdk/javascript/packages/core/test/record_link.test.ts
+++ b/sdk/javascript/packages/core/test/record_link.test.ts
@@ -342,3 +342,21 @@ test('ciphertext coincidentally starting with { or [ still decrypts (fallthrough
     // Plain JSON fast path is unaffected
     expect(await plainLink({a: 1}).getLinkData()).toEqual({a: 1})
 })
+
+// ── test 18 ────────────────────────────────────────────────────────────────────
+test('hasEncryptedData is not fooled by ciphertext coincidentally starting with { or [', () => {
+    const key = platform.getRandomBytes(32)
+    const plaintext = platform.stringToBytes(JSON.stringify({secret: 'value'}))
+
+    for (const marker of [0x7b /* { */, 0x5b /* [ */]) {
+        const iv = new Uint8Array(12)
+        iv[0] = marker
+        randomBytes(11).copy(Buffer.from(iv.buffer), 1)
+
+        const ciphertext = encryptWithCustomIv(plaintext, key, iv)
+        const link = new KeeperRecordLink({recordUid: 'RU', data: platform.bytesToBase64(ciphertext), path: undefined}, 'owner')
+
+        expect(link.getDecodedData()!.charCodeAt(0)).toBe(marker)
+        expect(link.hasEncryptedData()).toBe(true)
+    }
+})


### PR DESCRIPTION
## Summary
`KeeperRecordLink._isReadableJson` only checked whether the base64-decoded text started with `{` or `[`. Genuine ciphertext has a ~1-in-128 chance of coincidentally decoding to a leading `{` (0x7b) or `[` (0x5b) byte, which made `hasEncryptedData()` (and `hasReadableData()`) misclassify real encrypted data as "not encrypted".

Traced from a flaky failure in `test/record_link.test.ts` on the Node 24 leg of a CI run (unrelated to a separate throttle-related PR that passed in that same run).

## Root cause
`_isReadableJson` is the final decision inside `hasEncryptedData()`, with no fallback if the leading-character match is a false positive. `getLinkData()` already has a fallback (re-parses via `_parseJsonToRecord`, falls through to decryption on failure), which is why an existing test only covers that path and not `hasEncryptedData()`.

## Fix
`_isReadableJson` now requires the text to actually parse as valid JSON, not just start with the right character. This closes the gap consistently for all three call sites: `hasReadableData`, `hasEncryptedData`, `getLinkData`.

## Verification
- Reproduced the flake locally: 30,000 trials of the encrypt-then-check logic against the pre-fix code failed at ~0.8% (matches the theoretical 2/256 chance of the first byte landing on `{` or `[`), identically on Node 22 and Node 24, confirming this was never Node-version-specific.
- After the fix: 0/50,000 failures (Node 24), 0/30,000 failures (Node 22).
- Added a regression test mirroring the existing `getLinkData` fallthrough test, using a pinned IV so the leading byte is deterministically `{`/`[`.
- Full suite: 77/77 passing on Node 22 and Node 24.

## Testing
```
cd sdk/javascript/packages/core
npm test
```

## Breaking Changes
None.