### PR TITLE
JavaScript SDK: drain fileUpload's response body so the process can exit (KSM-1209)

### DIFF
--- a/sdk/javascript/packages/core/src/node/nodePlatform.ts
+++ b/sdk/javascript/packages/core/src/node/nodePlatform.ts
@@ -297,6 +297,10 @@ const fileUpload = (
         // no listener that throws instead of doing nothing, per Node's EventEmitter contract for
         // unhandled 'error' events.
         res.on('error', reject)
+        // An unconsumed response body leaves the socket open (paused, not closed), which keeps
+        // the event loop alive - a script with no other pending work never exits on its own after
+        // a successful upload. resume() discards the body without buffering it; nothing here reads it.
+        res.resume()
         clear()
         resolve({
             headers: res.headers,


### PR DESCRIPTION
## Summary
JavaScript SDK: `fileUpload()` never reads its HTTP response body, which keeps the process alive after a successful upload. Drains the body so a script can exit on its own.

## Changes

### Fixed
- `fileUpload()`'s response handler now calls `res.resume()` to discard the unread body, alongside the existing `res.on('error', reject)` from the earlier KSM-1209 review-fix round (KSM-1209)

## Testing
```
cd sdk/javascript/packages/core && npm test
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1209