### PR TITLE
Fix interpolate file writes on Windows (fchmod and rename)

### DIFF
--- a/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
+++ b/integration/keeper_secrets_manager_cli/keeper_secrets_manager_cli/interpolate.py
@@ -404,13 +404,13 @@ class Interpolate:
                 # Use atomic write for in-place editing
                 temp_path = Path(input_file).with_suffix('.tmp')
                 with open(temp_path, 'w', encoding='utf-8') as f:
-                    os.fchmod(f.fileno(), self.SECURE_FILE_PERMS)
+                    self._apply_secure_perms(f)
                     f.write(result)
                     f.flush()
                     os.fsync(f.fileno())
 
                 # Atomic rename
-                os.rename(temp_path, input_file)
+                os.replace(temp_path, input_file)
 
                 # Create safety marker
                 self._create_safety_marker(input_file)
@@ -696,6 +696,19 @@ class Interpolate:
     # FILE OPERATIONS
     # ========================================================================
 
+    def _apply_secure_perms(self, file_obj):
+        """Restrict an open file to owner-only access, where the platform allows it.
+
+        os.fchmod() only gained Windows support in Python 3.13; on older builds
+        it does not exist and calling it raises AttributeError. Windows has no
+        NTFS equivalent of the POSIX mode bits either - os.chmod() there only
+        toggles the read-only flag - so rather than approximate 0o600 with a
+        call that does not mean the same thing, the step is skipped and the file
+        inherits the permissions of its parent directory.
+        """
+        if hasattr(os, 'fchmod'):
+            os.fchmod(file_obj.fileno(), self.SECURE_FILE_PERMS)
+
     def _write_output(self, content, output_file):
         """Write content to output file with secure permissions"""
         try:
@@ -721,14 +734,13 @@ class Interpolate:
             temp_path = output_path.with_suffix('.tmp')
             try:
                 with open(temp_path, 'w', encoding='utf-8') as f:
-                    # Set permissions before writing
-                    os.fchmod(f.fileno(), self.SECURE_FILE_PERMS)
+                    self._apply_secure_perms(f)
                     f.write(content)
                     f.flush()
                     os.fsync(f.fileno())
 
                 # Atomic rename
-                os.rename(temp_path, output_path)
+                os.replace(temp_path, output_path)
 
                 # Create safety marker
                 self._create_safety_marker(output_file)

--- a/integration/keeper_secrets_manager_cli/tests/interpolate_test.py
+++ b/integration/keeper_secrets_manager_cli/tests/interpolate_test.py
@@ -438,3 +438,60 @@ DB_PASSWORD=keeper://TEST/field/password
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestWindowsFileWrite:
+    """Regression tests for writing output files on Windows (issue #1159)"""
+
+    def test_write_output_without_fchmod(self, monkeypatch):
+        """os.fchmod is missing on Windows before Python 3.13 - must not crash"""
+        monkeypatch.delattr(os, 'fchmod', raising=False)
+
+        interpolate = Interpolate(create_mock_cli())
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, 'secrets.env')
+
+            interpolate._write_output('PLAIN=hello\n', out)
+
+            assert Path(out).read_text() == 'PLAIN=hello\n'
+
+    def test_write_output_overwrites_existing_file(self, monkeypatch):
+        """os.rename cannot replace an existing file on Windows - os.replace can
+
+        On POSIX os.rename() overwrites silently, so the Windows behaviour is
+        simulated to keep the regression meaningful on a Linux CI runner.
+        """
+        def windows_rename(*args, **kwargs):
+            raise FileExistsError(17, 'Cannot create a file when that file already exists')
+
+        monkeypatch.setattr(os, 'rename', windows_rename)
+
+        interpolate = Interpolate(create_mock_cli())
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, 'secrets.env')
+            Path(out).write_text('STALE=old\n')
+
+            interpolate._write_output('FRESH=new\n', out)
+
+            assert Path(out).read_text() == 'FRESH=new\n'
+
+    def test_write_output_leaves_no_temp_file(self):
+        """The atomic write must not leave its .tmp file behind"""
+        interpolate = Interpolate(create_mock_cli())
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, 'secrets.env')
+
+            interpolate._write_output('PLAIN=hello\n', out)
+
+            assert not Path(os.path.join(d, 'secrets.tmp')).exists()
+
+    @pytest.mark.skipif(os.name != 'posix', reason='POSIX mode bits')
+    def test_secure_perms_still_applied_on_posix(self):
+        """Guarding the call must not weaken permissions where fchmod exists"""
+        interpolate = Interpolate(create_mock_cli())
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, 'secrets.env')
+
+            interpolate._write_output('PLAIN=hello\n', out)
+
+            assert oct(os.stat(out).st_mode & 0o777) == oct(0o600)


### PR DESCRIPTION
Fixes #1159.

`ksm interpolate` cannot write an output file on Windows. While fixing the reported
`os.fchmod` crash I found a second call in the same path with no Windows-compatible
semantics, so this addresses both.

## The two problems

**1. `os.fchmod()` is unavailable on Windows before Python 3.13.**

The reported crash. Worth correcting one detail from my issue report: `os.fchmod` is *not*
Unix-only — it [gained Windows support in Python 3.13](https://docs.python.org/3/library/os.html#os.fchmod).
The reason every Windows user hits this anyway is that the official installer bundles
Python 3.12, so the affected build ships with the CLI:

```
> keeper-ksm.exe version
Python Version: 3.12.10
```

A `pip install` on Windows with Python 3.13+ would not hit this one — but would still hit
the next.

**2. `os.rename()` cannot overwrite on Windows.**

Not in the original report. `os.rename()` raises `FileExistsError` when the destination
exists on Windows, so even with the permission call fixed, writing to an existing output
file fails. Confirmed on Windows 11 / Python 3.14.4:

```
os.rename over existing:  FAIL -> FileExistsError [WinError 183] Cannot create a file when that file already exists
os.replace over existing: OK
```

This matters because re-running interpolation over an existing file is the normal case, and
it affects `-w/--in-place` unconditionally, since that destination exists by definition.

## The change

- Both permission calls go through a new `_apply_secure_perms()` helper, guarded on
  `hasattr(os, 'fchmod')`.
- Both `os.rename()` calls become `os.replace()`, the cross-platform atomic overwrite.

POSIX behaviour is unchanged — output files are still created with mode `0600`, covered by a
test.

## Testing

Four regression tests in `tests/interpolate_test.py`. The two that cover the bugs fail on
`master` and pass with this change:

```
# master
FAILED tests/interpolate_test.py::TestWindowsFileWrite::test_write_output_without_fchmod
FAILED tests/interpolate_test.py::TestWindowsFileWrite::test_write_output_overwrites_existing_file
2 failed, 2 passed

# this branch
26 passed
```

Since `os.rename()` overwrites silently on POSIX, that test monkeypatches it to raise
`FileExistsError` so the regression stays meaningful on a Linux runner.

Full `integration/keeper_secrets_manager_cli/tests/` suite: `13 failed, 133 passed, 4 skipped`,
against a `master` baseline of `13 failed, 129 passed, 4 skipped` — the same 13 pre-existing
failures, which look like incompatibilities with current dependency versions and are unrelated
to this change. Delta is the 4 added tests.
