### PR TITLE
fix(javascript): widen throttle retry status gate to accept 429 (KSM-1395)

### DIFF
--- a/sdk/javascript/packages/core/CHANGELOG.md
+++ b/sdk/javascript/packages/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 17.6.0
+- KSM-1395 - Fixed throttle retry never firing against the real backend: the retry gate checked only for HTTP 403, but the backend has returned HTTP 429 for a throttled Secrets Manager request since 2026-06-15 (an unrelated login-security fix changed a response code shared with the Secrets Manager throttle path; see KSM-1386 for the full history). The gate now accepts both 403 and 429, so a throttled request is retried as originally intended (KSM-880) instead of failing immediately.
 - KSM-1073 - Added `dbConnectionMethod` to `PamSettingsConnection`.
 - KSM-1079 - Fixed `getFolders()` crashing when a folder in the response has a corrupted or missing key. The SDK now skips undecryptable folders and returns the remaining folders normally.
 - KSM-1084 - Fixed `deleteSecret()` and `deleteFolder()` silently reporting success when the server rejected some UIDs. The SDK now surfaces per-item error messages from the server to the caller.

--- a/sdk/javascript/packages/core/src/errors.ts
+++ b/sdk/javascript/packages/core/src/errors.ts
@@ -16,8 +16,9 @@ export class KeeperError extends Error {
 }
 
 /**
- * Thrown when the Keeper backend throttles requests (HTTP 403 {"error":"throttled"}) and the
- * SDK has exhausted its automatic retries (MAX_THROTTLE_RETRIES). Extends KeeperError so existing
+ * Thrown when the Keeper backend throttles requests (HTTP 429, or HTTP 403 for a possible second
+ * limiter, both carrying {"error":"throttled"}; see KSM-1386) and the SDK has exhausted its
+ * automatic retries (MAX_THROTTLE_RETRIES). Extends KeeperError so existing
  * `catch` handlers keep working; callers that want to react specifically to throttling can
  * check `instanceof KeeperThrottleError`.
  */

--- a/sdk/javascript/packages/core/src/keeper.ts
+++ b/sdk/javascript/packages/core/src/keeper.ts
@@ -15,9 +15,12 @@ const KEY_APP_KEY = 'appKey' // The application key with which all secrets are e
 const KEY_OWNER_PUBLIC_KEY = 'appOwnerPublicKey' // The application owner public key, to create records
 const KEY_PRIVATE_KEY = 'privateKey' // The client's private key
 
-// Throttle retry. The backend throttles HTTP 403 {"error":"throttled"}
+// Throttle retry. The backend throttles HTTP 429 {"error":"throttled"}
 // per clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every
-// request, so the counter only clears after 10s of silence).
+// request, so the counter only clears after 10s of silence). The backend used HTTP 403 for
+// this until 2026-06-15, when an unrelated login-security fix (KA-8807) changed the shared
+// response code; the gate below accepts both statuses (KSM-1395) since a second, unconfirmed
+// rate limiter might still use 403 (KSM-1386).
 const MAX_THROTTLE_RETRIES = 5
 // Bounds the server-key-rotation retry (postQuery's `error === 'key'` branch, no custom key
 // pinned): one legitimate rotation should resolve it, so this only needs to tolerate a little
@@ -815,10 +818,10 @@ const postQuery = async (options: SecretManagerOptions, path: string, payload: A
             let errorMessage
             if (response.data) {
                 errorMessage = platform.bytesToString(response.data.slice(0, 1000))
-                // Throttle retry with exponential backoff + jitter. Checked
-                // before key-rotation so that path is untouched, and gated on the 403 status so a
-                // non-403 response carrying a {"error":"throttled"} body is not retried.
-                if (response.statusCode === 403) {
+                // Throttle retry with exponential backoff + jitter. Checked before key-rotation
+                // so that path is untouched. Gated on 403 or 429 (KSM-1395) so a response on
+                // neither status, carrying a {"error":"throttled"} body, is not retried.
+                if (response.statusCode === 403 || response.statusCode === 429) {
                     const retryAfter = parseThrottle(errorMessage)
                     if (retryAfter !== null) {
                         if (throttleAttempt >= MAX_THROTTLE_RETRIES) {

--- a/sdk/javascript/packages/core/test/throttle.test.ts
+++ b/sdk/javascript/packages/core/test/throttle.test.ts
@@ -17,8 +17,10 @@ import {
 const FAKE_TOKEN = 'YyIhK5wXFHj36wGBAOmBsxI3v5rIruINrC8KXjyM58c'
 const enc = new TextEncoder()
 
-const throttle403 = (retryAfter?: number): KeeperHttpResponse => ({
-    statusCode: 403,
+// The backend used 403 for this until 2026-06-15 and uses 429 now (KSM-1386); the gate accepts
+// both (KSM-1395), so the e2e cases below run once per status.
+const throttleResponse = (statusCode: 403 | 429, retryAfter?: number): KeeperHttpResponse => ({
+    statusCode,
     data: enc.encode(
         JSON.stringify(
             retryAfter === undefined
@@ -97,11 +99,11 @@ describe('parseThrottle (unit)', () => {
     })
 })
 
-describe('throttle retry (e2e via getSecrets)', () => {
+describe.each([403, 429] as const)('throttle retry (e2e via getSecrets), status %d', (status) => {
     test('retries then succeeds', async () => {
         let call = 0
         const { options, sleeps } = await makeOptions(async (_url, tk) => {
-            if (call++ === 0) return throttle403()
+            if (call++ === 0) return throttleResponse(status)
             return { statusCode: 200, data: await platform.encryptWithKey(enc.encode('{}'), tk.key), headers: [] }
         })
         const secrets = await getSecrets(options)
@@ -113,27 +115,17 @@ describe('throttle retry (e2e via getSecrets)', () => {
         let call = 0
         const { options, sleeps } = await makeOptions(async () => {
             call++
-            return throttle403()
+            return throttleResponse(status)
         })
         await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
         expect(sleeps.length).toBe(5)
         expect(call).toBe(6) // 5 retries + the final throttled response
     })
 
-    // The setPrototypeOf chain must survive transpilation, otherwise consumers' `instanceof KeeperError`
-    // catches would silently break when a KeeperThrottleError is thrown.
-    test('thrown KeeperThrottleError is also instanceof KeeperError and Error', async () => {
-        const { options } = await makeOptions(async () => throttle403())
-        const err = await getSecrets(options).catch(e => e)
-        expect(err).toBeInstanceOf(KeeperThrottleError)
-        expect(err).toBeInstanceOf(KeeperError)
-        expect(err).toBeInstanceOf(Error)
-    })
-
     test('honors retry_after from the response body', async () => {
         let call = 0
         const { options, sleeps } = await makeOptions(async () =>
-            call++ === 0 ? throttle403(3) : throttle403()
+            call++ === 0 ? throttleResponse(status, 3) : throttleResponse(status)
         )
         await expect(getSecrets(options)).rejects.toBeInstanceOf(KeeperThrottleError)
         // retry_after = 3s with one-sided [0, +25%) jitter -> [3s, 3.75s]; never below the 3s floor
@@ -141,17 +133,30 @@ describe('throttle retry (e2e via getSecrets)', () => {
         expect(sleeps[0]).toBeLessThanOrEqual(3750)
     })
 
-    test('non-throttle 403 is not retried', async () => {
+    test('non-throttle body on this status is not retried', async () => {
         const { options, sleeps } = await makeOptions(async () => ({
-            statusCode: 403,
+            statusCode: status,
             data: enc.encode(JSON.stringify({ error: 'access_denied', message: 'nope' })),
             headers: [],
         }))
         await expect(getSecrets(options)).rejects.not.toBeInstanceOf(KeeperThrottleError)
         expect(sleeps.length).toBe(0)
     })
+})
 
-    test('a 502 carrying a throttled body is not retried (403 gate)', async () => {
+describe('throttle retry (e2e via getSecrets), status-independent', () => {
+    // The setPrototypeOf chain must survive transpilation, otherwise consumers' `instanceof KeeperError`
+    // catches would silently break when a KeeperThrottleError is thrown. Only needs checking once;
+    // it does not depend on which of the two gated statuses triggered it.
+    test('thrown KeeperThrottleError is also instanceof KeeperError and Error', async () => {
+        const { options } = await makeOptions(async () => throttleResponse(403))
+        const err = await getSecrets(options).catch(e => e)
+        expect(err).toBeInstanceOf(KeeperThrottleError)
+        expect(err).toBeInstanceOf(KeeperError)
+        expect(err).toBeInstanceOf(Error)
+    })
+
+    test('a 502 carrying a throttled body is not retried (403/429 gate)', async () => {
         const { options, sleeps } = await makeOptions(async () => ({
             statusCode: 502,
             data: enc.encode(JSON.stringify({ error: 'throttled' })),


### PR DESCRIPTION
## Summary
- `postQuery`'s throttle retry only fired on HTTP 403. The backend returned 403 for a throttled Secrets Manager request. A fix changed the shared response code to 429. The SDK's gate was correct when written and has been silently dead ever since: a throttled request now fails immediately with a plain `Error` instead of retrying with backoff. 
- Widened the check to accept 429 in addition to 403, rather than replacing it: leaves open whether a second rate limiter, on some other call pattern, still returns 403. Accepting both keeps that path working if it exists.
- Corrected the two code comments in `keeper.ts` and `KeeperThrottleError`'s doc comment in `errors.ts` that stated the backend throttles with 403.
- Added a CHANGELOG entry under the existing unreleased 17.6.0 section.

## Test plan
- [x] `npm test` passes in `sdk/javascript/packages/core` (127/127, including 18 in `throttle.test.ts`)
- [x] `npx tsc --noEmit` clean
- [x] Rewrote every status-dependent case in `throttle.test.ts` (retry-then-succeed, exhaustion, `retry_after` honored, non-throttle body not retried) via `describe.each([403, 429])`, so the suite proves 403 and 429 are handled identically rather than adding an isolated new test alongside the old one
- [x] Kept the 403-vs-502 "wrong status, throttled body, not retried" case and the `KeeperThrottleError` instanceof case as single, status-independent tests, since neither depends on which of the two gated statuses is used
- [x] Confirmed this is the only behavior change: no caller-facing API changes, `SecretManagerOptions` unchanged