### PR TITLE
Python SDK: raise minimum Python version to 3.10 (KSM-1214)

### DIFF
--- a/.github/workflows/publish.pypi.sdk.yml
+++ b/.github/workflows/publish.pypi.sdk.yml
@@ -210,10 +210,10 @@ jobs:
       - name: Get the source code
         uses: actions/checkout@v6.0.2
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install build tools
         run: |

--- a/.github/workflows/test.python.helper.yml
+++ b/.github/workflows/test.python.helper.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.python.helper.yml
+++ b/.github/workflows/test.python.helper.yml
@@ -2,7 +2,9 @@ name: Test-Python-Helper
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/sdk/python/core/**'
     paths:
       - 'sdk/python/helper/**'
       - 'sdk/python/core/**'

--- a/.github/workflows/test.python.yml
+++ b/.github/workflows/test.python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     defaults:
       run:

--- a/.github/workflows/test.python.yml
+++ b/.github/workflows/test.python.yml
@@ -2,7 +2,9 @@ name: Test-Python
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/sdk/python/core/**'
     paths:
       - 'sdk/python/core/**'
       - '.github/workflows/test.python.yml'

--- a/sdk/python/core/README.md
+++ b/sdk/python/core/README.md
@@ -2,7 +2,7 @@
 
 For more information, see our official documentation page https://docs.keeper.io/secrets-manager/secrets-manager/developer-sdk-library/python-sdk
 
-**Python Requirements**: Python 3.9 or higher
+**Python Requirements**: Python 3.10 or higher
 
 ## Custom Server Public Key (Isolated Deployments)
 
@@ -34,6 +34,7 @@ see the official docs link above.
 ## Change Log
 
 ### 17.4.0
+* **Breaking**: KSM-1214 - Minimum Python version raised from 3.9 to 3.10. Python 3.9 reached end-of-life 2026-10-05. The new floor also clears the `urllib3` decompression-bomb bypass (CVE-2026-44432) and cross-host-redirect header leak (CVE-2026-44431) fixes, neither of which was backported to a 3.9-compatible `urllib3` release. `urllib3` floor raised from `>=2.6.3` to `>=2.7.0`.
 * KSM-299 - Fixed `InMemoryKeyValueStorage` raising a cryptic `TypeError: object of type 'NoneType' has no len()` when initialized with a config string that is not valid JSON or base64-encoded JSON. The SDK now raises `KeeperError` with a clear message instead.
 * KSM-1019 - Fixed `KSMCache` silently ignoring an explicit `kms_cache_file_name` assignment when the assigned path equaled the import-time default (regression from KSM-1004). The SDK now detects the override by object identity, so an explicit assignment always takes precedence over `KSM_CACHE_DIR`. Default behavior and `KSM_CACHE_DIR` resolution are unchanged.
 * KSM-1145 - Fixed `get_secrets()` returning duplicate entries when a record is accessible both via a shared folder and as an individual share. The SDK now deduplicates records by UID before returning them.

--- a/sdk/python/core/keeper_secrets_manager_core/core.py
+++ b/sdk/python/core/keeper_secrets_manager_core/core.py
@@ -114,10 +114,10 @@ class SecretsManager:
         > pre-existing config file values.
         """
 
-        # Make sure the Python is 3.9 or higher. We'll handle Python 4 in the future :)
+        # Make sure the Python is 3.10 or higher. We'll handle Python 4 in the future :)
         python_version = sys.version_info
-        if python_version.major < 3 or (python_version.major == 3 and python_version.minor < 9):
-            raise Exception("KSM SDK requires Python 3.9 or greater")
+        if python_version.major < 3 or (python_version.major == 3 and python_version.minor < 10):
+            raise Exception("KSM SDK requires Python 3.10 or greater")
 
         self.token = None
         self.hostname = None

--- a/sdk/python/core/requirements.txt
+++ b/sdk/python/core/requirements.txt
@@ -1,4 +1,4 @@
 cryptography>=46.0.7
 requests>=2.32.4
-urllib3>=2.6.3
+urllib3>=2.7.0
 pytest>=7.2.1

--- a/sdk/python/core/setup.py
+++ b/sdk/python/core/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(here, 'README.md'), "r", encoding='utf-8') as fp:
 install_requires = [
     'requests>=2.32.4',
     'cryptography>=46.0.7',
-    'urllib3>=2.6.3',
+    'urllib3>=2.7.0',
 ]
 
 setup(
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=False,
     install_requires=install_requires,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://github.com/Keeper-Security/secrets-manager",
@@ -48,7 +48,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/sdk/python/helper/README.md
+++ b/sdk/python/helper/README.md
@@ -7,6 +7,7 @@ For more information see our official documentation page https://docs.keeper.io/
 ## Recent Changes
 
 ### Version 1.1.3
+- **Breaking**: KSM-1214 - Minimum Python version raised from 3.9 to 3.10, matching `keeper-secrets-manager-core`. Python 3.9 reached end-of-life 2026-10-05.
 - KSM-1119 - Fixed `FieldType.__init__` crashing with `IndexError` when a complex field (address, name, host, paymentCard, etc.) is returned by the server with an empty value list. The SDK now leaves attribute variables as `None` instead of indexing into `[]`.
 - KSM-1127 - Fixed `PamSettings.connection` schema missing `database` and `dbConnectionMethod` fields. Both fields are now present in the `pamDatabase` connection schema, so template generation and record construction can use them.
 - KSM-1140 - Added `allowSupplyHost` to `PamSettings` (field level, alongside `connection`). Added audio control and browser session fields to `PamRemoteBrowserSettings.connection`: `disableAudio`, `disableCopy`, `disablePaste`, `audioChannels`, `audioBps`, `audioSampleRate`, `sessionPersistence`, `allowFileUploads`, `allowFileDownloads`, `ignoreInitialSslCert`, `recordingIncludeKeys`.

--- a/sdk/python/helper/setup.py
+++ b/sdk/python/helper/setup.py
@@ -29,7 +29,7 @@ setup(
     package_data={},
     include_package_data=True,
     install_requires=install_requires,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     project_urls={
         "Bug Tracker": "https://github.com/Keeper-Security/secrets-manager/issues",
         "Documentation": "https://app.gitbook.com/"
@@ -43,7 +43,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
Python SDK: raises the minimum supported Python version for `keeper-secrets-manager-core` and `keeper-secrets-manager-helper` from 3.9 to 3.10, and fixes both packages' CI workflows to actually run on PRs targeting a release branch.

## Changes

### Maintenance
- Raise `python_requires` and trove classifiers in both packages' `setup.py` from `>=3.9` to `>=3.10` (KSM-1214)
- Raise the hardcoded runtime version guard in `core.py` to match (was raising below 3.9, now raises below 3.10)
- Raise the `urllib3` floor from `>=2.6.3` to `>=2.7.0` in `setup.py` and `requirements.txt` — this is the first `urllib3` release carrying the fix for CVE-2026-44432 and CVE-2026-44431, neither of which was backported to a 3.9-compatible release, and both require Python >=3.10
- Move the `publish.pypi.sdk.yml` build step's interpreter from 3.9 to 3.10
- CHANGELOG entries in both `README.md` files
- `test.python.yml` / `test.python.helper.yml` (KSM-1335/KSM-1336): add `release/sdk/python/core/**` to `pull_request.branches`. Both workflows previously ran on PRs into `master` only, so a fix PR developed against a release branch (like this one) got no test signal beyond the Socket Security scans. No `push` trigger added, per KSM-1302's duplicate-run warning.

## Testing
```bash
cd sdk/python/core && pytest
cd sdk/python/helper && pytest
```
Verified locally against a real Python 3.9 interpreter (confirms the runtime guard still rejects it) and a fresh Python 3.11 venv resolving `urllib3==2.7.0`/`cryptography` from PyPI (150 passed/1 skipped for core, 63 passed for helper). Also self-verifying in CI: this PR's own `test.python.yml`/`test.python.helper.yml` changes ran against this same PR (base is a release branch) and all 8 matrix jobs (3.10-3.13, both workflows) are green.

## Breaking Changes
Minimum supported Python version raised from 3.9 to 3.10. Python 3.9 reached end-of-life 2026-10-05. Users on Python 3.9 will need to upgrade their interpreter before installing this version of either package.

## Related Issues
- Jira: KSM-1214, KSM-1335, KSM-1336