### PR TITLE
JavaScript SDK: remove TLS verification bypass from examples (KSM-1316)

### DIFF
--- a/examples/javascript/hello-secret/hello.js
+++ b/examples/javascript/hello-secret/hello.js
@@ -1,5 +1,3 @@
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
 const {
     getSecrets,
     initializeStorage,

--- a/examples/javascript/proxy-support/hello.js
+++ b/examples/javascript/proxy-support/hello.js
@@ -1,5 +1,3 @@
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
 const {
     getSecrets,
     initializeStorage,


### PR DESCRIPTION
## Summary
JavaScript SDK: `hello-secret` and `proxy-support` disable TLS certificate verification process-wide via `NODE_TLS_REJECT_UNAUTHORIZED`, with no self-signed-cert scenario in either example to justify it.

## Changes

### Fixed
- Removed the unconditional `NODE_TLS_REJECT_UNAUTHORIZED = '0'` bypass from both examples (KSM-1316)

## Testing
```
cd examples/javascript/hello-secret && npm install && node hello.js
cd examples/javascript/proxy-support && npm install && node hello.js
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-1316